### PR TITLE
feat: JSON fixture cross-validation + Java-Pine engine

### DIFF
--- a/docs/json-fixture-plan.md
+++ b/docs/json-fixture-plan.md
@@ -15,19 +15,20 @@
 - [x] 识别哪些测试可以转为 fixture
 
 ### Phase 2: JSON fixture 格式设计与迁移
-- [ ] 设计 fixture JSON schema（config + input + expected_output）
-- [ ] 编写 Go test runner 加载 fixture 文件
-- [ ] 逐算子迁移测试为 fixture 形式
-- [ ] 保留原有 Go 测试作为回归保护
+- [x] 设计 fixture JSON schema（config + input + expected_output）
+- [x] 编写 Go test runner 加载 fixture 文件
+- [x] 逐算子迁移测试为 fixture 形式（Batch 1: 10 纯计算算子，Batch 2: Lua）
+- [x] 保留原有 Go 测试作为回归保护
+- [x] Batch 3 跳过（Redis/HTTP/Resource 依赖、非确定性）
 
 ### Phase 3: Go 引擎适配
-- [ ] 确保引擎支持 fixture runner（单算子隔离执行模式）
-- [ ] 验证原有测试行为不变
-- [ ] 验证 fixture 测试等价性
+- [x] 确保引擎支持 fixture runner（单算子隔离执行模式）
+- [x] 验证原有测试行为不变（go test ./... 全部通过）
+- [x] 验证 fixture 测试等价性（44 个 fixture 用例全部通过）
 
 ### Phase 4: 整理
-- [ ] 项目结构整理（fixture 目录、runner 位置）
-- [ ] 文档更新
+- [x] 项目结构整理（fixture 目录、runner 位置）
+- [x] 文档更新
 
 ### Phase 5: Java-Pine 开发
 - [ ] Java 项目初始化
@@ -38,7 +39,8 @@
 
 ## 当前进度
 
-Phase 1 完成，进入 Phase 2。
+Phase 1-4 完成。Go 端 JSON fixture 测试系统已就绪（11 个算子，44 个用例）。
+下一步：Phase 5 Java-Pine 开发。
 
 ---
 

--- a/docs/json-fixture-plan.md
+++ b/docs/json-fixture-plan.md
@@ -31,16 +31,17 @@
 - [x] 文档更新
 
 ### Phase 5: Java-Pine 开发
-- [ ] Java 项目初始化
-- [ ] 核心数据模型（OperatorInput/Output, Common/Items）
-- [ ] Operator 接口 + Registry
-- [ ] 逐算子实现（共享 fixture 验证）
+- [x] Java 项目初始化（Maven, JDK 11+）
+- [x] 核心数据模型（OperatorInput/Output, Common/Items）
+- [x] Operator 接口 + Registry
+- [x] 逐算子实现（10 个纯计算算子，共享 fixture 验证通过）
 - [ ] CI cross-validation
+- [ ] transform_by_lua（需 LuaJ 依赖）
 
 ## 当前进度
 
-Phase 1-4 完成。Go 端 JSON fixture 测试系统已就绪（11 个算子，44 个用例）。
-下一步：Phase 5 Java-Pine 开发。
+Phase 1-5 基本完成。Go 和 Java 双端共享 36 个 fixture 用例全部通过。
+剩余：CI cross-validation 配置、Lua 算子 Java 实现。
 
 ---
 

--- a/docs/json-fixture-plan.md
+++ b/docs/json-fixture-plan.md
@@ -1,0 +1,85 @@
+# JSON Fixture 统一测试 & Java-Pine 计划
+
+## 目标
+
+将 Pineapple 的算子测试从 Go 代码内嵌形式迁移为独立 JSON fixture，
+使 Go 和 Java 双端可以加载同一组 fixture 进行 cross-validation，消除 training-serving skew。
+
+## 阶段
+
+### Phase 0: 调研与计划
+- [x] 编写计划文件
+
+### Phase 1: 现有测试统计
+- [x] 统计每个算子的测试数量和类型
+- [x] 识别哪些测试可以转为 fixture
+
+### Phase 2: JSON fixture 格式设计与迁移
+- [ ] 设计 fixture JSON schema（config + input + expected_output）
+- [ ] 编写 Go test runner 加载 fixture 文件
+- [ ] 逐算子迁移测试为 fixture 形式
+- [ ] 保留原有 Go 测试作为回归保护
+
+### Phase 3: Go 引擎适配
+- [ ] 确保引擎支持 fixture runner（单算子隔离执行模式）
+- [ ] 验证原有测试行为不变
+- [ ] 验证 fixture 测试等价性
+
+### Phase 4: 整理
+- [ ] 项目结构整理（fixture 目录、runner 位置）
+- [ ] 文档更新
+
+### Phase 5: Java-Pine 开发
+- [ ] Java 项目初始化
+- [ ] 核心数据模型（OperatorInput/Output, Common/Items）
+- [ ] Operator 接口 + Registry
+- [ ] 逐算子实现（共享 fixture 验证）
+- [ ] CI cross-validation
+
+## 当前进度
+
+Phase 1 完成，进入 Phase 2。
+
+---
+
+## Phase 1 调查结果
+
+### 算子测试统计
+
+| 算子 | Unit | Bench | 可转 Fixture | 不可转原因 |
+|------|------|-------|-------------|-----------|
+| filter_condition | 5 | 1 | 4 | 1 Init 参数校验 |
+| filter_truncate | 7 | 1 | 4 | 3 Init 参数解析 |
+| filter_paginate | 5 | 0 | 4 | 1 参数类型 coerce |
+| transform_by_lua | 12 | 7 | 6 | 并发/Init/nil/string 返回值 |
+| transform_copy | 6 | 0 | 5 | 1 Init bad direction |
+| transform_dispatch | 4 | 2 | 3 | 1 Init |
+| transform_normalize | 7 | 2 | 4 | 2 Init + 1 BadType |
+| transform_redis_get | 12 | 0 | 7 | 需 miniredis，infra-error 测试 |
+| transform_redis_set | 11 | 0 | 5 | 需 miniredis，error cases |
+| transform_by_remote_pineapple | 10 | 0 | 2 | 网络行为(SSRF/timeout/500) |
+| transform_resource_lookup | 6 | 0 | 4 | 需 resource.Context |
+| transform_size | 3 | 0 | 2 | 1 Init |
+| merge_dedup | 5 | 3 | 3 | 2 Init 参数校验 |
+| observe_log | 5 | 0 | 2 | Init + SetMetadata + 无副作用验证 |
+| recall_static | 7 | 7 | 3 | 内存隔离(Go-specific) + 3 Init |
+| recall_resource | 5 | 0 | 3 | 需 resource.Context |
+| reorder_sort | 8 | 5 | 5 | 3 Init |
+| reorder_shuffle_by_salt | 4 | 0 | 2 | shuffle 非确定性 |
+| **Lua sandbox** | 8 | 0 | 0 | 全部 Go-specific 安全测试 |
+| **Lua pool** | 11 | 0 | 0 | 全部 Go-specific 生命周期 |
+| **合计** | 141 | 28 | ~68 | |
+
+### 关键发现
+
+1. **约 68 个测试可转为 JSON fixture**（有明确的 params + input → output 断言）
+2. **不可转的测试**主要是：Init 参数校验、Go 并发/生命周期、需要外部服务（Redis/HTTP）
+3. **没有真正的 E2E 正确性测试**使用真实注册算子跑完整管线并断言输出
+4. **Redis/Remote 算子**依赖外部服务，fixture 只能覆盖纯计算逻辑部分
+
+### Fixture 迁移优先级（由易到难）
+
+1. **第一批（纯计算，无外部依赖）**：filter_condition, filter_truncate, filter_paginate, transform_copy, transform_dispatch, transform_normalize, transform_size, merge_dedup, reorder_sort, recall_static
+2. **第二批（Lua 脚本）**：transform_by_lua（需要 fixture 中嵌入 lua_script）
+3. **第三批（需 mock 外部服务，可能不转）**：transform_redis_get/set, transform_by_remote_pineapple, recall_resource, transform_resource_lookup
+4. **不转**：Lua sandbox/pool 测试、shuffle（非确定性）

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,49 @@
+# Operator Test Fixtures
+
+JSON fixture files for cross-language operator validation.
+
+## Schema
+
+Each file is named `{operator_name}.json` and contains:
+
+```json
+{
+  "operator": "string — registered operator type_name",
+  "cases": [
+    {
+      "name": "string — human-readable test case name",
+      "params": { "key": "value" },
+      "metadata": {
+        "common_input": ["field1"],
+        "item_input": ["field2"],
+        "common_output": ["field3"],
+        "item_output": ["field4"]
+      },
+      "input": {
+        "common": { "field1": "value" },
+        "items": [ { "field2": "value" } ]
+      },
+      "expected": {
+        "common": { "field3": "value" },
+        "items": [ { "field4": "value" } ],
+        "added_items": [ { "key": "value" } ],
+        "removed_indices": [0, 2],
+        "warnings": ["optional warning substring match"]
+      }
+    }
+  ]
+}
+```
+
+## Expected output semantics
+
+- `expected.common`: fields that must appear in common writes (subset match)
+- `expected.items`: for Transform/Recall — the full expected items list after execution
+- `expected.added_items`: for Recall — items produced by the operator
+- `expected.removed_indices`: for Filter — indices of items removed
+- `expected.warnings`: if present, each string must be a substring of a warning message
+- Omitted fields in `expected` are not checked
+
+## File naming
+
+`fixtures/{operator_name}.json` — one file per operator, e.g. `fixtures/filter_condition.json`

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -38,12 +38,36 @@ Each file is named `{operator_name}.json` and contains:
 ## Expected output semantics
 
 - `expected.common`: fields that must appear in common writes (subset match)
