### PR TITLE
feat: HTTP and DAG-level metrics, migrate lint to pre-push hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,17 +1,4 @@
 {
-  "hooks": {
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/lint-on-stop.sh",
-            "timeout": 60
-          }
-        ]
-      }
-    ]
-  },
+  "hooks": {},
   "enabledPlugins": {}
 }

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,5 @@
 #!/bin/bash
+# pre-push: block push if lint fails.
 set -uo pipefail
 
 if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
@@ -7,7 +8,6 @@ fi
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 
-# Activate project venv if present (provides ruff, etc.)
 if [ -f ".venv/bin/activate" ]; then
   source .venv/bin/activate
 fi
@@ -32,8 +32,7 @@ fi
 
 if [ -n "$errors" ]; then
   echo -e "$errors" >&2
-  exit 2
+  exit 1
 fi
 
-echo "lint ok" >&2
 exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     tags: ["v*"]
     paths-ignore:
       - ".claude/**"
+      - ".githooks/**"
       - ".github/workflows/agentic-*.yml"
       - "apple_generated/**"
       - "blog/**"
@@ -18,6 +19,7 @@ on:
   pull_request:
     paths-ignore:
       - ".claude/**"
+      - ".githooks/**"
       - ".github/workflows/agentic-*.yml"
       - "apple_generated/**"
       - "blog/**"

--- a/internal/runtime/engine_metrics.go
+++ b/internal/runtime/engine_metrics.go
@@ -11,6 +11,10 @@ type EngineMetrics struct {
 	OpExecDuration metrics.Histogram
 	OpSkipTotal    metrics.Counter
 	OpErrorTotal   metrics.Counter
+
+	DAGExecTotal    metrics.Counter
+	DAGExecDuration metrics.Histogram
+	DAGOpsExecuted  metrics.Histogram
 }
 
 // NewEngineMetrics creates all engine-level metrics from the given provider.
@@ -47,6 +51,24 @@ func NewEngineMetrics(p metrics.Provider) *EngineMetrics {
 			Name:       "pine_operator_error_total",
 			Help:       "Total failed operator executions.",
 			LabelNames: opLabels,
+		}),
+		DAGExecTotal: p.NewCounter(metrics.MetricOpts{
+			Name:       "pine_dag_executions_total",
+			Help:       "Total DAG executions.",
+			LabelNames: []string{"status"},
+		}),
+		DAGExecDuration: p.NewHistogram(metrics.HistogramOpts{
+			MetricOpts: metrics.MetricOpts{
+				Name: "pine_dag_execution_duration_seconds",
+				Help: "DAG execution duration in seconds.",
+			},
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0},
+		}),
+		DAGOpsExecuted: p.NewHistogram(metrics.HistogramOpts{
+			MetricOpts: metrics.MetricOpts{
+				Name: "pine_dag_operators_executed",
+				Help: "Number of operators executed (not skipped) per DAG run.",
+			},
 		}),
 	}
 }

