### PR TITLE
fix: Go server and engine audit fixes

### DIFF
--- a/internal/dag/visualize.go
+++ b/internal/dag/visualize.go
@@ -2,6 +2,7 @@ package dag
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Liam0205/pineapple/internal/types"
@@ -87,8 +88,10 @@ func RenderMermaid(g *Graph) string {
 	return b.String()
 }
 
+var mermaidIDRe = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
 func sanitizeMermaidID(name string) string {
-	return strings.NewReplacer("-", "_", ".", "_", " ", "_").Replace(name)
+	return mermaidIDRe.ReplaceAllString(name, "_")
 }
 
 // collapsedGraph computes the aggregated view for level-based SubFlow rendering.

--- a/operators/lua/lua.go
+++ b/operators/lua/lua.go
@@ -80,6 +80,17 @@ func (o *LuaOp) Init(params map[string]any) error {
 		return fmt.Errorf("lua: failed to load script: %w", err)
 	}
 
+	// Validate that the declared function exists in the script.
+	L := o.pool.Borrow()
+	if L == nil {
+		return fmt.Errorf("lua: failed to borrow state for validation")
+	}
+	if L.GetGlobal(o.funcName) == glua.LNil {
+		o.pool.Return(L)
+		return fmt.Errorf("lua: function %q not defined in script", o.funcName)
+	}
+	o.pool.Return(L)
+
 	return nil
 }
 

--- a/operators/lua/lua_test.go
+++ b/operators/lua/lua_test.go
@@ -205,13 +205,13 @@ func TestLuaOpForItemEmpty(t *testing.T) {
 }
 
 func TestLuaOpFunctionNotFound(t *testing.T) {
-	op := newLuaOp(t, `function other() return 1 end`, "missing_func", "",
-		nil, nil, nil, []string{"out"})
-
-	items := []map[string]any{{"x": 1.0}}
-	in := pine.NewOperatorInput(nil, items)
-	out := pine.NewOperatorOutput()
-	err := op.Execute(context.Background(), in, out)
+	op := &LuaOp{}
+	params := map[string]any{
+		"lua_script":          `function other() return 1 end`,
+		"function_for_item":   "missing_func",
+		"function_for_common": "",
+	}
+	err := op.Init(params)
 	if err == nil {
 		t.Fatal("expected error for missing function")
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,6 +7,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"os"
@@ -20,6 +21,11 @@ import (
 	"github.com/Liam0205/pineapple/pkg/metrics"
 	"github.com/Liam0205/pineapple/pkg/resource"
 )
+
+// errorResponse is a lightweight JSON error envelope used for non-200 responses.
+type errorResponse struct {
+	Error string `json:"error"`
+}
 
 // Config holds the server startup settings.
 type Config struct {
@@ -224,7 +230,11 @@ func (s *Server) reloadConfig(path string) error {
 }
 
 func (s *Server) watchConfig(ctx context.Context, path string) {
+	// Initialize lastMod to current file mtime to avoid spurious reload on first tick.
 	var lastMod time.Time
+	if info, err := os.Stat(path); err == nil {
+		lastMod = info.ModTime()
+	}
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -284,20 +294,25 @@ type traceEntry struct {
 
 func (s *Server) handleExecute(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
 		return
 	}
 
 	snap := s.snapshot.Load()
 	if snap == nil {
-		http.Error(w, "engine not loaded", http.StatusServiceUnavailable)
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse{Error: "engine not loaded"})
 		return
 	}
 
 	var req executeRequest
 	r.Body = http.MaxBytesReader(w, r.Body, s.effectiveMaxRequestBodySize())
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, executeResponse{Error: "invalid request: " + err.Error()})
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "request body too large"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request: " + err.Error()})
 		return
 	}
 
@@ -349,13 +364,13 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
 		return
 	}
 
 	snap := s.snapshot.Load()
 	if snap == nil {
-		http.Error(w, "engine not loaded", http.StatusServiceUnavailable)
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse{Error: "engine not loaded"})
 		return
 	}
 
@@ -380,13 +395,13 @@ func (s *Server) serverStats() map[string]int64 {
 
 func (s *Server) handleDAG(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
 		return
 	}
 
 	snap := s.snapshot.Load()
 	if snap == nil {
-		http.Error(w, "engine not loaded", http.StatusServiceUnavailable)
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse{Error: "engine not loaded"})
 		return
 	}
 
@@ -399,7 +414,7 @@ func (s *Server) handleDAG(w http.ResponseWriter, r *http.Request) {
 	if collapseStr := r.URL.Query().Get("collapse"); collapseStr != "" {
 		level, err := strconv.Atoi(collapseStr)
 		if err != nil || level < 0 {
-			http.Error(w, "collapse must be a non-negative integer", http.StatusBadRequest)
+			writeJSON(w, http.StatusBadRequest, errorResponse{Error: "collapse must be a non-negative integer"})
 			return
 		}
 		if level > 0 {
@@ -409,7 +424,7 @@ func (s *Server) handleDAG(w http.ResponseWriter, r *http.Request) {
 
 	output, err := snap.engine.RenderDAG(format, opts...)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
 		return
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -577,8 +577,8 @@ func TestExecuteRequestBodyTooLarge(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.handleExecute(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want 400", w.Code)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", w.Code)
 	}
 	body := w.Body.String()
 	if !strings.Contains(body, "too large") && !strings.Contains(body, "request body") {


### PR DESCRIPTION
## Summary
- Server error responses: all `http.Error()` calls replaced with JSON `errorResponse` struct for consistent Content-Type across endpoints
- Body too large: detect `http.MaxBytesError` and return 413 (was 400)
- watchConfig: initialize `lastMod` from file mtime to prevent spurious reload on first tick
- Lua Init: validate function existence at Init time (fail-fast on typos)
- sanitizeMermaidID: replace all non-`[a-zA-Z0-9_]` chars (was only `-. `)

Note: globalDebug (#4 from audit) was verified as already correct — no change needed.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` all packages pass
- [x] `TestExecuteRequestBodyTooLarge` updated to expect 413
- [x] `TestLuaOpFunctionNotFound` updated to test at Init time