-- `expected.items`: for Transform/Recall — the full expected items list after execution
+- `expected.items`: for Transform — per-item writes indexed by position
 - `expected.added_items`: for Recall — items produced by the operator
 - `expected.removed_indices`: for Filter — indices of items removed
+- `expected.item_order`: for Reorder — final item index order after sorting
 - `expected.warnings`: if present, each string must be a substring of a warning message
 - Omitted fields in `expected` are not checked
 
 ## File naming
 
 `fixtures/{operator_name}.json` — one file per operator, e.g. `fixtures/filter_condition.json`
+
+## Coverage
+
+| Operator | Cases | Type |
+|----------|-------|------|
+| filter_condition | 4 | Filter |
+| filter_truncate | 4 | Filter |
+| filter_paginate | 5 | Filter |
+| transform_copy | 5 | Transform |
+| transform_dispatch | 3 | Transform |
+| transform_normalize | 4 | Transform |
+| transform_size | 2 | Transform |
+| transform_by_lua | 8 | Transform (Lua) |
+| merge_dedup | 3 | Merge |
+| reorder_sort | 4 | Reorder |
+| recall_static | 2 | Recall |
+| **Total** | **44** | |
+
+Not converted (require external services or non-deterministic):
+- transform_redis_get/set (requires Redis)
+- transform_by_remote_pineapple (requires HTTP)
+- transform_resource_lookup, recall_resource (requires resource.Context)
+- reorder_shuffle_by_salt (non-deterministic)

--- a/fixtures/filter_condition.json
+++ b/fixtures/filter_condition.json
@@ -1,0 +1,83 @@
+{
+  "operator": "filter_condition",
+  "cases": [
+    {
+      "name": "remove matching string items",
+      "params": { "value": "offline" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["status"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_id": "a", "status": "online" },
+          { "item_id": "b", "status": "offline" },
+          { "item_id": "c", "status": "online" },
+          { "item_id": "d", "status": "offline" }
+        ]
+      },
+      "expected": {
+        "removed_indices": [1, 3]
+      }
+    },
+    {
+      "name": "no items match",
+      "params": { "value": "offline" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["status"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_id": "a", "status": "online" }
+        ]
+      },
+      "expected": {
+        "removed_indices": []
+      }
+    },
+    {
+      "name": "numeric value match",
+      "params": { "value": 0 },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["flag"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "flag": 0 },
+          { "flag": 1 }
+        ]
+      },
+      "expected": {
+        "removed_indices": [0]
+      }
+    },
+    {
+      "name": "empty items list",
+      "params": { "value": "offline" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["status"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": []
+      },
+      "expected": {
+        "removed_indices": []
+      }
+    }
+  ]
+}

--- a/fixtures/filter_paginate.json
+++ b/fixtures/filter_paginate.json
@@ -1,0 +1,117 @@
+{
+  "operator": "filter_paginate",
+  "cases": [
+    {
+      "name": "second page of ten items",
+      "params": {},
+      "metadata": {
+        "common_input": ["page", "size"],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": { "page": 1, "size": 3 },
+        "items": [
+          { "id": 0 },
+          { "id": 1 },
+          { "id": 2 },
+          { "id": 3 },
+          { "id": 4 },
+          { "id": 5 },
+          { "id": 6 },
+          { "id": 7 },
+          { "id": 8 },
+          { "id": 9 }
+        ]
+      },
+      "expected": {
+        "removed_indices": [0, 1, 2, 6, 7, 8, 9]
+      }
+    },
+    {
+      "name": "first page keeps leading items",
+      "params": {},
+      "metadata": {
+        "common_input": ["page", "size"],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": { "page": 0, "size": 3 },
+        "items": [
+          { "id": 0 },
+          { "id": 1 },
+          { "id": 2 },
+          { "id": 3 },
+          { "id": 4 }
+        ]
+      },
+      "expected": {
+        "removed_indices": [3, 4]
+      }
+    },
+    {
+      "name": "page beyond end removes all items",
+      "params": {},
+      "metadata": {
+        "common_input": ["page", "size"],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": { "page": 10, "size": 5 },
+        "items": [
+          { "id": 0 },
+          { "id": 1 },
+          { "id": 2 }
+        ]
+      },
+      "expected": {
+        "removed_indices": [0, 1, 2]
+      }
+    },
+    {
+      "name": "empty items list",
+      "params": {},
+      "metadata": {
+        "common_input": ["page", "size"],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": { "page": 0, "size": 10 },
+        "items": []
+      },
+      "expected": {
+        "removed_indices": []
+      }
+    },
+    {
+      "name": "float64 params from JSON decoding",
+      "params": {},
+      "metadata": {
+        "common_input": ["page", "size"],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": { "page": 0, "size": 2 },
+        "items": [
+          { "id": 0 },
+          { "id": 1 },
+          { "id": 2 },
+          { "id": 3 },
+          { "id": 4 }
+        ]
+      },
+      "expected": {
+        "removed_indices": [2, 3, 4]
+      }
+    }
+  ]
+}

--- a/fixtures/filter_truncate.json
+++ b/fixtures/filter_truncate.json
@@ -1,0 +1,84 @@
+{
+  "operator": "filter_truncate",
+  "cases": [
+    {
+      "name": "truncate to top 2 items",
+      "params": { "top_n": 2 },
+      "metadata": {
+        "common_input": [],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_id": "a" },
+          { "item_id": "b" },
+          { "item_id": "c" },
+          { "item_id": "d" }
+        ]
+      },
+      "expected": {
+        "removed_indices": [2, 3]
+      }
+    },
+    {
+      "name": "no truncation when top_n exceeds item count",
+      "params": { "top_n": 10 },
+      "metadata": {
+        "common_input": [],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_id": "a" },
+          { "item_id": "b" }
+        ]
+      },
+      "expected": {
+        "removed_indices": []
+      }
+    },
+    {
+      "name": "top_n zero removes all items",
+      "params": { "top_n": 0 },
+      "metadata": {
+        "common_input": [],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_id": "a" },
+          { "item_id": "b" }
+        ]
+      },
+      "expected": {
+        "removed_indices": [0, 1]
+      }
+    },
+    {
+      "name": "empty items list",
+      "params": { "top_n": 5 },
+      "metadata": {
+        "common_input": [],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": []
+      },
+      "expected": {
+        "removed_indices": []
+      }
+    }
+  ]
+}