--- a/internal/runtime/engine_metrics.go
+++ b/internal/runtime/engine_metrics.go
@@ -67,8 +67,9 @@ func NewEngineMetrics(p metrics.Provider) *EngineMetrics {
 		DAGOpsExecuted: p.NewHistogram(metrics.HistogramOpts{
 			MetricOpts: metrics.MetricOpts{
 				Name: "pine_dag_operators_executed",
-				Help: "Number of operators executed (not skipped) per DAG run.",
+				Help: "Number of operators executed (not skipped or cancelled) per DAG run.",
 			},
+			Buckets: []float64{1, 5, 10, 20, 50, 100, 200},
 		}),
 	}
 }

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -51,6 +51,8 @@ func Run(ctx context.Context, plan *Plan, frame dataframe.Frame, stats *Stats, e
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	dagStart := time.Now()
+
 	if stats != nil {
 		stats.RecordRun()
 	}
@@ -285,6 +287,23 @@ func Run(ctx context.Context, plan *Plan, frame dataframe.Frame, stats *Stats, e
 		if t.Name != "" {
 			filtered = append(filtered, t)
 		}
+	}
+
+	if em != nil {
+		dagDuration := time.Since(dagStart)
+		em.DAGExecDuration.Observe(metrics.DurationSeconds(dagDuration))
+		if fatalErr != nil {
+			em.DAGExecTotal.With("error").Inc()
+		} else {
+			em.DAGExecTotal.With("success").Inc()
+		}
+		var executed int
+		for _, t := range filtered {
+			if !t.Skipped {
+				executed++
+			}
+		}
+		em.DAGOpsExecuted.Observe(float64(executed))
 	}
 
 	return warnings, filtered, fatalErr

--- a/pkg/server/http_metrics.go
+++ b/pkg/server/http_metrics.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/Liam0205/pineapple/pkg/metrics"
+)
+
+var knownPaths = map[string]bool{
+	"/execute": true,
+	"/health":  true,
+	"/stats":   true,
+	"/dag":     true,
+}
+
+func normalizePath(path string) string {
+	if knownPaths[path] {
+		return path
+	}
+	return "_other"
+}
+
+func statusBucket(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return "2xx"
+	case code >= 300 && code < 400:
+		return "3xx"
+	case code >= 400 && code < 500:
+		return "4xx"
+	default:
+		return "5xx"
+	}
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func httpMetricsMiddleware(mp metrics.Provider, next http.Handler) http.Handler {
+	requestsTotal := mp.NewCounter(metrics.MetricOpts{
+		Name:       "pine_http_requests_total",
+		Help:       "Total HTTP requests.",
+		LabelNames: []string{"method", "path", "status"},
+	})
+	requestDuration := mp.NewHistogram(metrics.HistogramOpts{
+		MetricOpts: metrics.MetricOpts{
+			Name:       "pine_http_request_duration_seconds",
+			Help:       "HTTP request duration in seconds.",
+			LabelNames: []string{"method", "path"},
+		},
+		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0},
+	})
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		path := normalizePath(r.URL.Path)
+
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+
+		duration := time.Since(start)
+		status := statusBucket(rec.status)
+
+		requestsTotal.With(r.Method, path, status).Inc()
+		requestDuration.With(r.Method, path).Observe(metrics.DurationSeconds(duration))
+	})
+}

