### PR TITLE
fix(pine-java): fix GPG signing for no-passphrase key in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,9 @@ jobs:
           server-username: CENTRAL_USERNAME
           server-password: CENTRAL_TOKEN
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-      - run: mvn deploy -B -DskipTests -Prelease -Dgpg.passphrase=
+          gpg-passphrase: GPG_PASSPHRASE
+      - run: mvn deploy -B -DskipTests -Prelease
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
+          GPG_PASSPHRASE: ""

--- a/pine-java/pom.xml
+++ b/pine-java/pom.xml
@@ -182,6 +182,12 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>3.2.4</version>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
## Summary
- Fix `settings-security.xml` not found error when GPG key has no passphrase
- Use `gpg-passphrase` env var mapping in setup-java with empty string
- Add `--pinentry-mode loopback` to gpg-plugin config for non-interactive signing

## Root cause
GPG plugin 3.2.4 tries to decrypt passphrase via `settings-security.xml` even when passed empty. The fix uses the `setup-java` action's built-in passphrase env var mapping and loopback pinentry mode.

## Test plan
- [ ] Merge, move v0.7.1 tag, verify release workflow passes