--- a/fixtures/fixture_test.go
+++ b/fixtures/fixture_test.go
@@ -43,6 +43,7 @@ type fixtureExpected struct {
 	Items          []map[string]any `json:"items"`
 	AddedItems     []map[string]any `json:"added_items"`
 	RemovedIndices []int            `json:"removed_indices"`
+	ItemOrder      []int            `json:"item_order"`
 	Warnings       []string         `json:"warnings"`
 }
 
@@ -160,6 +161,19 @@ func runFixtureCase(t *testing.T, operatorName string, tc fixtureCase) {
 			}
 			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", expectedVal) {
 				t.Errorf("common_writes[%q] = %v, expected %v", key, got, expectedVal)
+			}
+		}
+	}
+
+	// Validate item order (Reorder)
+	if tc.Expected.ItemOrder != nil {
+		order := output.GetItemOrder()
+		if len(order) != len(tc.Expected.ItemOrder) {
+			t.Fatalf("item_order: got %d entries, expected %d", len(order), len(tc.Expected.ItemOrder))
+		}
+		for i, expected := range tc.Expected.ItemOrder {
+			if order[i] != expected {
+				t.Errorf("item_order[%d] = %d, expected %d", i, order[i], expected)
 			}
 		}
 	}

--- a/fixtures/fixture_test.go
+++ b/fixtures/fixture_test.go
@@ -1,0 +1,188 @@
+package fixtures_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pine "github.com/Liam0205/pineapple"
+	_ "github.com/Liam0205/pineapple/operators"
+)
+
+type fixtureFile struct {
+	Operator string        `json:"operator"`
+	Cases    []fixtureCase `json:"cases"`
+}
+
+type fixtureCase struct {
+	Name     string          `json:"name"`
+	Params   map[string]any  `json:"params"`
+	Metadata fixtureMetadata `json:"metadata"`
+	Input    fixtureInput    `json:"input"`
+	Expected fixtureExpected `json:"expected"`
+}
+
+type fixtureMetadata struct {
+	CommonInput  []string `json:"common_input"`
+	ItemInput    []string `json:"item_input"`
+	CommonOutput []string `json:"common_output"`
+	ItemOutput   []string `json:"item_output"`
+}
+
+type fixtureInput struct {
+	Common map[string]any   `json:"common"`
+	Items  []map[string]any `json:"items"`
+}
+
+type fixtureExpected struct {
+	Common         map[string]any   `json:"common"`
+	Items          []map[string]any `json:"items"`
+	AddedItems     []map[string]any `json:"added_items"`
+	RemovedIndices []int            `json:"removed_indices"`
+	Warnings       []string         `json:"warnings"`
+}
+
+func TestFixtures(t *testing.T) {
+	files, err := filepath.Glob("*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Skip("no fixture files found")
+	}
+
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var ff fixtureFile
+			if err := json.Unmarshal(data, &ff); err != nil {
+				t.Fatal(err)
+			}
+			for _, tc := range ff.Cases {
+				t.Run(tc.Name, func(t *testing.T) {
+					runFixtureCase(t, ff.Operator, tc)
+				})
+			}
+		})
+	}
+}
+
+func runFixtureCase(t *testing.T, operatorName string, tc fixtureCase) {
+	t.Helper()
+
+	// Build operator via registry
+	op, _, err := pine.BuildOperator(operatorName, tc.Params)
+	if err != nil {
+		t.Fatalf("BuildOperator(%q): %v", operatorName, err)
+	}
+
+	// Inject metadata if the operator is MetadataAware
+	if ma, ok := op.(interface {
+		SetMetadata(commonInput, commonOutput, itemInput, itemOutput []string)
+	}); ok {
+		ma.SetMetadata(
+			tc.Metadata.CommonInput,
+			tc.Metadata.CommonOutput,
+			tc.Metadata.ItemInput,
+			tc.Metadata.ItemOutput,
+		)
+	}
+
+	// Build input
+	input := pine.NewOperatorInput(tc.Input.Common, tc.Input.Items)
+
+	// Execute
+	output := pine.NewOperatorOutput()
+	err = op.Execute(context.Background(), input, output)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Validate warnings
+	if tc.Expected.Warnings != nil {
+		w := output.GetWarning()
+		if w == nil && len(tc.Expected.Warnings) > 0 {
+			t.Errorf("expected warnings but got none")
+		} else if w != nil {
+			warnStr := w.Error()
+			for _, substr := range tc.Expected.Warnings {
+				if !strings.Contains(warnStr, substr) {
+					t.Errorf("warning %q does not contain %q", warnStr, substr)
+				}
+			}
+		}
+	}
+
+	// Validate removed indices (Filter)
+	if tc.Expected.RemovedIndices != nil {
+		removed := output.GetRemovedItems()
+		for _, idx := range tc.Expected.RemovedIndices {
+			if _, ok := removed[idx]; !ok {
+				t.Errorf("expected item[%d] to be removed, but it wasn't", idx)
+			}
+		}
+		if len(removed) != len(tc.Expected.RemovedIndices) {
+			t.Errorf("removed %d items, expected %d", len(removed), len(tc.Expected.RemovedIndices))
+		}
+	}
+
+	// Validate added items (Recall)
+	if tc.Expected.AddedItems != nil {
+		added := output.GetAddedItems()
+		if len(added) != len(tc.Expected.AddedItems) {
+			t.Fatalf("added_items: got %d, expected %d", len(added), len(tc.Expected.AddedItems))
+		}
+		for i, expectedItem := range tc.Expected.AddedItems {
+			for key, expectedVal := range expectedItem {
+				got := added[i][key]
+				if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", expectedVal) {
+					t.Errorf("added_items[%d].%s = %v, expected %v", i, key, got, expectedVal)
+				}
+			}
+		}
+	}
+
+	// Validate common writes
+	if tc.Expected.Common != nil {
+		cw := output.GetCommonWrites()
+		for key, expectedVal := range tc.Expected.Common {
+			got, ok := cw[key]
+			if !ok {
+				t.Errorf("common_writes missing key %q", key)
+				continue
+			}
+			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", expectedVal) {
+				t.Errorf("common_writes[%q] = %v, expected %v", key, got, expectedVal)
+			}
+		}
+	}
+
+	// Validate item writes (Transform)
+	if tc.Expected.Items != nil {
+		iw := output.GetItemWrites()
+		for i, expectedItem := range tc.Expected.Items {
+			for key, expectedVal := range expectedItem {
+				writes, ok := iw[i]
+				if !ok {
+					t.Errorf("item_writes[%d] missing, expected writes for key %q", i, key)
+					continue
+				}
+				got, ok := writes[key]
+				if !ok {
+					t.Errorf("item_writes[%d] missing key %q", i, key)
+					continue
+				}
+				if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", expectedVal) {
+					t.Errorf("item_writes[%d].%s = %v, expected %v", i, key, got, expectedVal)
+				}
+			}
+		}
+	}
+}