--- a/pkg/server/http_metrics.go
+++ b/pkg/server/http_metrics.go
@@ -23,14 +23,16 @@ func normalizePath(path string) string {
 
 func statusBucket(code int) string {
 	switch {
-	case code >= 200 && code < 300:
-		return "2xx"
-	case code >= 300 && code < 400:
-		return "3xx"
-	case code >= 400 && code < 500:
-		return "4xx"
-	default:
+	case code >= 500:
 		return "5xx"
+	case code >= 400:
+		return "4xx"
+	case code >= 300:
+		return "3xx"
+	case code >= 200:
+		return "2xx"
+	default:
+		return "other"
 	}
 }
 
@@ -42,6 +44,10 @@ type statusRecorder struct {
 func (r *statusRecorder) WriteHeader(code int) {
 	r.status = code
 	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
 }
 
 func httpMetricsMiddleware(mp metrics.Provider, next http.Handler) http.Handler {

--- a/pkg/server/http_metrics_test.go
+++ b/pkg/server/http_metrics_test.go
@@ -1,0 +1,254 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Liam0205/pineapple/pkg/metrics"
+)
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/execute", "/execute"},
+		{"/health", "/health"},
+		{"/stats", "/stats"},
+		{"/dag", "/dag"},
+		{"/unknown", "_other"},
+		{"/execute/extra", "_other"},
+		{"/", "_other"},
+	}
+	for _, tt := range tests {
+		if got := normalizePath(tt.input); got != tt.want {
+			t.Errorf("normalizePath(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestStatusBucket(t *testing.T) {
+	tests := []struct {
+		code int
+		want string
+	}{
+		{200, "2xx"},
+		{201, "2xx"},
+		{204, "2xx"},
+		{301, "3xx"},
+		{400, "4xx"},
+		{404, "4xx"},
+		{500, "5xx"},
+		{503, "5xx"},
+	}
+	for _, tt := range tests {
+		if got := statusBucket(tt.code); got != tt.want {
+			t.Errorf("statusBucket(%d) = %q, want %q", tt.code, got, tt.want)
+		}
+	}
+}
+
+func TestStatusRecorder(t *testing.T) {
+	w := httptest.NewRecorder()
+	rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+	rec.WriteHeader(http.StatusNotFound)
+	if rec.status != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.status, http.StatusNotFound)
+	}
+	if w.Code != http.StatusNotFound {
+		t.Errorf("underlying recorder code = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestStatusRecorderDefaultStatus(t *testing.T) {
+	w := httptest.NewRecorder()
+	rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+	_, _ = rec.Write([]byte("hello"))
+	if rec.status != http.StatusOK {
+		t.Errorf("status = %d, want %d (default)", rec.status, http.StatusOK)
+	}
+}
+
+func TestHTTPMetricsMiddleware_Integration(t *testing.T) {
+	mp := &recordingProvider{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", handleHealth)
+	mux.HandleFunc("/execute", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad", http.StatusBadRequest)
+	})
+
+	handler := httpMetricsMiddleware(mp, mux)
+
+	// GET /health → 200
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("/health status = %d", w.Code)
+	}
+
+	// POST /execute → 400
+	req = httptest.NewRequest(http.MethodPost, "/execute", strings.NewReader("{}"))
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("/execute status = %d", w.Code)
+	}
+
+	// GET /unknown → 404 (mux default)
+	req = httptest.NewRequest(http.MethodGet, "/unknown", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Verify counter labels
+	counter := mp.counter
+	counter.mu.Lock()
+	defer counter.mu.Unlock()
+
+	found200 := false
+	found400 := false
+	foundOther := false
+	for _, call := range counter.incs {
+		if call == "GET|/health|2xx" {
+			found200 = true
+		}
+		if call == "POST|/execute|4xx" {
+			found400 = true
+		}
+		if strings.Contains(call, "_other") {
+			foundOther = true
+		}
+	}
+	if !found200 {
+		t.Errorf("missing counter for GET /health 2xx; got %v", counter.incs)
+	}
+	if !found400 {
+		t.Errorf("missing counter for POST /execute 4xx; got %v", counter.incs)
+	}
+	if !foundOther {
+		t.Errorf("missing counter for unknown path → _other; got %v", counter.incs)
+	}
+
+	// Verify histogram observations
+	histogram := mp.histogram
+	histogram.mu.Lock()
+	defer histogram.mu.Unlock()
+
+	if len(histogram.observations) != 3 {
+		t.Errorf("histogram observations = %d, want 3", len(histogram.observations))
+	}
+	for _, obs := range histogram.observations {
+		if obs.value <= 0 {
+			t.Errorf("histogram observation = %v, want > 0", obs.value)
+		}
+	}
+}
+
+func TestHTTPMetricsMiddleware_NopProvider(t *testing.T) {
+	mp := metrics.Nop()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", handleHealth)
+
+	handler := httpMetricsMiddleware(mp, mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+// --- recording metrics provider for testing ---
+
+type recordingProvider struct {
+	counter   *recordingCounter
+	histogram *recordingHistogram
+}
+
+func (p *recordingProvider) NewCounter(opts metrics.MetricOpts) metrics.Counter {
+	p.counter = &recordingCounter{}
+	return p.counter
+}
+
+func (p *recordingProvider) NewGauge(opts metrics.MetricOpts) metrics.Gauge {
+	return metrics.Nop().NewGauge(opts)
+}
+
+func (p *recordingProvider) NewHistogram(opts metrics.HistogramOpts) metrics.Histogram {
+	p.histogram = &recordingHistogram{}
+	return p.histogram
+}
+
+type recordingCounter struct {
+	mu   sync.Mutex
+	incs []string
+}
+
+func (c *recordingCounter) With(labelValues ...string) metrics.Counter {
+	return &recordingCounterWith{parent: c, key: strings.Join(labelValues, "|")}
+}
+
+func (c *recordingCounter) Inc() {
+	c.mu.Lock()
+	c.incs = append(c.incs, "")
+	c.mu.Unlock()
+}
+
+type recordingCounterWith struct {
+	parent *recordingCounter
+	key    string
+}
+
+func (c *recordingCounterWith) With(labelValues ...string) metrics.Counter {
+	return &recordingCounterWith{parent: c.parent, key: c.key + "|" + strings.Join(labelValues, "|")}
+}
+
+func (c *recordingCounterWith) Inc() {
+	c.parent.mu.Lock()
+	c.parent.incs = append(c.parent.incs, c.key)
+	c.parent.mu.Unlock()
+}
+
+type observation struct {
+	key   string
+	value float64
+}
+
+type recordingHistogram struct {
+	mu           sync.Mutex
+	observations []observation
+}
+
+func (h *recordingHistogram) With(labelValues ...string) metrics.Histogram {
+	return &recordingHistogramWith{parent: h, key: strings.Join(labelValues, "|")}
+}
+
+func (h *recordingHistogram) Observe(v float64) {
+	h.mu.Lock()
+	h.observations = append(h.observations, observation{key: "", value: v})
+	h.mu.Unlock()
+}
+
+type recordingHistogramWith struct {
+	parent *recordingHistogram
+	key    string
+}
+
+func (h *recordingHistogramWith) With(labelValues ...string) metrics.Histogram {
+	return &recordingHistogramWith{parent: h.parent, key: h.key + "|" + strings.Join(labelValues, "|")}
+}
+
+func (h *recordingHistogramWith) Observe(v float64) {
+	h.parent.mu.Lock()
+	h.parent.observations = append(h.parent.observations, observation{key: h.key, value: v})
+	h.parent.mu.Unlock()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -156,8 +156,11 @@ func (s *Server) run(cfg Config) error {
 	mux.HandleFunc("/stats", s.handleStats)
 	mux.HandleFunc("/dag", s.handleDAG)
 
-	// Apply middlewares (outer-to-inner: first middleware sees request first)
-	var handler http.Handler = mux
+	// Apply HTTP metrics as innermost middleware (measures handler duration
+	// excluding user middleware overhead).
+	var handler http.Handler = httpMetricsMiddleware(mp, mux)
+
+	// Apply user middlewares (outer-to-inner: first middleware sees request first)
 	for i := len(cfg.Middlewares) - 1; i >= 0; i-- {
 		handler = cfg.Middlewares[i](handler)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -158,7 +158,7 @@ func (s *Server) run(cfg Config) error {
 
 	// Apply HTTP metrics as innermost middleware (measures handler duration
 	// excluding user middleware overhead).
-	var handler http.Handler = httpMetricsMiddleware(mp, mux)
+	handler := httpMetricsMiddleware(mp, mux)
 
 	// Apply user middlewares (outer-to-inner: first middleware sees request first)
 	for i := len(cfg.Middlewares) - 1; i >= 0; i-- {


### PR DESCRIPTION
## Summary

- Add built-in HTTP request metrics middleware (`pine_http_requests_total`, `pine_http_request_duration_seconds`) to `pkg/server`, applied as innermost middleware
- Add DAG-level execution metrics (`pine_dag_executions_total`, `pine_dag_execution_duration_seconds`, `pine_dag_operators_executed`) to the engine runtime
- Replace Claude Code stop hook with a git pre-push hook (`.githooks/pre-push`), matching ctex-kit's pattern

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New unit tests for HTTP metrics middleware (path normalization, status bucketing, integration)
- [x] `golangci-lint` clean
- [ ] Verify `/metrics` endpoint exposes new metrics when a Prometheus provider is wired
- [ ] After clone: `git config --local core.hooksPath .githooks` activates pre-push lint