### PR TITLE
fix: skip lint-on-stop hook in CI

### DIFF
--- a/.claude/hooks/lint-on-stop.sh
+++ b/.claude/hooks/lint-on-stop.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -uo pipefail
 
+if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+  exit 0
+fi
+
 cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 
 # Activate project venv if present (provides ruff, etc.)


### PR DESCRIPTION
## Summary

- 在 `.claude/hooks/lint-on-stop.sh` 开头加 CI 环境检测，跳过执行

## 背景

`claude-code-action` 安全机制会从 `origin/master` 恢复 `.claude/` 目录。
master 上的 hook 没有 CI skip，导致 agent 每次 "stop" 时触发 lint，
lint 失败后 agent 收到错误反馈继续工作，永远不退出。

合并此 PR 后 PR #6 的 review workflow 即可正常运行。

## Test plan

- [ ] 合并后触发 PR #6 的 review，观察是否 2 分钟内正常退出