### PR TITLE
fix: server ValidationError→400, redis_set fail_on_error

### DIFF
--- a/apple_generated/operators.py
+++ b/apple_generated/operators.py
@@ -612,6 +612,7 @@ class TransformRedisSetOp(BaseOp):
     _name = "transform_redis_set"
     _params_schema = {
         "data_type": {"type": "string", "required": False, "default": "string"},
+        "fail_on_error": {"type": "bool", "required": False, "default": False},
         "key_prefix": {"type": "string", "required": True},
         "redis_addr": {"type": "string", "required": True},
         "redis_db": {"type": "int", "required": False, "default": 0},
@@ -623,6 +624,7 @@ class TransformRedisSetOp(BaseOp):
         self,
         *,
         data_type: str = "string",
+        fail_on_error: bool = False,
         key_prefix: str = ...,
         redis_addr: str = ...,
         redis_db: int = 0,
@@ -640,6 +642,7 @@ class TransformRedisSetOp(BaseOp):
     ) -> "TransformRedisSetOp":
         _params = {
             "data_type": data_type,
+            "fail_on_error": fail_on_error,
             "key_prefix": key_prefix,
             "redis_addr": redis_addr,
             "redis_db": redis_db,

--- a/doc/operators/transform_redis_set.md
+++ b/doc/operators/transform_redis_set.md
@@ -9,6 +9,7 @@ Generic Redis write operator. Writes a value by key with optional TTL.
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | data_type | string | No | `"string"` | Redis data type: "set", "string", or "list". |
+| fail_on_error | bool | No | `False` | Return fatal error on Redis infrastructure failure instead of logging and continuing. |
 | key_prefix | string | Yes | - | Key prefix prepended to the suffix built from common_input fields. |
 | redis_addr | string | Yes | - | Redis server address (host:port). |
 | redis_db | int | No | `0` | Redis DB number. |
@@ -29,6 +30,7 @@ Generic Redis write operator. Writes a value by key with optional TTL.
 ```python
 flow.transform_redis_set(
     data_type=...,
+    fail_on_error=...,
     key_prefix=...,
     redis_addr=...,
     redis_db=...,

--- a/operators/transform/redis_set.go
+++ b/operators/transform/redis_set.go
@@ -154,7 +154,7 @@ func (o *RedisSetOp) Execute(ctx context.Context, in *pine.OperatorInput, out *p
 	if err != nil {
 		log.Printf("transform_redis_set: write key %s: %v", key, err)
 		if o.failOnError {
-			return err
+			return fmt.Errorf("transform_redis_set: write key %s: %w", key, err)
 		}
 		out.SetWarning(fmt.Errorf("transform_redis_set: write key %s: %w", key, err))
 	}

--- a/operators/transform/redis_set.go
+++ b/operators/transform/redis_set.go
@@ -9,6 +9,7 @@
 //   - key_prefix (string, required): Key prefix prepended to the suffix built from common_input fields.
 //   - data_type (string, optional, default="string"): Redis data type: "set", "string", or "list".
 //   - ttl (int, optional, default=0): TTL in seconds. 0 means no expiry.
+//   - fail_on_error (bool, optional, default=false): Return fatal error on Redis infrastructure failure instead of logging and continuing.
 //
 // Key construction: key_prefix + join(first N-1 common_input values, ":").
 // Value is the last common_input field.
@@ -42,6 +43,7 @@ func init() {
 			"key_prefix":     {Type: "string", Required: true, Description: "Key prefix prepended to the suffix built from common_input fields."},
 			"data_type":      {Type: "string", Required: false, Default: "string", Description: `Redis data type: "set", "string", or "list".`},
 			"ttl":            {Type: "int", Required: false, Default: 0, Description: "TTL in seconds. 0 means no expiry."},
+			"fail_on_error":  {Type: "bool", Required: false, Default: false, Description: "Return fatal error on Redis infrastructure failure instead of logging and continuing."},
 		},
 	}, func() pine.Operator {
 		return &RedisSetOp{}
@@ -52,10 +54,11 @@ func init() {
 type RedisSetOp struct {
 	pine.MetadataHolder
 	pine.ConcurrentSafeMarker
-	rdb       *redis.Client
-	keyPrefix string
-	dataType  string
-	ttl       time.Duration
+	rdb         *redis.Client
+	keyPrefix   string
+	dataType    string
+	ttl         time.Duration
+	failOnError bool
 }
 
 func (o *RedisSetOp) Init(params map[string]any) error {
@@ -72,6 +75,9 @@ func (o *RedisSetOp) Init(params map[string]any) error {
 	}
 	if v, ok := params["ttl"]; ok {
 		o.ttl = time.Duration(toInt64Param(v)) * time.Second
+	}
+	if v, ok := params["fail_on_error"].(bool); ok {
+		o.failOnError = v
 	}
 
 	if addr != "" {
@@ -147,6 +153,10 @@ func (o *RedisSetOp) Execute(ctx context.Context, in *pine.OperatorInput, out *p
 
 	if err != nil {
 		log.Printf("transform_redis_set: write key %s: %v", key, err)
+		if o.failOnError {
+			return err
+		}
+		out.SetWarning(fmt.Errorf("transform_redis_set: write key %s: %w", key, err))
 	}
 	return nil
 }

--- a/operators/transform/redis_set_test.go
+++ b/operators/transform/redis_set_test.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	pine "github.com/Liam0205/pineapple"
@@ -268,5 +269,64 @@ func TestRedisSetOp_SetEmptyMembers(t *testing.T) {
 	}
 	if s.Exists("prefix:u1") {
 		t.Error("key should not exist for empty set")
+	}
+}
+
+func TestRedisSetOp_FailOnError_True(t *testing.T) {
+	s := miniredis.RunT(t)
+
+	op := &RedisSetOp{}
+	if err := op.Init(map[string]any{
+		"redis_addr":    s.Addr(),
+		"key_prefix":    "prefix:",
+		"data_type":     "string",
+		"fail_on_error": true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	op.SetMetadata([]string{"uid", "val"}, nil, nil, nil)
+
+	// Close miniredis to simulate infrastructure failure
+	s.Close()
+
+	in := pine.NewOperatorInput(map[string]any{"uid": "u1", "val": "hello"}, nil)
+	out := pine.NewOperatorOutput()
+	err := op.Execute(context.Background(), in, out)
+	if err == nil {
+		t.Fatal("expected fatal error with fail_on_error=true")
+	}
+	if !strings.Contains(err.Error(), "transform_redis_set") {
+		t.Errorf("error should have operator prefix, got: %v", err)
+	}
+}
+
+func TestRedisSetOp_FailOnError_False_SetWarning(t *testing.T) {
+	s := miniredis.RunT(t)
+
+	op := &RedisSetOp{}
+	if err := op.Init(map[string]any{
+		"redis_addr":    s.Addr(),
+		"key_prefix":    "prefix:",
+		"data_type":     "string",
+		"fail_on_error": false,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	op.SetMetadata([]string{"uid", "val"}, nil, nil, nil)
+
+	// Close miniredis to simulate infrastructure failure
+	s.Close()
+
+	in := pine.NewOperatorInput(map[string]any{"uid": "u1", "val": "hello"}, nil)
+	out := pine.NewOperatorOutput()
+	err := op.Execute(context.Background(), in, out)
+	if err != nil {
+		t.Errorf("expected nil error (default fail_on_error=false), got %v", err)
+	}
+	if out.GetWarning() == nil {
+		t.Error("expected warning to be set on infrastructure failure")
+	}
+	if !strings.Contains(out.GetWarning().Error(), "transform_redis_set") {
+		t.Errorf("warning should have operator prefix, got: %v", out.GetWarning())
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -349,7 +349,12 @@ func (s *Server) handleExecute(w http.ResponseWriter, r *http.Request) {
 			log.Printf("execute error: %s", de.DetailedError())
 		}
 		resp.Error = err.Error()
-		writeJSON(w, http.StatusInternalServerError, resp)
+		var ve *pine.ValidationError
+		if errors.As(err, &ve) {
+			writeJSON(w, http.StatusBadRequest, resp)
+		} else {
+			writeJSON(w, http.StatusInternalServerError, resp)
+		}
 		return
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -586,6 +586,29 @@ func TestExecuteRequestBodyTooLarge(t *testing.T) {
 	}
 }
 
+func TestHandleExecute_ValidationError_Returns400(t *testing.T) {
+	s := setupEngine(t)
+
+	// The test engine's flow_contract requires common field "x".
+	// Sending a request without "x" should trigger ValidationError → 400.
+	body := `{"common":{"missing_field":1},"items":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/execute", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	s.handleExecute(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for ValidationError", w.Code)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	errMsg, _ := resp["error"].(string)
+	if !strings.Contains(errMsg, "missing required common input field") {
+		t.Errorf("error = %q, want mention of missing field", errMsg)
+	}
+}
+
 func TestHandleStats_Success(t *testing.T) {
 	s := setupEngine(t)
 


### PR DESCRIPTION
## Summary
- Server `handleExecute` now maps `*pine.ValidationError` to HTTP 400 instead of 500, allowing clients to distinguish request validation failures (don't retry) from internal errors (retry-safe)
- `transform_redis_set` adds `fail_on_error` parameter (bool, default false) and uses `output.SetWarning()` for non-fatal Redis errors instead of silently logging

## Context
Seventh-round Pine-Go/Pine-Java parity audit identified these as Go-side gaps:
- H3: Java already correctly returns 400 for validation errors
- M3/M4: Java already implements `fail_on_error` pattern

## Test plan
- [x] `go test ./...` passes (all packages)
- [x] Codegen regenerated (`apple_generated/operators.py`, `doc/operators/`)
- [ ] CI green