--- a/fixtures/merge_dedup.json
+++ b/fixtures/merge_dedup.json
@@ -1,0 +1,65 @@
+{
+  "operator": "merge_dedup",
+  "cases": [
+    {
+      "name": "remove duplicate items keeping first",
+      "params": { "strategy": "first" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["item_id"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_id": "a", "score": 1.0 },
+          { "item_id": "b", "score": 2.0 },
+          { "item_id": "a", "score": 3.0 },
+          { "item_id": "c", "score": 4.0 },
+          { "item_id": "b", "score": 5.0 }
+        ]
+      },
+      "expected": {
+        "removed_indices": [2, 4]
+      }
+    },
+    {
+      "name": "no duplicates",
+      "params": { "strategy": "first" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["item_id"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_id": "a" },
+          { "item_id": "b" }
+        ]
+      },
+      "expected": {
+        "removed_indices": []
+      }
+    },
+    {
+      "name": "empty items list",
+      "params": { "strategy": "first" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["item_id"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": []
+      },
+      "expected": {
+        "removed_indices": []
+      }
+    }
+  ]
+}

--- a/fixtures/recall_static.json
+++ b/fixtures/recall_static.json
@@ -1,0 +1,49 @@
+{
+  "operator": "recall_static",
+  "cases": [
+    {
+      "name": "recalls configured items",
+      "params": {
+        "items": [
+          { "item_id": "x", "val": 10 },
+          { "item_id": "y", "val": 20 }
+        ]
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": []
+      },
+      "expected": {
+        "added_items": [
+          { "item_id": "x", "val": 10 },
+          { "item_id": "y", "val": 20 }
+        ]
+      }
+    },
+    {
+      "name": "empty items config adds nothing",
+      "params": {
+        "items": []
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": [],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": []
+      },
+      "expected": {
+        "added_items": []
+      }
+    }
+  ]
+}

--- a/fixtures/reorder_sort.json
+++ b/fixtures/reorder_sort.json
@@ -1,0 +1,83 @@
+{
+  "operator": "reorder_sort",
+  "cases": [
+    {
+      "name": "descending sort by score",
+      "params": { "order": "desc" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["score"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_id": "a", "score": 10.0 },
+          { "item_id": "b", "score": 30.0 },
+          { "item_id": "c", "score": 20.0 }
+        ]
+      },
+      "expected": {
+        "item_order": [1, 2, 0]
+      }
+    },
+    {
+      "name": "ascending sort by score",
+      "params": { "order": "asc" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["score"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_id": "a", "score": 30.0 },
+          { "item_id": "b", "score": 10.0 },
+          { "item_id": "c", "score": 20.0 }
+        ]
+      },
+      "expected": {
+        "item_order": [1, 2, 0]
+      }
+    },
+    {
+      "name": "empty items list",
+      "params": { "order": "desc" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["score"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": []
+      },
+      "expected": {}
+    },
+    {
+      "name": "integer score values",
+      "params": { "order": "desc" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["score"],
+        "common_output": [],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "score": 5 },
+          { "score": 15 },
+          { "score": 10 }
+        ]
+      },
+      "expected": {
+        "item_order": [1, 2, 0]
+      }
+    }
+  ]
+}

--- a/fixtures/transform_by_lua.json
+++ b/fixtures/transform_by_lua.json
@@ -1,0 +1,202 @@
+{
+  "operator": "transform_by_lua",
+  "cases": [
+    {
+      "name": "item function applies discount for young user",
+      "params": {
+        "lua_script": "function adjust_price()\n  if user_age < 18 then\n    return item_price * 0.8\n  else\n    return item_price\n  end\nend",
+        "function_for_item": "adjust_price",
+        "function_for_common": ""
+      },
+      "metadata": {
+        "common_input": ["user_age"],
+        "item_input": ["item_price"],
+        "common_output": [],
+        "item_output": ["item_adjusted"]
+      },
+      "input": {
+        "common": { "user_age": 15.0 },
+        "items": [
+          { "item_price": 100.0 },
+          { "item_price": 200.0 }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "item_adjusted": 80.0 },
+          { "item_adjusted": 160.0 }
+        ]
+      }
+    },
+    {
+      "name": "item function no discount for adult user",
+      "params": {
+        "lua_script": "function adjust_price()\n  if user_age < 18 then\n    return item_price * 0.8\n  else\n    return item_price\n  end\nend",
+        "function_for_item": "adjust_price",
+        "function_for_common": ""
+      },
+      "metadata": {
+        "common_input": ["user_age"],
+        "item_input": ["item_price"],
+        "common_output": [],
+        "item_output": ["item_adjusted"]
+      },
+      "input": {
+        "common": { "user_age": 25.0 },
+        "items": [
+          { "item_price": 100.0 }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "item_adjusted": 100.0 }
+        ]
+      }
+    },
+    {
+      "name": "common function computes aggregate stats",
+      "params": {
+        "lua_script": "function compute_stats()\n  local sum = 0\n  local max_val = -math.huge\n  for i = 1, #item_price do\n    local p = item_price[i] or 0\n    sum = sum + p\n    if p > max_val then max_val = p end\n  end\n  return sum / #item_price, max_val\nend",
+        "function_for_item": "",
+        "function_for_common": "compute_stats"
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["item_price"],
+        "common_output": ["avg_price", "max_price"],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_price": 100.0 },
+          { "item_price": 200.0 },
+          { "item_price": 300.0 }
+        ]
+      },
+      "expected": {
+        "common": {
+          "avg_price": 200.0,
+          "max_price": 300.0
+        }
+      }
+    },
+    {
+      "name": "common function returns boolean false",
+      "params": {
+        "lua_script": "function evaluate()\n  if (item_count > 0) then return false else return true end\nend",
+        "function_for_item": "",
+        "function_for_common": "evaluate"
+      },
+      "metadata": {
+        "common_input": ["item_count"],
+        "item_input": [],
+        "common_output": ["_if_1"],
+        "item_output": []
+      },
+      "input": {
+        "common": { "item_count": 5.0 },
+        "items": []
+      },
+      "expected": {
+        "common": {
+          "_if_1": false
+        }
+      }
+    },
+    {
+      "name": "common function returns boolean true",
+      "params": {
+        "lua_script": "function evaluate()\n  if (item_count > 0) then return false else return true end\nend",
+        "function_for_item": "",
+        "function_for_common": "evaluate"
+      },
+      "metadata": {
+        "common_input": ["item_count"],
+        "item_input": [],
+        "common_output": ["_if_1"],
+        "item_output": []
+      },
+      "input": {
+        "common": { "item_count": 0.0 },
+        "items": []
+      },
+      "expected": {
+        "common": {
+          "_if_1": true
+        }
+      }
+    },
+    {
+      "name": "item function with multiple return values",
+      "params": {
+        "lua_script": "function f() return item_x * 2, item_x + 10 end",
+        "function_for_item": "f",
+        "function_for_common": ""
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["item_x"],
+        "common_output": [],
+        "item_output": ["double", "plus10"]
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_x": 5.0 }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "double": 10.0, "plus10": 15.0 }
+        ]
+      }
+    },
+    {
+      "name": "item function with empty items produces no writes",
+      "params": {
+        "lua_script": "function f() return 1 end",
+        "function_for_item": "f",
+        "function_for_common": ""
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": [],
+        "common_output": [],
+        "item_output": ["out"]
+      },
+      "input": {
+        "common": {},
+        "items": []
+      },
+      "expected": {
+        "items": []
+      }
+    },
+    {
+      "name": "item function with string concatenation",
+      "params": {
+        "lua_script": "function f() return \"hello_\" .. item_name end",
+        "function_for_item": "f",
+        "function_for_common": ""
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["item_name"],
+        "common_output": [],
+        "item_output": ["greeting"]
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_name": "world" }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "greeting": "hello_world" }
+        ]
+      }
+    }
+  ]
+}

--- a/fixtures/transform_copy.json
+++ b/fixtures/transform_copy.json
@@ -1,0 +1,90 @@
+{
+  "operator": "transform_copy",
+  "cases": [
+    {
+      "name": "common_to_common copies multiple fields",
+      "params": { "direction": "common_to_common" },
+      "metadata": {
+        "common_input": ["src_a", "src_b"],
+        "item_input": [],
+        "common_output": ["dst_a", "dst_b"],
+        "item_output": []
+      },
+      "input": {
+        "common": { "src_a": "hello", "src_b": 42.0 },
+        "items": []
+      },
+      "expected": {
+        "common": { "dst_a": "hello", "dst_b": 42.0 }
+      }
+    },
+    {
+      "name": "common_to_item broadcasts value to all items",
+      "params": { "direction": "common_to_item" },
+      "metadata": {
+        "common_input": ["user_tag"],
+        "item_input": [],
+        "common_output": [],
+        "item_output": ["item_tag"]
+      },
+      "input": {
+        "common": { "user_tag": "vip" },
+        "items": [{ "id": 1 }, { "id": 2 }]
+      },
+      "expected": {
+        "items": [{ "item_tag": "vip" }, { "item_tag": "vip" }]
+      }
+    },
+    {
+      "name": "item_to_item copies per-item field",
+      "params": { "direction": "item_to_item" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["price"],
+        "common_output": [],
+        "item_output": ["original_price"]
+      },
+      "input": {
+        "common": {},
+        "items": [{ "price": 10.0 }, { "price": 20.0 }]
+      },
+      "expected": {
+        "items": [{ "original_price": 10.0 }, { "original_price": 20.0 }]
+      }
+    },
+    {
+      "name": "item_to_common collects values into list",
+      "params": { "direction": "item_to_common" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["price"],
+        "common_output": ["price_list"],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [{ "price": 10.0 }, { "price": 20.0 }, { "price": 30.0 }]
+      },
+      "expected": {
+        "common": { "price_list": [10.0, 20.0, 30.0] }
+      }
+    },
+    {
+      "name": "common_to_item with empty items produces no writes",
+      "params": { "direction": "common_to_item" },
+      "metadata": {
+        "common_input": ["tag"],
+        "item_input": [],
+        "common_output": [],
+        "item_output": ["item_tag"]
+      },
+      "input": {
+        "common": { "tag": "test" },
+        "items": []
+      },
+      "expected": {
+        "items": []
+      }
+    }
+  ]
+}

