### PR TITLE
feat(pine-java): publish to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,6 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     defaults:
       run:
         working-directory: pine-java
@@ -96,6 +94,11 @@ jobs:
           distribution: temurin
           java-version: "11"
           cache: maven
-      - run: mvn deploy -B -DskipTests
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+      - run: mvn deploy -B -DskipTests -Prelease -Dgpg.passphrase=
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}

--- a/pine-java/pom.xml
+++ b/pine-java/pom.xml
@@ -20,19 +20,18 @@
         </license>
     </licenses>
 
+    <developers>
+        <developer>
+            <name>Liam Huang</name>
+            <url>https://liam.page</url>
+        </developer>
+    </developers>
+
     <scm>
         <connection>scm:git:git://github.com/Liam0205/pineapple.git</connection>
         <developerConnection>scm:git:ssh://github.com/Liam0205/pineapple.git</developerConnection>
         <url>https://github.com/Liam0205/pineapple</url>
     </scm>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/Liam0205/pineapple</url>
-        </repository>
-    </distributionManagement>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
@@ -144,4 +143,67 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <configuration>
+                            <doclint>none</doclint>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Summary
- Replace GitHub Packages with Maven Central (Sonatype Central Portal) for pine-java publishing
- Add `release` profile with source-jar, javadoc-jar, GPG signing, and central-publishing-maven-plugin
- Add `<developers>` metadata required by Maven Central
- Update release workflow to use Central Portal credentials and GPG signing

## Downstream usage (after publish)
```xml
<dependency>
    <groupId>page.liam</groupId>
    <artifactId>pine</artifactId>
    <version>0.7.1</version>
</dependency>
```
No extra repository or authentication needed.

## Required secrets (already configured)
- `GPG_PRIVATE_KEY`
- `CENTRAL_USERNAME`
- `CENTRAL_TOKEN`

## Test plan
- [ ] Merge and tag next release, verify CI deploys successfully to Central Portal
- [ ] Confirm artifact appears on https://central.sonatype.com after ~30min
- [ ] Verify downstream `mvn dependency:resolve` works without auth