--- a/fixtures/transform_dispatch.json
+++ b/fixtures/transform_dispatch.json
@@ -1,0 +1,66 @@
+{
+  "operator": "transform_dispatch",
+  "cases": [
+    {
+      "name": "dispatches common field to all items",
+      "params": {},
+      "metadata": {
+        "common_input": ["scene"],
+        "item_input": [],
+        "common_output": [],
+        "item_output": ["item_scene"]
+      },
+      "input": {
+        "common": { "scene": "homepage" },
+        "items": [
+          { "item_id": "a" },
+          { "item_id": "b" },
+          { "item_id": "c" }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "item_scene": "homepage" },
+          { "item_scene": "homepage" },
+          { "item_scene": "homepage" }
+        ]
+      }
+    },
+    {
+      "name": "empty items produces no writes",
+      "params": {},
+      "metadata": {
+        "common_input": ["scene"],
+        "item_input": [],
+        "common_output": [],
+        "item_output": ["item_scene"]
+      },
+      "input": {
+        "common": { "scene": "test" },
+        "items": []
+      },
+      "expected": {
+        "items": []
+      }
+    },
+    {
+      "name": "missing common field dispatches nil",
+      "params": {},
+      "metadata": {
+        "common_input": ["missing"],
+        "item_input": [],
+        "common_output": [],
+        "item_output": ["item_missing"]
+      },
+      "input": {
+        "common": {},
+        "items": [{ "item_id": "a" }]
+      },
+      "expected": {
+        "items": [
+          { "item_missing": null }
+        ]
+      }
+    }
+  ]
+}

--- a/fixtures/transform_normalize.json
+++ b/fixtures/transform_normalize.json
@@ -1,0 +1,93 @@
+{
+  "operator": "transform_normalize",
+  "cases": [
+    {
+      "name": "min_max scales to 0-1 range",
+      "params": { "method": "min_max" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["score"],
+        "common_output": [],
+        "item_output": ["score_norm"]
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "score": 0.0 },
+          { "score": 50.0 },
+          { "score": 100.0 }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "score_norm": 0.0 },
+          { "score_norm": 0.5 },
+          { "score_norm": 1.0 }
+        ]
+      }
+    },
+    {
+      "name": "equal values produce all zeros",
+      "params": { "method": "min_max" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["score"],
+        "common_output": [],
+        "item_output": ["score_norm"]
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "score": 5.0 },
+          { "score": 5.0 }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "score_norm": 0.0 },
+          { "score_norm": 0.0 }
+        ]
+      }
+    },
+    {
+      "name": "empty items produces no writes",
+      "params": { "method": "min_max" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["score"],
+        "common_output": [],
+        "item_output": ["score_norm"]
+      },
+      "input": {
+        "common": {},
+        "items": []
+      },
+      "expected": {
+        "items": []
+      }
+    },
+    {
+      "name": "int64 values are handled correctly",
+      "params": { "method": "min_max" },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["score"],
+        "common_output": [],
+        "item_output": ["score_norm"]
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "score": 0 },
+          { "score": 100 }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "score_norm": 0.0 },
+          { "score_norm": 1.0 }
+        ]
+      }
+    }
+  ]
+}

--- a/fixtures/transform_size.json
+++ b/fixtures/transform_size.json
@@ -1,0 +1,39 @@
+{
+  "operator": "transform_size",
+  "cases": [
+    {
+      "name": "counts three items",
+      "params": {},
+      "metadata": {
+        "common_input": [],
+        "item_input": [],
+        "common_output": ["item_count"],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": [{"id": 1}, {"id": 2}, {"id": 3}]
+      },
+      "expected": {
+        "common": {"item_count": 3}
+      }
+    },
+    {
+      "name": "empty items returns zero",
+      "params": {},
+      "metadata": {
+        "common_input": [],
+        "item_input": [],
+        "common_output": ["item_count"],
+        "item_output": []
+      },
+      "input": {
+        "common": {},
+        "items": []
+      },
+      "expected": {
+        "common": {"item_count": 0}
+      }
+    }
+  ]
+}

--- a/java-pine/.gitignore
+++ b/java-pine/.gitignore
@@ -1,0 +1,5 @@
+target/
+*.class
+*.jar
+.idea/
+*.iml

--- a/java-pine/pom.xml
+++ b/java-pine/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.tipsy</groupId>
+    <artifactId>pine</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Java-Pine</name>
+    <description>Java implementation of Pineapple operator engine for MaxCompute UDFs</description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+        <jackson.version>2.17.0</jackson.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java-pine/src/main/java/com/tipsy/pine/AbstractOperator.java
+++ b/java-pine/src/main/java/com/tipsy/pine/AbstractOperator.java
@@ -1,0 +1,19 @@
+package com.tipsy.pine;
+
+import java.util.List;
+
+public abstract class AbstractOperator implements Operator, MetadataAware {
+    protected List<String> commonInput;
+    protected List<String> commonOutput;
+    protected List<String> itemInput;
+    protected List<String> itemOutput;
+
+    @Override
+    public void setMetadata(List<String> commonInput, List<String> commonOutput,
+                            List<String> itemInput, List<String> itemOutput) {
+        this.commonInput = commonInput;
+        this.commonOutput = commonOutput;
+        this.itemInput = itemInput;
+        this.itemOutput = itemOutput;
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/MetadataAware.java
+++ b/java-pine/src/main/java/com/tipsy/pine/MetadataAware.java
@@ -1,0 +1,8 @@
+package com.tipsy.pine;
+
+import java.util.List;
+
+public interface MetadataAware {
+    void setMetadata(List<String> commonInput, List<String> commonOutput,
+                     List<String> itemInput, List<String> itemOutput);
+}

--- a/java-pine/src/main/java/com/tipsy/pine/Operator.java
+++ b/java-pine/src/main/java/com/tipsy/pine/Operator.java
@@ -1,0 +1,8 @@
+package com.tipsy.pine;
+
+import java.util.Map;
+
+public interface Operator {
+    void init(Map<String, Object> params) throws Exception;
+    void execute(OperatorInput input, OperatorOutput output) throws Exception;
+}

--- a/java-pine/src/main/java/com/tipsy/pine/OperatorInput.java
+++ b/java-pine/src/main/java/com/tipsy/pine/OperatorInput.java
@@ -1,0 +1,38 @@
+package com.tipsy.pine;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class OperatorInput {
+    private final Map<String, Object> common;
+    private final List<Map<String, Object>> items;
+
+    public OperatorInput(Map<String, Object> common, List<Map<String, Object>> items) {
+        this.common = common != null ? common : Collections.emptyMap();
+        this.items = items != null ? items : Collections.emptyList();
+    }
+
+    public Object common(String field) {
+        return common.get(field);
+    }
+
+    public int itemCount() {
+        return items.size();
+    }
+
+    public Object item(int index, String field) {
+        if (index < 0 || index >= items.size()) {
+            return null;
+        }
+        return items.get(index).get(field);
+    }
+
+    public Map<String, Object> rawCommon() {
+        return common;
+    }
+
+    public List<Map<String, Object>> rawItems() {
+        return items;
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/OperatorOutput.java
+++ b/java-pine/src/main/java/com/tipsy/pine/OperatorOutput.java
@@ -1,0 +1,63 @@
+package com.tipsy.pine;
+
+import java.util.*;
+
+public class OperatorOutput {
+    private Map<String, Object> commonWrites;
+    private Map<Integer, Map<String, Object>> itemWrites;
+    private List<Map<String, Object>> addedItems;
+    private Set<Integer> removedItems;
+    private List<Integer> itemOrder;
+
+    public void setCommon(String field, Object value) {
+        if (commonWrites == null) {
+            commonWrites = new LinkedHashMap<>();
+        }
+        commonWrites.put(field, value);
+    }
+
+    public void setItem(int index, String field, Object value) {
+        if (itemWrites == null) {
+            itemWrites = new HashMap<>();
+        }
+        itemWrites.computeIfAbsent(index, k -> new LinkedHashMap<>()).put(field, value);
+    }
+
+    public void addItem(Map<String, Object> fields) {
+        if (addedItems == null) {
+            addedItems = new ArrayList<>();
+        }
+        addedItems.add(fields);
+    }
+
+    public void removeItem(int index) {
+        if (removedItems == null) {
+            removedItems = new HashSet<>();
+        }
+        removedItems.add(index);
+    }
+
+    public void setItemOrder(List<Integer> order) {
+        this.itemOrder = order;
+    }
+
+    public Map<String, Object> getCommonWrites() {
+        return commonWrites != null ? commonWrites : Collections.emptyMap();
+    }
+
+    public Map<Integer, Map<String, Object>> getItemWrites() {
+        return itemWrites != null ? itemWrites : Collections.emptyMap();
+    }
+
+    public List<Map<String, Object>> getAddedItems() {
+        return addedItems != null ? addedItems : Collections.emptyList();
+    }
+
+    public Set<Integer> getRemovedItems() {
+        return removedItems != null ? removedItems : Collections.emptySet();
+    }
+
+    public List<Integer> getItemOrder() {
+        return itemOrder;
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/OperatorType.java
+++ b/java-pine/src/main/java/com/tipsy/pine/OperatorType.java
@@ -1,0 +1,10 @@
+package com.tipsy.pine;
+
+public enum OperatorType {
+    RECALL,
+    TRANSFORM,
+    FILTER,
+    MERGE,
+    REORDER,
+    OBSERVE
+}

--- a/java-pine/src/main/java/com/tipsy/pine/Registry.java
+++ b/java-pine/src/main/java/com/tipsy/pine/Registry.java
@@ -1,0 +1,41 @@
+package com.tipsy.pine;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class Registry {
+    private static final Map<String, OperatorEntry> operators = new HashMap<>();
+
+    public static void register(String name, OperatorType type, Supplier<Operator> factory) {
+        if (operators.containsKey(name)) {
+            throw new IllegalStateException("operator already registered: " + name);
+        }
+        operators.put(name, new OperatorEntry(type, factory));
+    }
+
+    public static Operator buildOperator(String typeName, Map<String, Object> params) throws Exception {
+        OperatorEntry entry = operators.get(typeName);
+        if (entry == null) {
+            throw new IllegalArgumentException("unknown operator: " + typeName);
+        }
+        Operator op = entry.factory.get();
+        op.init(params);
+        return op;
+    }
+
+    public static OperatorType getType(String typeName) {
+        OperatorEntry entry = operators.get(typeName);
+        return entry != null ? entry.type : null;
+    }
+
+    private static class OperatorEntry {
+        final OperatorType type;
+        final Supplier<Operator> factory;
+
+        OperatorEntry(OperatorType type, Supplier<Operator> factory) {
+            this.type = type;
+            this.factory = factory;
+        }
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/AllOperators.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/AllOperators.java
@@ -1,0 +1,23 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.OperatorType;
+import com.tipsy.pine.Registry;
+
+public class AllOperators {
+    static {
+        Registry.register("filter_condition", OperatorType.FILTER, FilterCondition::new);
+        Registry.register("filter_truncate", OperatorType.FILTER, FilterTruncate::new);
+        Registry.register("filter_paginate", OperatorType.FILTER, FilterPaginate::new);
+        Registry.register("transform_copy", OperatorType.TRANSFORM, TransformCopy::new);
+        Registry.register("transform_dispatch", OperatorType.TRANSFORM, TransformDispatch::new);
+        Registry.register("transform_normalize", OperatorType.TRANSFORM, TransformNormalize::new);
+        Registry.register("transform_size", OperatorType.TRANSFORM, TransformSize::new);
+        Registry.register("merge_dedup", OperatorType.MERGE, MergeDedup::new);
+        Registry.register("reorder_sort", OperatorType.REORDER, ReorderSort::new);
+        Registry.register("recall_static", OperatorType.RECALL, RecallStatic::new);
+    }
+
+    public static void ensureRegistered() {
+        // Force class loading triggers static initializer
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/FilterCondition.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/FilterCondition.java
@@ -1,0 +1,27 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.AbstractOperator;
+import com.tipsy.pine.OperatorInput;
+import com.tipsy.pine.OperatorOutput;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class FilterCondition extends AbstractOperator {
+    private Object value;
+
+    @Override
+    public void init(Map<String, Object> params) {
+        this.value = params.get("value");
+    }
+
+    @Override
+    public void execute(OperatorInput input, OperatorOutput output) {
+        String field = itemInput.get(0);
+        for (int i = 0; i < input.itemCount(); i++) {
+            if (Objects.equals(String.valueOf(input.item(i, field)), String.valueOf(value))) {
+                output.removeItem(i);
+            }
+        }
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/FilterPaginate.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/FilterPaginate.java
@@ -1,0 +1,39 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.AbstractOperator;
+import com.tipsy.pine.OperatorInput;
+import com.tipsy.pine.OperatorOutput;
+
+import java.util.Map;
+
+public class FilterPaginate extends AbstractOperator {
+    @Override
+    public void init(Map<String, Object> params) {}
+
+    @Override
+    public void execute(OperatorInput input, OperatorOutput output) {
+        int n = input.itemCount();
+        if (n == 0) return;
+
+        int page = toInt(input.common(commonInput.get(0)));
+        int size = toInt(input.common(commonInput.get(1)));
+        if (size <= 0) size = 10;
+        if (page < 0) page = 0;
+
+        int start = page * size;
+        int end = Math.min(start + size, n);
+
+        for (int i = 0; i < n; i++) {
+            if (i < start || i >= end) {
+                output.removeItem(i);
+            }
+        }
+    }
+
+    private static int toInt(Object v) {
+        if (v instanceof Number) {
+            return ((Number) v).intValue();
+        }
+        return 0;
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/FilterTruncate.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/FilterTruncate.java
@@ -1,0 +1,31 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.AbstractOperator;
+import com.tipsy.pine.OperatorInput;
+import com.tipsy.pine.OperatorOutput;
+
+import java.util.Map;
+
+public class FilterTruncate extends AbstractOperator {
+    private int topN;
+
+    @Override
+    public void init(Map<String, Object> params) throws Exception {
+        Object v = params.get("top_n");
+        if (v instanceof Number) {
+            topN = ((Number) v).intValue();
+        } else {
+            throw new IllegalArgumentException("filter_truncate: top_n must be numeric");
+        }
+        if (topN < 0) {
+            throw new IllegalArgumentException("filter_truncate: top_n must be non-negative");
+        }
+    }
+
+    @Override
+    public void execute(OperatorInput input, OperatorOutput output) {
+        for (int i = topN; i < input.itemCount(); i++) {
+            output.removeItem(i);
+        }
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/MergeDedup.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/MergeDedup.java
@@ -1,0 +1,34 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.AbstractOperator;
+import com.tipsy.pine.OperatorInput;
+import com.tipsy.pine.OperatorOutput;
+
+import java.util.*;
+
+public class MergeDedup extends AbstractOperator {
+    private String strategy;
+
+    @Override
+    public void init(Map<String, Object> params) throws Exception {
+        strategy = (String) params.getOrDefault("strategy", "first");
+        if (!"first".equals(strategy)) {
+            throw new IllegalArgumentException("merge_dedup: unsupported strategy: " + strategy);
+        }
+    }
+
+    @Override
+    public void execute(OperatorInput input, OperatorOutput output) {
+        String dedupBy = itemInput.get(0);
+        Set<Object> seen = new LinkedHashSet<>();
+        for (int i = 0; i < input.itemCount(); i++) {
+            Object key = input.item(i, dedupBy);
+            String keyStr = String.valueOf(key);
+            if (seen.contains(keyStr)) {
+                output.removeItem(i);
+            } else {
+                seen.add(keyStr);
+            }
+        }
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/RecallStatic.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/RecallStatic.java
@@ -1,0 +1,34 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.AbstractOperator;
+import com.tipsy.pine.OperatorInput;
+import com.tipsy.pine.OperatorOutput;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RecallStatic extends AbstractOperator {
+    private List<Map<String, Object>> items;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void init(Map<String, Object> params) throws Exception {
+        Object raw = params.get("items");
+        if (raw == null) {
+            throw new IllegalArgumentException("recall_static: missing required param 'items'");
+        }
+        if (!(raw instanceof List)) {
+            throw new IllegalArgumentException("recall_static: 'items' must be a list");
+        }
+        items = (List<Map<String, Object>>) raw;
+    }
+
+    @Override
+    public void execute(OperatorInput input, OperatorOutput output) {
+        for (Map<String, Object> item : items) {
+            Map<String, Object> copy = new HashMap<>(item);
+            output.addItem(copy);
+        }
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/ReorderSort.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/ReorderSort.java
@@ -1,0 +1,64 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.AbstractOperator;
+import com.tipsy.pine.OperatorInput;
+import com.tipsy.pine.OperatorOutput;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ReorderSort extends AbstractOperator {
+    private boolean ascending;
+
+    @Override
+    public void init(Map<String, Object> params) throws Exception {
+        String order = (String) params.getOrDefault("order", "desc");
+        switch (order) {
+            case "asc":
+                ascending = true;
+                break;
+            case "desc":
+                ascending = false;
+                break;
+            default:
+                throw new IllegalArgumentException("reorder_sort: unsupported order: " + order);
+        }
+    }
+
+    @Override
+    public void execute(OperatorInput input, OperatorOutput output) throws Exception {
+        int n = input.itemCount();
+        if (n == 0) return;
+
+        String field = itemInput.get(0);
+        List<int[]> entries = new ArrayList<>(n);
+        double[] vals = new double[n];
+        for (int i = 0; i < n; i++) {
+            vals[i] = toDouble(input.item(i, field));
+            entries.add(new int[]{i});
+        }
+
+        Integer[] indices = new Integer[n];
+        for (int i = 0; i < n; i++) indices[i] = i;
+
+        final double[] sortVals = vals;
+        java.util.Arrays.sort(indices, (a, b) -> {
+            int cmp = Double.compare(sortVals[a], sortVals[b]);
+            return ascending ? cmp : -cmp;
+        });
+
+        List<Integer> order = new ArrayList<>(n);
+        for (int idx : indices) {
+            order.add(idx);
+        }
+        output.setItemOrder(order);
+    }
+
+    private static double toDouble(Object v) throws Exception {
+        if (v instanceof Number) {
+            return ((Number) v).doubleValue();
+        }
+        throw new Exception("cannot convert " + (v == null ? "null" : v.getClass().getName()) + " to double");
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/TransformCopy.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/TransformCopy.java
@@ -1,0 +1,69 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.AbstractOperator;
+import com.tipsy.pine.OperatorInput;
+import com.tipsy.pine.OperatorOutput;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class TransformCopy extends AbstractOperator {
+    private String direction;
+
+    @Override
+    public void init(Map<String, Object> params) throws Exception {
+        direction = (String) params.get("direction");
+        switch (direction) {
+            case "common_to_item":
+            case "item_to_common":
+            case "common_to_common":
+            case "item_to_item":
+                break;
+            default:
+                throw new IllegalArgumentException("transform_copy: unsupported direction: " + direction);
+        }
+    }
+
+    @Override
+    public void execute(OperatorInput input, OperatorOutput output) {
+        switch (direction) {
+            case "common_to_common":
+                for (int i = 0; i < commonInput.size(); i++) {
+                    output.setCommon(commonOutput.get(i), input.common(commonInput.get(i)));
+                }
+                break;
+
+            case "common_to_item":
+                for (int i = 0; i < commonInput.size(); i++) {
+                    Object val = input.common(commonInput.get(i));
+                    String dst = itemOutput.get(i);
+                    for (int j = 0; j < input.itemCount(); j++) {
+                        output.setItem(j, dst, val);
+                    }
+                }
+                break;
+
+            case "item_to_item":
+                for (int i = 0; i < itemInput.size(); i++) {
+                    String src = itemInput.get(i);
+                    String dst = itemOutput.get(i);
+                    for (int j = 0; j < input.itemCount(); j++) {
+                        output.setItem(j, dst, input.item(j, src));
+                    }
+                }
+                break;
+
+            case "item_to_common":
+                for (int i = 0; i < itemInput.size(); i++) {
+                    String src = itemInput.get(i);
+                    List<Object> vals = new ArrayList<>();
+                    for (int j = 0; j < input.itemCount(); j++) {
+                        vals.add(input.item(j, src));
+                    }
+                    output.setCommon(commonOutput.get(i), vals);
+                }
+                break;
+        }
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/TransformDispatch.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/TransformDispatch.java
@@ -1,0 +1,22 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.AbstractOperator;
+import com.tipsy.pine.OperatorInput;
+import com.tipsy.pine.OperatorOutput;
+
+import java.util.Map;
+
+public class TransformDispatch extends AbstractOperator {
+    @Override
+    public void init(Map<String, Object> params) {}
+
+    @Override
+    public void execute(OperatorInput input, OperatorOutput output) {
+        String commonField = commonInput.get(0);
+        String itemField = itemOutput.get(0);
+        Object val = input.common(commonField);
+        for (int i = 0; i < input.itemCount(); i++) {
+            output.setItem(i, itemField, val);
+        }
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/TransformNormalize.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/TransformNormalize.java
@@ -1,0 +1,52 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.AbstractOperator;
+import com.tipsy.pine.OperatorInput;
+import com.tipsy.pine.OperatorOutput;
+
+import java.util.Map;
+
+public class TransformNormalize extends AbstractOperator {
+    private String method;
+
+    @Override
+    public void init(Map<String, Object> params) throws Exception {
+        method = (String) params.getOrDefault("method", "min_max");
+        if (!"min_max".equals(method)) {
+            throw new IllegalArgumentException("transform_normalize: unsupported method: " + method);
+        }
+    }
+
+    @Override
+    public void execute(OperatorInput input, OperatorOutput output) throws Exception {
+        int n = input.itemCount();
+        if (n == 0) return;
+
+        String field = itemInput.get(0);
+        String outputField = itemOutput.get(0);
+
+        double[] vals = new double[n];
+        for (int i = 0; i < n; i++) {
+            vals[i] = toDouble(input.item(i, field));
+        }
+
+        double min = vals[0], max = vals[0];
+        for (int i = 1; i < n; i++) {
+            if (vals[i] < min) min = vals[i];
+            if (vals[i] > max) max = vals[i];
+        }
+
+        double range = max - min;
+        for (int i = 0; i < n; i++) {
+            double norm = range == 0 ? 0.0 : (vals[i] - min) / range;
+            output.setItem(i, outputField, norm);
+        }
+    }
+
+    private static double toDouble(Object v) throws Exception {
+        if (v instanceof Number) {
+            return ((Number) v).doubleValue();
+        }
+        throw new Exception("cannot convert " + (v == null ? "null" : v.getClass().getName()) + " to double");
+    }
+}

--- a/java-pine/src/main/java/com/tipsy/pine/operators/TransformSize.java
+++ b/java-pine/src/main/java/com/tipsy/pine/operators/TransformSize.java
@@ -1,0 +1,17 @@
+package com.tipsy.pine.operators;
+
+import com.tipsy.pine.AbstractOperator;
+import com.tipsy.pine.OperatorInput;
+import com.tipsy.pine.OperatorOutput;
+
+import java.util.Map;
+
+public class TransformSize extends AbstractOperator {
+    @Override
+    public void init(Map<String, Object> params) {}
+
+    @Override
+    public void execute(OperatorInput input, OperatorOutput output) {
+        output.setCommon(commonOutput.get(0), input.itemCount());
+    }
+}

--- a/java-pine/src/test/java/com/tipsy/pine/FixtureTest.java
+++ b/java-pine/src/test/java/com/tipsy/pine/FixtureTest.java
@@ -1,0 +1,180 @@
+package com.tipsy.pine;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tipsy.pine.operators.AllOperators;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+public class FixtureTest {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeAll
+    static void setup() {
+        AllOperators.ensureRegistered();
+    }
+
+    @TestFactory
+    @SuppressWarnings("unchecked")
+    Stream<DynamicNode> fixtureTests() throws Exception {
+        File fixtureDir = new File("../fixtures");
+        if (!fixtureDir.exists()) {
+            return Stream.empty();
+        }
+
+        File[] files = fixtureDir.listFiles((dir, name) -> name.endsWith(".json"));
+        if (files == null || files.length == 0) {
+            return Stream.empty();
+        }
+
+        Arrays.sort(files);
+        List<DynamicNode> nodes = new ArrayList<>();
+
+        for (File file : files) {
+            Map<String, Object> fixture = mapper.readValue(file, Map.class);
+            String operatorName = (String) fixture.get("operator");
+            List<Map<String, Object>> cases = (List<Map<String, Object>>) fixture.get("cases");
+
+            // Skip operators not yet implemented in Java
+            if (Registry.getType(operatorName) == null) {
+                continue;
+            }
+
+            List<DynamicTest> tests = new ArrayList<>();
+            for (Map<String, Object> tc : cases) {
+                String caseName = (String) tc.get("name");
+                tests.add(dynamicTest(caseName, () -> runCase(operatorName, tc)));
+            }
+            nodes.add(dynamicContainer(file.getName(), tests));
+        }
+        return nodes.stream();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void runCase(String operatorName, Map<String, Object> tc) throws Exception {
+        Map<String, Object> params = (Map<String, Object>) tc.getOrDefault("params", Collections.emptyMap());
+        Map<String, Object> metaMap = (Map<String, Object>) tc.getOrDefault("metadata", Collections.emptyMap());
+        Map<String, Object> inputMap = (Map<String, Object>) tc.getOrDefault("input", Collections.emptyMap());
+        Map<String, Object> expected = (Map<String, Object>) tc.getOrDefault("expected", Collections.emptyMap());
+
+        // Build operator
+        Operator op = Registry.buildOperator(operatorName, params);
+
+        // Set metadata
+        if (op instanceof MetadataAware) {
+            ((MetadataAware) op).setMetadata(
+                toStringList(metaMap.get("common_input")),
+                toStringList(metaMap.get("common_output")),
+                toStringList(metaMap.get("item_input")),
+                toStringList(metaMap.get("item_output"))
+            );
+        }
+
+        // Build input
+        Map<String, Object> common = (Map<String, Object>) inputMap.getOrDefault("common", Collections.emptyMap());
+        List<Map<String, Object>> items = (List<Map<String, Object>>) inputMap.getOrDefault("items", Collections.emptyList());
+        OperatorInput input = new OperatorInput(common, items);
+
+        // Execute
+        OperatorOutput output = new OperatorOutput();
+        op.execute(input, output);
+
+        // Validate removed_indices
+        if (expected.containsKey("removed_indices")) {
+            List<Number> expectedRemoved = (List<Number>) expected.get("removed_indices");
+            Set<Integer> removed = output.getRemovedItems();
+            assertEquals(expectedRemoved.size(), removed.size(),
+                "removed count mismatch");
+            for (Number idx : expectedRemoved) {
+                assertTrue(removed.contains(idx.intValue()),
+                    "expected item[" + idx + "] to be removed");
+            }
+        }
+
+        // Validate added_items
+        if (expected.containsKey("added_items")) {
+            List<Map<String, Object>> expectedAdded = (List<Map<String, Object>>) expected.get("added_items");
+            List<Map<String, Object>> added = output.getAddedItems();
+            assertEquals(expectedAdded.size(), added.size(), "added_items count mismatch");
+            for (int i = 0; i < expectedAdded.size(); i++) {
+                for (Map.Entry<String, Object> entry : expectedAdded.get(i).entrySet()) {
+                    Object got = added.get(i).get(entry.getKey());
+                    assertValueEquals(entry.getValue(), got,
+                        "added_items[" + i + "]." + entry.getKey());
+                }
+            }
+        }
+
+        // Validate common writes
+        if (expected.containsKey("common")) {
+            Map<String, Object> expectedCommon = (Map<String, Object>) expected.get("common");
+            Map<String, Object> cw = output.getCommonWrites();
+            for (Map.Entry<String, Object> entry : expectedCommon.entrySet()) {
+                assertTrue(cw.containsKey(entry.getKey()),
+                    "common_writes missing key: " + entry.getKey());
+                assertValueEquals(entry.getValue(), cw.get(entry.getKey()),
+                    "common_writes[" + entry.getKey() + "]");
+            }
+        }
+
+        // Validate item_order
+        if (expected.containsKey("item_order")) {
+            List<Number> expectedOrder = (List<Number>) expected.get("item_order");
+            List<Integer> order = output.getItemOrder();
+            assertNotNull(order, "item_order is null");
+            assertEquals(expectedOrder.size(), order.size(), "item_order length mismatch");
+            for (int i = 0; i < expectedOrder.size(); i++) {
+                assertEquals(expectedOrder.get(i).intValue(), order.get(i).intValue(),
+                    "item_order[" + i + "]");
+            }
+        }
+
+        // Validate item writes
+        if (expected.containsKey("items")) {
+            List<Map<String, Object>> expectedItems = (List<Map<String, Object>>) expected.get("items");
+            Map<Integer, Map<String, Object>> iw = output.getItemWrites();
+            for (int i = 0; i < expectedItems.size(); i++) {
+                Map<String, Object> expectedItem = expectedItems.get(i);
+                if (expectedItem == null || expectedItem.isEmpty()) continue;
+                Map<String, Object> writes = iw.get(i);
+                assertNotNull(writes, "item_writes[" + i + "] missing");
+                for (Map.Entry<String, Object> entry : expectedItem.entrySet()) {
+                    assertTrue(writes.containsKey(entry.getKey()),
+                        "item_writes[" + i + "] missing key: " + entry.getKey());
+                    assertValueEquals(entry.getValue(), writes.get(entry.getKey()),
+                        "item_writes[" + i + "]." + entry.getKey());
+                }
+            }
+        }
+    }
+
+    private void assertValueEquals(Object expected, Object actual, String path) {
+        if (expected instanceof Number && actual instanceof Number) {
+            assertEquals(((Number) expected).doubleValue(), ((Number) actual).doubleValue(), 1e-9, path);
+        } else if (expected instanceof Boolean && actual instanceof Boolean) {
+            assertEquals(expected, actual, path);
+        } else {
+            assertEquals(String.valueOf(expected), String.valueOf(actual), path);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> toStringList(Object raw) {
+        if (raw == null) return Collections.emptyList();
+        List<String> result = new ArrayList<>();
+        for (Object item : (List<Object>) raw) {
+            result.add((String) item);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

- JSON fixture 测试系统：统一 schema，Go test runner 自动发现并执行
- 迁移 11 个算子共 44 个测试用例为 JSON fixture 格式
- 初始化 Java-Pine 项目（Maven, JDK 11+），实现 10 个纯计算算子
- Go 和 Java 双端加载同一组 fixture 文件，36/36 用例全部通过
- 消除 training-serving skew 的基础设施

## 变更概览

| 类别 | 文件 |
|------|------|
| Fixture schema + runner | `fixtures/fixture_test.go`, `fixtures/README.md` |
| Fixture 文件 (11 个) | `fixtures/*.json` |
| Java 核心接口 | `java-pine/src/main/java/com/tipsy/pine/` |
| Java 算子实现 (10 个) | `java-pine/src/main/java/com/tipsy/pine/operators/` |
| Java fixture runner | `java-pine/src/test/java/com/tipsy/pine/FixtureTest.java` |
| 计划文档 | `docs/json-fixture-plan.md` |

## Test plan

- [x] `go test ./fixtures/` — 44 cases pass
- [x] `go test ./...` — all existing tests pass (no regression)
- [x] `mvn test` in `java-pine/` — 36 cases pass
- [ ] CI cross-validation (后续 PR)