### PR TITLE
fix: resolve all open issues — Nullable default, SubFlow control-flow, debug tri-state, and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ pine-cpp/build/
 pine-cpp/build-asan/
 pine-cpp/build-tests/
 pine-cpp/build-werror/
+pine-cpp/build-lint/
+pine-cpp/build/

--- a/apple/base.py
+++ b/apple/base.py
@@ -22,6 +22,8 @@ class OpCall:
     item_output: list[str] = field(default_factory=list)
     item_defaults: dict[str, Any] | None = None
     common_defaults: dict[str, Any] | None = None
+    nullable_common: list[str] = field(default_factory=list)
+    nullable_item: list[str] = field(default_factory=list)
     # Engine-level flags
     recall: bool = False
     sources: list[str] | None = None
@@ -55,6 +57,8 @@ class OpCall:
             tuple(self.item_output),
             repr(self.item_defaults),
             repr(self.common_defaults),
+            tuple(self.nullable_common),
+            tuple(self.nullable_item),
             self.recall,
             tuple(self.sources) if self.sources else (),
             tuple(self.skip) if self.skip else (),

--- a/apple/base.py
+++ b/apple/base.py
@@ -37,10 +37,34 @@ class OpCall:
     name: str = ""
 
     def unique_name(self) -> str:
-        """Return explicit name if set, otherwise generate type_name_HASH6."""
+        """Return explicit name if set, otherwise generate type_name_HASH6.
+
+        Hash input excludes code_info (source file path + line number) since
+        it is purely debugging metadata and should not affect the operator's
+        identity. subflow_path is intentionally included because it reflects
+        the operator's position in the DAG topology.
+        """
         if self.name:
             return self.name
-        h = hashlib.md5(repr(self).encode()).hexdigest()[:6].upper()
+        semantic = (
+            self.type_name,
+            repr(self.params),
+            tuple(self.common_input),
+            tuple(self.common_output),
+            tuple(self.item_input),
+            tuple(self.item_output),
+            repr(self.item_defaults),
+            repr(self.common_defaults),
+            self.recall,
+            tuple(self.sources) if self.sources else (),
+            tuple(self.skip) if self.skip else (),
+            self.for_branch_control,
+            self.consumes_row_set,
+            self.data_parallel,
+            self.debug,
+            self.subflow_path,
+        )
+        h = hashlib.md5(repr(semantic).encode()).hexdigest()[:6].upper()
         return f"{self.type_name}_{h}"
 
 

--- a/apple/compiler.py
+++ b/apple/compiler.py
@@ -222,6 +222,13 @@ def _rename_field(op: OpCall, old: str, new: str) -> None:
     op.skip = [new if s == old else s for s in op.skip]
     op.common_input = [new if f == old else f for f in op.common_input]
     op.common_output = [new if f == old else f for f in op.common_output]
+    # Also rename Lua variable references inside lua_script for control ops.
+    # Use _ENV["name"] syntax since namespaced names (containing ::) are not
+    # valid Lua identifiers.
+    lua_script = op.params.get("lua_script")
+    if lua_script and old in lua_script:
+        lua_safe_new = f'_ENV["{new}"]'
+        op.params["lua_script"] = lua_script.replace(f"({old})", f"({lua_safe_new})")
 
 
 def _apply_field_renames(fields: list[str], renames: dict[str, str]) -> list[str]:

--- a/apple/compiler.py
+++ b/apple/compiler.py
@@ -172,7 +172,7 @@ def compile_flow(flow: Any) -> dict[str, Any]:
     _validate_resource_refs(named_ops, declared_resources)
 
     # 9b. Validate SubFlow contracts (if declared)
-    _validate_subflow_contracts(flow, named_ops, declared_resources)
+    _validate_subflow_contracts(flow, declared_resources)
 
     # 10. Build result
     result: dict[str, Any] = {
@@ -410,7 +410,6 @@ def _validate_resource_refs(
 
 def _validate_subflow_contracts(
     flow: Any,
-    named_ops: list[tuple[str, Any]],
     declared_resources: set[str],
 ) -> None:
     """Validate SubFlow-declared required_resources against parent Flow."""

--- a/apple/compiler.py
+++ b/apple/compiler.py
@@ -115,6 +115,10 @@ def compile_flow(flow: Any) -> dict[str, Any]:
             entry["item_defaults"] = op.item_defaults
         if op.common_defaults:
             entry["common_defaults"] = op.common_defaults
+        if op.nullable_common:
+            entry["nullable_common"] = op.nullable_common
+        if op.nullable_item:
+            entry["nullable_item"] = op.nullable_item
         if op.debug:
             entry["debug"] = True
         if op.data_parallel > 1:

--- a/apple/compiler.py
+++ b/apple/compiler.py
@@ -230,11 +230,12 @@ def _rename_field(op: OpCall, old: str, new: str) -> None:
     op.common_input = [new if f == old else f for f in op.common_input]
     op.common_output = [new if f == old else f for f in op.common_output]
     # Also rename Lua variable references inside lua_script for control ops.
-    # Use _ENV["name"] syntax since namespaced names (containing ::) are not
-    # valid Lua identifiers.
+    # Use _G["name"] syntax since namespaced names (containing ::) are not
+    # valid Lua identifiers.  _G is the Lua 5.1 global table; _ENV is
+    # Lua 5.2+ and not available in LuaJIT / gopher-lua / lupa runtimes.
     lua_script = op.params.get("lua_script")
     if lua_script and old in lua_script:
-        lua_safe_new = f'_ENV["{new}"]'
+        lua_safe_new = f'_G["{new}"]'
         op.params["lua_script"] = lua_script.replace(f"({old})", f"({lua_safe_new})")
 
 

--- a/apple/compiler.py
+++ b/apple/compiler.py
@@ -167,6 +167,9 @@ def compile_flow(flow: Any) -> dict[str, Any]:
         declared_resources = {r.name for r in flow._resources}
     _validate_resource_refs(named_ops, declared_resources)
 
+    # 9b. Validate SubFlow contracts (if declared)
+    _validate_subflow_contracts(flow, named_ops, declared_resources)
+
     # 10. Build result
     result: dict[str, Any] = {
         "_PINEAPPLE_VERSION": __version__,
@@ -398,6 +401,37 @@ def _validate_resource_refs(
                 f"but no such resource was declared via flow.resource(). "
                 f"Declared resources: {sorted(declared_resources) or '(none)'}"
             )
+
+
+def _validate_subflow_contracts(
+    flow: Any,
+    named_ops: list[tuple[str, Any]],
+    declared_resources: set[str],
+) -> None:
+    """Validate SubFlow-declared required_resources against parent Flow."""
+    visited: set[int] = set()
+    _validate_sf_contracts_recursive(flow, declared_resources, visited)
+
+
+def _validate_sf_contracts_recursive(
+    node: Any,
+    declared_resources: set[str],
+    visited: set[int],
+) -> None:
+    obj_id = id(node)
+    if obj_id in visited:
+        return
+    visited.add(obj_id)
+    for sf in getattr(node, '_sub_flows', []):
+        if getattr(sf, '_required_resources', None):
+            for res in sf._required_resources:
+                if res not in declared_resources:
+                    raise ValidationError(
+                        f"SubFlow {sf._name!r} requires resource {res!r} "
+                        f"but it is not declared. "
+                        f"Declared: {sorted(declared_resources) or '(none)'}"
+                    )
+        _validate_sf_contracts_recursive(sf, declared_resources, visited)
 
 
 def compile_to_json(flow: Any, indent: int = 2) -> str:

--- a/apple/flow.py
+++ b/apple/flow.py
@@ -273,6 +273,10 @@ class SubFlow(_FlowBase):
     Optionally declares input/output field contracts and required resources
     for compile-time validation. All contract parameters are optional —
     existing SubFlows with only a name argument continue to work unchanged.
+
+    Note: ``required_resources`` is validated at compile time.
+    ``common_input``/``common_output``/``item_input``/``item_output`` are
+    currently stored as metadata only and not yet validated by the compiler.
     """
 
     def __init__(

--- a/apple/flow.py
+++ b/apple/flow.py
@@ -270,10 +270,26 @@ class _FlowBase:
 class SubFlow(_FlowBase):
     """A reusable fragment of operator declarations.
 
-    SubFlows don't declare input/output contracts — that's done at the
-    top-level Flow.
+    Optionally declares input/output field contracts and required resources
+    for compile-time validation. All contract parameters are optional —
+    existing SubFlows with only a name argument continue to work unchanged.
     """
-    pass
+
+    def __init__(
+        self,
+        name: str,
+        common_input: list[str] | None = None,
+        common_output: list[str] | None = None,
+        item_input: list[str] | None = None,
+        item_output: list[str] | None = None,
+        required_resources: list[str] | None = None,
+    ):
+        super().__init__(name)
+        self._common_input = common_input
+        self._common_output = common_output
+        self._item_input = item_input
+        self._item_output = item_output
+        self._required_resources = required_resources
 
 
 class Flow(_FlowBase):

--- a/apple/tests/test_compiler.py
+++ b/apple/tests/test_compiler.py
@@ -545,18 +545,33 @@ class TestRenameControlFields:
         from apple.base import OpCall
         from apple.compiler import _rename_control_fields
 
+        lua_if = (
+            "function evaluate() if (flag == true) "
+            "then return false else return true end end"
+        )
+        lua_else = (
+            "function evaluate() if ((_if_1)) "
+            "then return false else return true end end"
+        )
+
         ctrl_if = OpCall(
             type_name="transform_by_lua",
-            params={"lua_script": 'function evaluate() if (flag == true) then return false else return true end end',
-                    "function_for_common": "evaluate", "function_for_item": ""},
+            params={
+                "lua_script": lua_if,
+                "function_for_common": "evaluate",
+                "function_for_item": "",
+            },
             common_output=["_if_1"],
             for_branch_control=True,
             name="if_1",
         )
         ctrl_else = OpCall(
             type_name="transform_by_lua",
-            params={"lua_script": 'function evaluate() if ((_if_1)) then return false else return true end end',
-                    "function_for_common": "evaluate", "function_for_item": ""},
+            params={
+                "lua_script": lua_else,
+                "function_for_common": "evaluate",
+                "function_for_item": "",
+            },
             common_input=["_if_1"],
             common_output=["_else_2"],
             for_branch_control=True,

--- a/apple/tests/test_compiler.py
+++ b/apple/tests/test_compiler.py
@@ -541,7 +541,7 @@ class TestRenameControlFields:
         assert biz_op.skip == ["_L1::if_1"]
 
     def test_subflow_rename_updates_lua_script(self):
-        """Lua evaluate in else/elseif must reference namespaced field via _ENV."""
+        """Lua evaluate in else/elseif must reference namespaced field via _G."""
         from apple.base import OpCall
         from apple.compiler import _rename_control_fields
 
@@ -580,7 +580,7 @@ class TestRenameControlFields:
         _rename_control_fields(
             [ctrl_if, ctrl_else], [("op", 0), ("op", 1)], "my_sf"
         )
-        assert '_ENV["_my_sf::if_1"]' in ctrl_else.params["lua_script"]
+        assert '_G["_my_sf::if_1"]' in ctrl_else.params["lua_script"]
         assert "(_if_1)" not in ctrl_else.params["lua_script"]
 
     def test_nested_path_uses_double_colon(self):
@@ -689,3 +689,151 @@ class TestCollectExclusionGroups:
         assert len(groups) == 1
         assert "_L1::if_1" in groups[0]
         assert "_else_2" in groups[0]
+
+
+class TestUniqueNameStability:
+    """#31: unique_name must be stable across different code_info values
+    and sensitive to subflow_path differences."""
+
+    def test_same_op_different_code_info_same_name(self):
+        """Same operator config from different source locations must produce
+        the same unique_name, since code_info is excluded from the hash."""
+        from apple.base import OpCall
+
+        op1 = OpCall(
+            type_name="transform_by_lua",
+            params={"lua_script": "function f() return x end",
+                    "function_for_item": "f", "function_for_common": ""},
+            item_input=["x"],
+            item_output=["y"],
+            code_info="file_a.py:10 in test(): .transform_by_lua(...)",
+        )
+        op2 = OpCall(
+            type_name="transform_by_lua",
+            params={"lua_script": "function f() return x end",
+                    "function_for_item": "f", "function_for_common": ""},
+            item_input=["x"],
+            item_output=["y"],
+            code_info="file_b.py:99 in other(): .transform_by_lua(...)",
+        )
+        assert op1.unique_name() == op2.unique_name()
+
+    def test_same_op_no_code_info_same_name(self):
+        """An op with empty code_info and one with non-empty code_info
+        must still produce the same unique_name."""
+        from apple.base import OpCall
+
+        op1 = OpCall(
+            type_name="transform_copy",
+            params={"direction": "common_to_item"},
+            common_input=["tag"],
+            item_output=["tag"],
+            code_info="",
+        )
+        op2 = OpCall(
+            type_name="transform_copy",
+            params={"direction": "common_to_item"},
+            common_input=["tag"],
+            item_output=["tag"],
+            code_info="some_file.py:42 in build(): .transform_copy(...)",
+        )
+        assert op1.unique_name() == op2.unique_name()
+
+    def test_different_subflow_path_different_name(self):
+        """Same operator config placed in different SubFlow paths must
+        produce different unique_names."""
+        from apple.base import OpCall
+
+        op1 = OpCall(
+            type_name="transform_by_lua",
+            params={"lua_script": "function f() return x end",
+                    "function_for_item": "f", "function_for_common": ""},
+            item_input=["x"],
+            item_output=["y"],
+            subflow_path="recall/candidates",
+        )
+        op2 = OpCall(
+            type_name="transform_by_lua",
+            params={"lua_script": "function f() return x end",
+                    "function_for_item": "f", "function_for_common": ""},
+            item_input=["x"],
+            item_output=["y"],
+            subflow_path="ranking/features",
+        )
+        assert op1.unique_name() != op2.unique_name()
+
+    def test_explicit_name_ignores_hash(self):
+        """When an explicit name is set, unique_name returns it directly."""
+        from apple.base import OpCall
+
+        op = OpCall(
+            type_name="transform_copy",
+            params={},
+            name="my_explicit_step",
+        )
+        assert op.unique_name() == "my_explicit_step"
+
+
+class TestSubFlowRequiredResources:
+    """#37: SubFlow required_resources must be validated against parent Flow."""
+
+    def test_missing_resource_raises(self):
+        """SubFlow declares required_resources not in parent Flow → error."""
+        from apple.validator import ValidationError
+
+        sf = SubFlow(
+            name="needs_feed",
+            required_resources=["feed_data"],
+        )
+        sf._add_op(
+            "transform_by_lua",
+            item_input=["x"],
+            item_output=["y"],
+            lua_script="function f() return x end",
+            function_for_item="f",
+            function_for_common="",
+        )
+
+        flow = Flow(
+            name="parent",
+            item_input=["x"],
+            item_output=["y"],
+            sub_flows=[sf],
+        )
+
+        with pytest.raises(ValidationError, match="requires resource.*feed_data"):
+            compile_flow(flow)
+
+    def test_declared_resource_passes(self):
+        """SubFlow declares required_resources that parent Flow has → OK."""
+        from apple.resource import BaseResource
+
+        class FakeResource(BaseResource):
+            resource_type = "fake"
+            interval = 60
+            params: dict = {}
+
+        sf = SubFlow(
+            name="needs_feed",
+            required_resources=["feed_data"],
+        )
+        sf._add_op(
+            "transform_resource_lookup",
+            item_input=["item_id"],
+            item_output=["item_feed"],
+            resource_name="feed_data",
+            lookup_key="item_id",
+            output_field="item_feed",
+        )
+
+        flow = Flow(
+            name="parent",
+            item_input=["item_id"],
+            item_output=["item_id", "item_feed"],
+            sub_flows=[sf],
+        )
+        flow.resource("feed_data", FakeResource())
+
+        # Should not raise
+        cfg = compile_flow(flow)
+        assert "pipeline_config" in cfg

--- a/apple/tests/test_compiler.py
+++ b/apple/tests/test_compiler.py
@@ -540,6 +540,34 @@ class TestRenameControlFields:
         assert biz_op.common_input == ["_L1::if_1"]
         assert biz_op.skip == ["_L1::if_1"]
 
+    def test_subflow_rename_updates_lua_script(self):
+        """Lua evaluate in else/elseif must reference namespaced field via _ENV."""
+        from apple.base import OpCall
+        from apple.compiler import _rename_control_fields
+
+        ctrl_if = OpCall(
+            type_name="transform_by_lua",
+            params={"lua_script": 'function evaluate() if (flag == true) then return false else return true end end',
+                    "function_for_common": "evaluate", "function_for_item": ""},
+            common_output=["_if_1"],
+            for_branch_control=True,
+            name="if_1",
+        )
+        ctrl_else = OpCall(
+            type_name="transform_by_lua",
+            params={"lua_script": 'function evaluate() if ((_if_1)) then return false else return true end end',
+                    "function_for_common": "evaluate", "function_for_item": ""},
+            common_input=["_if_1"],
+            common_output=["_else_2"],
+            for_branch_control=True,
+            name="else_2",
+        )
+        _rename_control_fields(
+            [ctrl_if, ctrl_else], [("op", 0), ("op", 1)], "my_sf"
+        )
+        assert '_ENV["_my_sf::if_1"]' in ctrl_else.params["lua_script"]
+        assert "(_if_1)" not in ctrl_else.params["lua_script"]
+
     def test_nested_path_uses_double_colon(self):
         """Nested SubFlow path uses :: as separator."""
         from apple.base import OpCall

--- a/fixtures/pipelines/control_op_nil_field_no_crash.json
+++ b/fixtures/pipelines/control_op_nil_field_no_crash.json
@@ -1,0 +1,81 @@
+{
+  "name": "control operator nil field does not crash — branch skipped",
+  "config": {
+    "_PINEAPPLE_VERSION": "0.8.0",
+    "pipeline_config": {
+      "operators": {
+        "ctrl_if": {
+          "type_name": "transform_by_lua",
+          "lua_script": "function evaluate() if ((event or '') == 'expose' and (expose_duration or 0) > 300) then return false else return true end end",
+          "function_for_common": "evaluate",
+          "function_for_item": "",
+          "for_branch_control": true,
+          "$metadata": {
+            "common_input": ["event", "expose_duration"],
+            "common_output": ["_if_1"],
+            "item_input": [],
+            "item_output": []
+          }
+        },
+        "branch_a": {
+          "type_name": "transform_by_lua",
+          "lua_script": "function tag() return 'exposed' end",
+          "function_for_common": "tag",
+          "function_for_item": "",
+          "skip": ["_if_1"],
+          "$metadata": {
+            "common_input": ["_if_1"],
+            "common_output": ["tag"],
+            "item_input": [],
+            "item_output": []
+          }
+        },
+        "size": {
+          "type_name": "transform_size",
+          "$metadata": {
+            "common_input": [],
+            "common_output": ["size"],
+            "item_input": [],
+            "item_output": []
+          }
+        }
+      },
+      "pipeline_map": {}
+    },
+    "pipeline_group": {
+      "main": {
+        "pipeline": ["ctrl_if", "branch_a", "size"]
+      }
+    },
+    "flow_contract": {
+      "common_input": ["event", "expose_duration"],
+      "common_output": ["size", "tag"],
+      "item_input": [],
+      "item_output": []
+    }
+  },
+  "cases": [
+    {
+      "name": "expose_duration is nil — branch skipped, no error",
+      "request": {
+        "common": {"event": "expose", "expose_duration": null},
+        "items": [{"id": "a"}, {"id": "b"}]
+      },
+      "expected": {
+        "common": {"size": 2},
+        "items": [{}, {}]
+      }
+    },
+    {
+      "name": "expose_duration > 300 — branch taken",
+      "request": {
+        "common": {"event": "expose", "expose_duration": 500},
+        "items": [{"id": "a"}]
+      },
+      "expected": {
+        "common": {"size": 1, "tag": "exposed"},
+        "items": [{}]
+      }
+    }
+  ]
+}

--- a/fixtures/pipelines/field_mode_nullable_vs_defaulted.json
+++ b/fixtures/pipelines/field_mode_nullable_vs_defaulted.json
@@ -1,17 +1,17 @@
 {
-  "name": "nullable field mode — explicit nil pass-through vs missing error",
+  "name": "three field modes — strict vs nullable vs defaulted",
   "config": {
     "_PINEAPPLE_VERSION": "0.8.0",
     "pipeline_config": {
       "operators": {
-        "set_nil": {
+        "write_nil": {
           "type_name": "transform_by_lua",
           "lua_script": "function f() return nil end",
           "function_for_common": "f",
           "function_for_item": "",
           "$metadata": {
             "common_input": [],
-            "common_output": ["nullable_field"],
+            "common_output": ["nullable_field", "strict_field", "defaulted_field"],
             "item_input": [],
             "item_output": []
           }
@@ -23,7 +23,20 @@
           "function_for_item": "",
           "$metadata": {
             "common_input": ["nullable_field"],
-            "common_output": ["result"],
+            "common_output": ["nullable_result"],
+            "item_input": [],
+            "item_output": []
+          }
+        },
+        "read_defaulted": {
+          "type_name": "transform_by_lua",
+          "lua_script": "function f()\n  return tostring(defaulted_field)\nend",
+          "function_for_common": "f",
+          "function_for_item": "",
+          "common_defaults": {"defaulted_field": "fallback"},
+          "$metadata": {
+            "common_input": ["defaulted_field"],
+            "common_output": ["defaulted_result"],
             "item_input": [],
             "item_output": []
           }
@@ -42,25 +55,25 @@
     },
     "pipeline_group": {
       "main": {
-        "pipeline": ["set_nil", "read_nullable", "size"]
+        "pipeline": ["write_nil", "read_nullable", "read_defaulted", "size"]
       }
     },
     "flow_contract": {
       "common_input": [],
-      "common_output": ["result", "size"],
+      "common_output": ["nullable_result", "defaulted_result", "size"],
       "item_input": [],
       "item_output": []
     }
   },
   "cases": [
     {
-      "name": "explicit nil is observable via nullable mode",
+      "name": "nullable passes nil through, defaulted substitutes fallback",
       "request": {
         "common": {},
         "items": [{"id": "a"}]
       },
       "expected": {
-        "common": {"result": "was_nil", "size": 1},
+        "common": {"nullable_result": "was_nil", "defaulted_result": "fallback", "size": 1},
         "items": [{}]
       }
     }

--- a/fixtures/pipelines/field_mode_strict_nil_error.json
+++ b/fixtures/pipelines/field_mode_strict_nil_error.json
@@ -1,38 +1,30 @@
 {
-  "name": "nullable field mode — explicit nil pass-through vs missing error",
+  "name": "strict field mode — nil triggers error",
   "config": {
     "_PINEAPPLE_VERSION": "0.8.0",
     "pipeline_config": {
       "operators": {
-        "set_nil": {
+        "write_nil": {
           "type_name": "transform_by_lua",
           "lua_script": "function f() return nil end",
           "function_for_common": "f",
           "function_for_item": "",
           "$metadata": {
             "common_input": [],
-            "common_output": ["nullable_field"],
+            "common_output": ["strict_field"],
             "item_input": [],
             "item_output": []
           }
         },
-        "read_nullable": {
+        "read_strict": {
           "type_name": "transform_by_lua",
-          "lua_script": "function f()\n  if nullable_field == nil then\n    return 'was_nil'\n  else\n    return tostring(nullable_field)\n  end\nend",
+          "lua_script": "function f() return strict_field end",
           "function_for_common": "f",
           "function_for_item": "",
+          "strict_common": ["strict_field"],
           "$metadata": {
-            "common_input": ["nullable_field"],
+            "common_input": ["strict_field"],
             "common_output": ["result"],
-            "item_input": [],
-            "item_output": []
-          }
-        },
-        "size": {
-          "type_name": "transform_size",
-          "$metadata": {
-            "common_input": [],
-            "common_output": ["size"],
             "item_input": [],
             "item_output": []
           }
@@ -42,27 +34,24 @@
     },
     "pipeline_group": {
       "main": {
-        "pipeline": ["set_nil", "read_nullable", "size"]
+        "pipeline": ["write_nil", "read_strict"]
       }
     },
     "flow_contract": {
       "common_input": [],
-      "common_output": ["result", "size"],
+      "common_output": ["result"],
       "item_input": [],
       "item_output": []
     }
   },
   "cases": [
     {
-      "name": "explicit nil is observable via nullable mode",
+      "name": "strict field nil triggers ExecutionError",
       "request": {
         "common": {},
         "items": [{"id": "a"}]
       },
-      "expected": {
-        "common": {"result": "was_nil", "size": 1},
-        "items": [{}]
-      }
+      "expect_error": "required field \"strict_field\" is nil in common"
     }
   ]
 }

--- a/fixtures/pipelines/nil_common_dispatch.json
+++ b/fixtures/pipelines/nil_common_dispatch.json
@@ -47,7 +47,7 @@
     {
       "name": "null common dispatched to item_label triggers error",
       "request": {"common": {"label": null}, "items": []},
-      "expect_error": "required field \"label\" is nil in common"
+      "expect_error": "required field \"label\" is missing in common"
     }
   ]
 }

--- a/fixtures/pipelines/nil_common_dispatch.json
+++ b/fixtures/pipelines/nil_common_dispatch.json
@@ -7,47 +7,96 @@
           "type_name": "recall_static",
           "recall": true,
           "items": [
-            {"item_id": "x1", "score": 50.0},
-            {"item_id": "x2", "score": 30.0},
-            {"item_id": "x3", "score": 70.0}
+            {
+              "item_id": "x1",
+              "score": 50.0
+            },
+            {
+              "item_id": "x2",
+              "score": 30.0
+            },
+            {
+              "item_id": "x3",
+              "score": 70.0
+            }
           ],
           "$metadata": {
-            "common_input": [], "common_output": [],
-            "item_input": [], "item_output": ["item_id", "score"]
+            "common_input": [],
+            "common_output": [],
+            "item_input": [],
+            "item_output": [
+              "item_id",
+              "score"
+            ]
           }
         },
         "dispatch_label": {
           "type_name": "transform_dispatch",
           "$metadata": {
-            "common_input": ["label"], "common_output": [],
-            "item_input": [], "item_output": ["item_label"]
-          }
+            "common_input": [
+              "label"
+            ],
+            "common_output": [],
+            "item_input": [],
+            "item_output": [
+              "item_label"
+            ]
+          },
+          "strict_common": [
+            "label"
+          ]
         },
         "truncate_top2": {
           "type_name": "filter_truncate",
           "top_n": 2,
           "consumes_row_set": true,
           "$metadata": {
-            "common_input": [], "common_output": [],
-            "item_input": ["item_label"], "item_output": []
-          }
+            "common_input": [],
+            "common_output": [],
+            "item_input": [
+              "item_label"
+            ],
+            "item_output": []
+          },
+          "strict_item": [
+            "item_label"
+          ]
         }
       }
     },
     "pipeline_group": {
-      "main": {"pipeline": ["recall_items", "dispatch_label", "truncate_top2"]}
+      "main": {
+        "pipeline": [
+          "recall_items",
+          "dispatch_label",
+          "truncate_top2"
+        ]
+      }
     },
     "flow_contract": {
-      "common_input": ["label"], "item_input": [],
-      "common_output": [], "item_output": ["item_id", "score", "item_label"]
+      "common_input": [
+        "label"
+      ],
+      "item_input": [],
+      "common_output": [],
+      "item_output": [
+        "item_id",
+        "score",
+        "item_label"
+      ]
     },
     "storage_mode": "column"
   },
   "cases": [
     {
       "name": "null common dispatched to item_label triggers error",
-      "request": {"common": {"label": null}, "items": []},
-      "expect_error": "required field \"label\" is missing in common"
+      "request": {
+        "common": {
+          "label": null
+        },
+        "items": []
+      },
+      "expect_error": "required field \"label\" is nil in common"
     }
   ]
 }

--- a/fixtures/pipelines/nil_multi_recall_merge.json
+++ b/fixtures/pipelines/nil_multi_recall_merge.json
@@ -52,7 +52,7 @@
     {
       "name": "merged items missing cross-recall fields triggers error",
       "request": {"common": {}, "items": []},
-      "expect_error": "is nil on item"
+      "expect_error": "is missing on item"
     }
   ]
 }

--- a/fixtures/pipelines/nil_multi_recall_merge.json
+++ b/fixtures/pipelines/nil_multi_recall_merge.json
@@ -7,25 +7,50 @@
           "type_name": "recall_static",
           "recall": true,
           "items": [
-            {"item_id": "a1", "score": 85.0},
-            {"item_id": "a2", "score": 72.0}
+            {
+              "item_id": "a1",
+              "score": 85.0
+            },
+            {
+              "item_id": "a2",
+              "score": 72.0
+            }
           ],
           "$metadata": {
-            "common_input": [], "common_output": [],
-            "item_input": [], "item_output": ["item_id", "score"]
+            "common_input": [],
+            "common_output": [],
+            "item_input": [],
+            "item_output": [
+              "item_id",
+              "score"
+            ]
           }
         },
         "recall_b": {
           "type_name": "recall_static",
           "recall": true,
           "items": [
-            {"item_id": "b1", "tag": "promo"},
-            {"item_id": "b2", "tag": "new"},
-            {"item_id": "b3", "tag": "sale"}
+            {
+              "item_id": "b1",
+              "tag": "promo"
+            },
+            {
+              "item_id": "b2",
+              "tag": "new"
+            },
+            {
+              "item_id": "b3",
+              "tag": "sale"
+            }
           ],
           "$metadata": {
-            "common_input": [], "common_output": [],
-            "item_input": [], "item_output": ["item_id", "tag"]
+            "common_input": [],
+            "common_output": [],
+            "item_input": [],
+            "item_output": [
+              "item_id",
+              "tag"
+            ]
           }
         },
         "truncate_top4": {
@@ -33,26 +58,50 @@
           "top_n": 4,
           "consumes_row_set": true,
           "$metadata": {
-            "common_input": [], "common_output": [],
-            "item_input": ["score", "tag"], "item_output": []
-          }
+            "common_input": [],
+            "common_output": [],
+            "item_input": [
+              "score",
+              "tag"
+            ],
+            "item_output": []
+          },
+          "strict_item": [
+            "score",
+            "tag"
+          ]
         }
       }
     },
     "pipeline_group": {
-      "main": {"pipeline": ["recall_a", "recall_b", "truncate_top4"]}
+      "main": {
+        "pipeline": [
+          "recall_a",
+          "recall_b",
+          "truncate_top4"
+        ]
+      }
     },
     "flow_contract": {
-      "common_input": [], "item_input": [],
-      "common_output": [], "item_output": ["item_id", "score", "tag"]
+      "common_input": [],
+      "item_input": [],
+      "common_output": [],
+      "item_output": [
+        "item_id",
+        "score",
+        "tag"
+      ]
     },
     "storage_mode": "column"
   },
   "cases": [
     {
       "name": "merged items missing cross-recall fields triggers error",
-      "request": {"common": {}, "items": []},
-      "expect_error": "is missing on item"
+      "request": {
+        "common": {},
+        "items": []
+      },
+      "expect_error": "is nil on item"
     }
   ]
 }

--- a/fixtures/pipelines/nil_recall_scalar.json
+++ b/fixtures/pipelines/nil_recall_scalar.json
@@ -7,14 +7,36 @@
           "type_name": "recall_static",
           "recall": true,
           "items": [
-            {"item_id": "p1", "item_name": "Widget A", "price": 9.99},
-            {"item_id": "p2", "item_name": null, "price": 12.50},
-            {"item_id": "p3", "item_name": "Widget C", "price": 7.00},
-            {"item_id": "p4", "item_name": null, "price": 15.00}
+            {
+              "item_id": "p1",
+              "item_name": "Widget A",
+              "price": 9.99
+            },
+            {
+              "item_id": "p2",
+              "item_name": null,
+              "price": 12.5
+            },
+            {
+              "item_id": "p3",
+              "item_name": "Widget C",
+              "price": 7.0
+            },
+            {
+              "item_id": "p4",
+              "item_name": null,
+              "price": 15.0
+            }
           ],
           "$metadata": {
-            "common_input": [], "common_output": [],
-            "item_input": [], "item_output": ["item_id", "item_name", "price"]
+            "common_input": [],
+            "common_output": [],
+            "item_input": [],
+            "item_output": [
+              "item_id",
+              "item_name",
+              "price"
+            ]
           }
         },
         "truncate_top3": {
@@ -22,26 +44,47 @@
           "top_n": 3,
           "consumes_row_set": true,
           "$metadata": {
-            "common_input": [], "common_output": [],
-            "item_input": ["item_name"], "item_output": []
-          }
+            "common_input": [],
+            "common_output": [],
+            "item_input": [
+              "item_name"
+            ],
+            "item_output": []
+          },
+          "strict_item": [
+            "item_name"
+          ]
         }
       }
     },
     "pipeline_group": {
-      "main": {"pipeline": ["recall_products", "truncate_top3"]}
+      "main": {
+        "pipeline": [
+          "recall_products",
+          "truncate_top3"
+        ]
+      }
     },
     "flow_contract": {
-      "common_input": [], "item_input": [],
-      "common_output": [], "item_output": ["item_id", "item_name", "price"]
+      "common_input": [],
+      "item_input": [],
+      "common_output": [],
+      "item_output": [
+        "item_id",
+        "item_name",
+        "price"
+      ]
     },
     "storage_mode": "column"
   },
   "cases": [
     {
       "name": "null item_name triggers strict accessor error",
-      "request": {"common": {}, "items": []},
-      "expect_error": "required field \"item_name\" is missing on item"
+      "request": {
+        "common": {},
+        "items": []
+      },
+      "expect_error": "required field \"item_name\" is nil on item"
     }
   ]
 }

--- a/fixtures/pipelines/nil_recall_scalar.json
+++ b/fixtures/pipelines/nil_recall_scalar.json
@@ -41,7 +41,7 @@
     {
       "name": "null item_name triggers strict accessor error",
       "request": {"common": {}, "items": []},
-      "expect_error": "required field \"item_name\" is nil on item"
+      "expect_error": "required field \"item_name\" is missing on item"
     }
   ]
 }

--- a/fixtures/pipelines/nullable_field_pass_through.json
+++ b/fixtures/pipelines/nullable_field_pass_through.json
@@ -1,0 +1,69 @@
+{
+  "name": "nullable field mode — explicit nil pass-through vs missing error",
+  "config": {
+    "_PINEAPPLE_VERSION": "0.8.0",
+    "pipeline_config": {
+      "operators": {
+        "set_nil": {
+          "type_name": "transform_by_lua",
+          "lua_script": "function f() return nil end",
+          "function_for_common": "f",
+          "function_for_item": "",
+          "$metadata": {
+            "common_input": [],
+            "common_output": ["nullable_field"],
+            "item_input": [],
+            "item_output": []
+          }
+        },
+        "read_nullable": {
+          "type_name": "transform_by_lua",
+          "lua_script": "function f()\n  if nullable_field == nil then\n    return 'was_nil'\n  else\n    return tostring(nullable_field)\n  end\nend",
+          "function_for_common": "f",
+          "function_for_item": "",
+          "nullable_common": ["nullable_field"],
+          "$metadata": {
+            "common_input": ["nullable_field"],
+            "common_output": ["result"],
+            "item_input": [],
+            "item_output": []
+          }
+        },
+        "size": {
+          "type_name": "transform_size",
+          "$metadata": {
+            "common_input": [],
+            "common_output": ["size"],
+            "item_input": [],
+            "item_output": []
+          }
+        }
+      },
+      "pipeline_map": {}
+    },
+    "pipeline_group": {
+      "main": {
+        "pipeline": ["set_nil", "read_nullable", "size"]
+      }
+    },
+    "flow_contract": {
+      "common_input": [],
+      "common_output": ["result", "size"],
+      "item_input": [],
+      "item_output": []
+    }
+  },
+  "cases": [
+    {
+      "name": "explicit nil is observable via nullable mode",
+      "request": {
+        "common": {},
+        "items": [{"id": "a"}]
+      },
+      "expected": {
+        "common": {"result": "was_nil", "size": 1},
+        "items": [{}]
+      }
+    }
+  ]
+}

--- a/fixtures/pipelines/strict_field_accessor.json
+++ b/fixtures/pipelines/strict_field_accessor.json
@@ -7,24 +7,46 @@
           "type_name": "recall_static",
           "recall": true,
           "items": [
-            {"item_id": "a1", "score": 10.0},
-            {"item_id": "a2", "score": 20.0}
+            {
+              "item_id": "a1",
+              "score": 10.0
+            },
+            {
+              "item_id": "a2",
+              "score": 20.0
+            }
           ],
           "$metadata": {
-            "common_input": [], "common_output": [],
-            "item_input": [], "item_output": ["item_id", "score"]
+            "common_input": [],
+            "common_output": [],
+            "item_input": [],
+            "item_output": [
+              "item_id",
+              "score"
+            ]
           }
         },
         "recall_b": {
           "type_name": "recall_static",
           "recall": true,
           "items": [
-            {"item_id": "b1", "tag": "hot"},
-            {"item_id": "b2", "tag": "new"}
+            {
+              "item_id": "b1",
+              "tag": "hot"
+            },
+            {
+              "item_id": "b2",
+              "tag": "new"
+            }
           ],
           "$metadata": {
-            "common_input": [], "common_output": [],
-            "item_input": [], "item_output": ["item_id", "tag"]
+            "common_input": [],
+            "common_output": [],
+            "item_input": [],
+            "item_output": [
+              "item_id",
+              "tag"
+            ]
           }
         },
         "sort_score": {
@@ -33,26 +55,48 @@
           "consumes_row_set": true,
           "mutates_row_set": true,
           "$metadata": {
-            "common_input": [], "common_output": [],
-            "item_input": ["score"], "item_output": []
-          }
+            "common_input": [],
+            "common_output": [],
+            "item_input": [
+              "score"
+            ],
+            "item_output": []
+          },
+          "strict_item": [
+            "score"
+          ]
         }
       }
     },
     "pipeline_group": {
-      "main": {"pipeline": ["recall_a", "recall_b", "sort_score"]}
+      "main": {
+        "pipeline": [
+          "recall_a",
+          "recall_b",
+          "sort_score"
+        ]
+      }
     },
     "flow_contract": {
-      "common_input": [], "item_input": [],
-      "common_output": [], "item_output": ["item_id", "score", "tag"]
+      "common_input": [],
+      "item_input": [],
+      "common_output": [],
+      "item_output": [
+        "item_id",
+        "score",
+        "tag"
+      ]
     },
     "storage_mode": "column"
   },
   "cases": [
     {
       "name": "sort on field missing from some items => framework error",
-      "request": {"common": {}, "items": []},
-      "expect_error": "required field \"score\" is missing on item"
+      "request": {
+        "common": {},
+        "items": []
+      },
+      "expect_error": "required field \"score\" is nil on item"
     }
   ]
 }

--- a/fixtures/pipelines/strict_field_accessor.json
+++ b/fixtures/pipelines/strict_field_accessor.json
@@ -52,7 +52,7 @@
     {
       "name": "sort on field missing from some items => framework error",
       "request": {"common": {}, "items": []},
-      "expect_error": "required field \"score\" is nil on item"
+      "expect_error": "required field \"score\" is missing on item"
     }
   ]
 }

--- a/fixtures/pipelines/subflow_if_else_control_flow.json
+++ b/fixtures/pipelines/subflow_if_else_control_flow.json
@@ -1,0 +1,121 @@
+{
+  "name": "SubFlow if/else control flow with namespaced fields",
+  "config": {
+    "_PINEAPPLE_VERSION": "0.8.0",
+    "pipeline_config": {
+      "operators": {
+        "my_sf::if_1": {
+          "type_name": "transform_by_lua",
+          "$metadata": {
+            "common_input": ["score_threshold"],
+            "common_output": ["_my_sf::if_1"],
+            "item_input": [],
+            "item_output": []
+          },
+          "for_branch_control": true,
+          "lua_script": "function evaluate() if (score_threshold > 50) then return false else return true end end",
+          "function_for_item": "",
+          "function_for_common": "evaluate"
+        },
+        "label_high_low": {
+          "type_name": "transform_by_lua",
+          "$metadata": {
+            "common_input": ["_my_sf::if_1", "score_threshold"],
+            "common_output": [],
+            "item_input": ["item_score"],
+            "item_output": ["item_label"]
+          },
+          "skip": ["_my_sf::if_1"],
+          "lua_script": "function label() if item_score >= score_threshold then return \"high\" else return \"low\" end end",
+          "function_for_item": "label",
+          "function_for_common": ""
+        },
+        "my_sf::else_2": {
+          "type_name": "transform_by_lua",
+          "$metadata": {
+            "common_input": ["_my_sf::if_1"],
+            "common_output": ["_my_sf::else_2"],
+            "item_input": [],
+            "item_output": []
+          },
+          "for_branch_control": true,
+          "lua_script": "function evaluate() if ((_G[\"_my_sf::if_1\"])) then return false else return true end end",
+          "function_for_item": "",
+          "function_for_common": "evaluate"
+        },
+        "label_default": {
+          "type_name": "transform_by_lua",
+          "$metadata": {
+            "common_input": ["_my_sf::else_2"],
+            "common_output": [],
+            "item_input": ["item_score"],
+            "item_output": ["item_label"]
+          },
+          "skip": ["_my_sf::else_2"],
+          "lua_script": "function fallback() return \"default\" end",
+          "function_for_item": "fallback",
+          "function_for_common": ""
+        }
+      },
+      "pipeline_map": {
+        "my_sf": {
+          "pipeline": [
+            "my_sf::if_1",
+            "label_high_low",
+            "my_sf::else_2",
+            "label_default"
+          ]
+        }
+      }
+    },
+    "pipeline_group": {
+      "main": {
+        "pipeline": ["my_sf"]
+      }
+    },
+    "flow_contract": {
+      "common_input": ["score_threshold"],
+      "item_input": ["item_score"],
+      "common_output": [],
+      "item_output": ["item_score", "item_label"]
+    }
+  },
+  "cases": [
+    {
+      "name": "if branch active (score_threshold > 50): labels by score comparison",
+      "request": {
+        "common": {"score_threshold": 80},
+        "items": [
+          {"item_score": 90},
+          {"item_score": 70},
+          {"item_score": 50}
+        ]
+      },
+      "expected": {
+        "common": {},
+        "items": [
+          {"item_score": 90, "item_label": "high"},
+          {"item_score": 70, "item_label": "low"},
+          {"item_score": 50, "item_label": "low"}
+        ]
+      }
+    },
+    {
+      "name": "else branch active (score_threshold <= 50): all get default label",
+      "request": {
+        "common": {"score_threshold": 30},
+        "items": [
+          {"item_score": 100},
+          {"item_score": 10}
+        ]
+      },
+      "expected": {
+        "common": {},
+        "items": [
+          {"item_score": 100, "item_label": "default"},
+          {"item_score": 10, "item_label": "default"}
+        ]
+      }
+    }
+  ]
+}

--- a/pine-cpp/include/pine/pine.hpp
+++ b/pine-cpp/include/pine/pine.hpp
@@ -184,6 +184,7 @@ struct OperatorConfig {
     bool additive_writes_row_set = false;
     bool concurrent_safe = false;
     bool debug = false;
+    bool for_branch_control = false;
     std::map<std::string, JsonValue> common_defaults;
     std::map<std::string, JsonValue> item_defaults;
     std::vector<std::string> sources;

--- a/pine-cpp/include/pine/pine.hpp
+++ b/pine-cpp/include/pine/pine.hpp
@@ -183,7 +183,7 @@ struct OperatorConfig {
     bool mutates_row_set = false;
     bool additive_writes_row_set = false;
     bool concurrent_safe = false;
-    bool debug = false;
+    std::optional<bool> debug;
     bool for_branch_control = false;
     std::map<std::string, JsonValue> common_defaults;
     std::map<std::string, JsonValue> item_defaults;

--- a/pine-cpp/include/pine/pine.hpp
+++ b/pine-cpp/include/pine/pine.hpp
@@ -187,6 +187,8 @@ struct OperatorConfig {
     bool for_branch_control = false;
     std::map<std::string, JsonValue> common_defaults;
     std::map<std::string, JsonValue> item_defaults;
+    std::vector<std::string> strict_common;
+    std::vector<std::string> strict_item;
     std::vector<std::string> sources;
     JsonValue params;
     std::string operator_type;
@@ -204,8 +206,10 @@ struct DefaultedField {
 struct InputFieldSpec {
     std::vector<std::string> strict_common;
     std::vector<DefaultedField> defaulted_common;
+    std::vector<std::string> nullable_common;
     std::vector<std::string> strict_item;
     std::vector<DefaultedField> defaulted_item;
+    std::vector<std::string> nullable_item;
 };
 
 // compute_input_field_spec derives the InputFieldSpec from an OperatorConfig.

--- a/pine-cpp/src/config/config.cpp
+++ b/pine-cpp/src/config/config.cpp
@@ -69,6 +69,7 @@ OperatorConfig parse_operator(const std::string& name, const JsonValue& value) {
     if (auto it = obj.find("mutates_row_set"); it != obj.end() && it->second.is_bool()) op.mutates_row_set = it->second.as_bool();
     if (auto it = obj.find("additive_writes_row_set"); it != obj.end() && it->second.is_bool()) op.additive_writes_row_set = it->second.as_bool();
     if (auto it = obj.find("debug"); it != obj.end() && it->second.is_bool()) op.debug = it->second.as_bool();
+    if (auto it = obj.find("for_branch_control"); it != obj.end() && it->second.is_bool()) op.for_branch_control = it->second.as_bool();
     if (auto it = obj.find("data_parallel"); it != obj.end() && it->second.is_number()) op.data_parallel = static_cast<int>(it->second.as_number());
     op.common_defaults = as_value_map(obj, "common_defaults");
     op.item_defaults = as_value_map(obj, "item_defaults");

--- a/pine-cpp/src/config/config.cpp
+++ b/pine-cpp/src/config/config.cpp
@@ -73,12 +73,15 @@ OperatorConfig parse_operator(const std::string& name, const JsonValue& value) {
     if (auto it = obj.find("data_parallel"); it != obj.end() && it->second.is_number()) op.data_parallel = static_cast<int>(it->second.as_number());
     op.common_defaults = as_value_map(obj, "common_defaults");
     op.item_defaults = as_value_map(obj, "item_defaults");
+    op.strict_common = as_string_list(obj, "strict_common");
+    op.strict_item = as_string_list(obj, "strict_item");
     op.sources = as_string_list(obj, "sources");
     JsonValue::object_t params;
     for (const auto& [key, item] : obj) {
         if (key == "type_name" || key == "$metadata" || key == "$code_info" || key == "skip" || key == "recall" ||
             key == "sources" || key == "debug" || key == "consumes_row_set" || key == "mutates_row_set" ||
-            key == "additive_writes_row_set" || key == "common_defaults" || key == "item_defaults" || key == "for_branch_control" ||
+            key == "additive_writes_row_set" || key == "common_defaults" || key == "item_defaults" ||
+            key == "strict_common" || key == "strict_item" || key == "for_branch_control" ||
             key == "data_parallel") {
             continue;
         }

--- a/pine-cpp/src/dataframe/column_frame.cpp
+++ b/pine-cpp/src/dataframe/column_frame.cpp
@@ -134,7 +134,7 @@ bool ColumnFrame::has_common(const std::string& field) const {
     std::shared_lock<std::shared_mutex> lk(mu_);
     const auto& src = view_common_ ? *view_common_ : common_;
     auto it = src.find(field);
-    return it != src.end() && !it->second.is_null();
+    return it != src.end();
 }
 
 void ColumnFrame::set_common(const std::string& field, JsonValue value) {
@@ -186,7 +186,7 @@ bool ColumnFrame::item_has(std::size_t index, const std::string& field) const {
     }
     const Column* col = store->column(field);
     if (!col) return false;
-    return !col->is_null(index);
+    return col->is_present(index);
 }
 
 std::vector<std::string> ColumnFrame::item_fields() const {

--- a/pine-cpp/src/dataframe/operator_input.cpp
+++ b/pine-cpp/src/dataframe/operator_input.cpp
@@ -1,6 +1,8 @@
 #include "pine/operator_input.hpp"
 #include "pine/frame.hpp"
 
+#include <set>
+
 namespace pine {
 
 OperatorInput::OperatorInput(const Frame& frame, const InputFieldSpec& spec)
@@ -33,6 +35,7 @@ std::vector<std::string> OperatorInput::common_keys() const {
     std::vector<std::string> keys;
     for (const auto& f : spec_->strict_common) keys.push_back(f);
     for (const auto& df : spec_->defaulted_common) keys.push_back(df.name);
+    for (const auto& f : spec_->nullable_common) keys.push_back(f);
     return keys;
 }
 
@@ -41,6 +44,7 @@ std::vector<std::string> OperatorInput::item_keys(std::size_t index) const {
     std::vector<std::string> keys;
     for (const auto& f : spec_->strict_item) keys.push_back(f);
     for (const auto& df : spec_->defaulted_item) keys.push_back(df.name);
+    for (const auto& f : spec_->nullable_item) keys.push_back(f);
     return keys;
 }
 
@@ -50,20 +54,33 @@ const std::map<std::string, JsonValue>* OperatorInput::resources() const {
 
 InputFieldSpec compute_input_field_spec(const OperatorConfig& config) {
     InputFieldSpec spec;
+
+    // Build skip and strict sets for O(1) lookup
+    std::set<std::string> skip_set(config.skip.begin(), config.skip.end());
+    std::set<std::string> strict_common_set(config.strict_common.begin(),
+                                             config.strict_common.end());
+    std::set<std::string> strict_item_set(config.strict_item.begin(),
+                                           config.strict_item.end());
+
     for (const auto& field : config.metadata.common_input) {
+        if (skip_set.count(field)) continue;
         auto def_it = config.common_defaults.find(field);
         if (def_it != config.common_defaults.end()) {
             spec.defaulted_common.push_back({field, def_it->second});
-        } else {
+        } else if (strict_common_set.count(field)) {
             spec.strict_common.push_back(field);
+        } else {
+            spec.nullable_common.push_back(field);
         }
     }
     for (const auto& field : config.metadata.item_input) {
         auto def_it = config.item_defaults.find(field);
         if (def_it != config.item_defaults.end()) {
             spec.defaulted_item.push_back({field, def_it->second});
-        } else {
+        } else if (strict_item_set.count(field)) {
             spec.strict_item.push_back(field);
+        } else {
+            spec.nullable_item.push_back(field);
         }
     }
     return spec;
@@ -80,11 +97,27 @@ OperatorInput build_operator_input(const Frame& frame,
         }
     }
 
+    // Validate nullable common fields: missing → error, null → pass through
+    for (const auto& field : spec.nullable_common) {
+        if (!frame.has_common(field)) {
+            throw ExecutionError(op_name, "required field \"" + field + "\" is missing in common");
+        }
+    }
+
     // Batch-validate strict item fields (PERF-1a)
     if (!spec.strict_item.empty()) {
         auto [bad_field, bad_row] = frame.validate_strict_items(spec.strict_item);
         if (bad_row >= 0) {
             throw ExecutionError(op_name, "required field \"" + bad_field + "\" is nil on item[" + std::to_string(bad_row) + "]");
+        }
+    }
+
+    // Validate nullable item fields: missing → error, null → pass through
+    for (const auto& field : spec.nullable_item) {
+        for (std::size_t i = 0; i < frame.item_count(); ++i) {
+            if (!frame.item_has(i, field)) {
+                throw ExecutionError(op_name, "required field \"" + field + "\" is missing on item[" + std::to_string(i) + "]");
+            }
         }
     }
 

--- a/pine-cpp/src/dataframe/row_frame.cpp
+++ b/pine-cpp/src/dataframe/row_frame.cpp
@@ -39,7 +39,7 @@ bool RowFrame::has_common(const std::string& field) const {
     std::shared_lock<std::shared_mutex> lk(mu_);
     const auto& src = view_common_ ? *view_common_ : common_;
     auto it = src.find(field);
-    return it != src.end() && !it->second.is_null();
+    return it != src.end();
 }
 
 void RowFrame::set_common(const std::string& field, JsonValue value) {
@@ -90,7 +90,7 @@ bool RowFrame::item_has(std::size_t index, const std::string& field) const {
         return false;
     }
     auto it = src[index].find(field);
-    return it != src[index].end() && !it->second.is_null();
+    return it != src[index].end();
 }
 
 std::vector<std::string> RowFrame::item_fields() const {

--- a/pine-cpp/src/render/render.cpp
+++ b/pine-cpp/src/render/render.cpp
@@ -28,7 +28,7 @@ std::string color_for(const std::string& t) {
     const auto& m = dot_colors_map();
     auto it = m.find(t);
     if (it != m.end()) return it->second;
-    return "#FFFFFF";
+    return "#F5F5F5";
 }
 
 std::string collapse_key(const std::string& subflow, int level) {

--- a/pine-cpp/src/render/render.cpp
+++ b/pine-cpp/src/render/render.cpp
@@ -12,13 +12,23 @@ std::string sanitize(const std::string& name) {
     return out;
 }
 
+const std::map<std::string, std::string>& dot_colors_map() {
+    static const std::map<std::string, std::string> m = {
+        {"recall", "#E8F5E9"},
+        {"transform", "#E3F2FD"},
+        {"filter", "#FFF3E0"},
+        {"merge", "#F3E5F5"},
+        {"reorder", "#FFFDE7"},
+        {"observe", "#F5F5F5"},
+    };
+    return m;
+}
+
 std::string color_for(const std::string& t) {
-    if (t == "recall") return "#E8F5E9";
-    if (t == "transform") return "#E3F2FD";
-    if (t == "filter") return "#FFF3E0";
-    if (t == "merge") return "#F3E5F5";
-    if (t == "reorder") return "#FFFDE7";
-    return "#F5F5F5";
+    const auto& m = dot_colors_map();
+    auto it = m.find(t);
+    if (it != m.end()) return it->second;
+    return "#FFFFFF";
 }
 
 std::string collapse_key(const std::string& subflow, int level) {
@@ -44,6 +54,7 @@ struct Group {
     std::string key;
     std::string label;
     bool subflow;
+    std::string operator_type;  // non-empty for standalone nodes (preserves type coloring)
 };
 
 std::pair<std::vector<Group>, std::vector<std::pair<int, int>>> build_collapsed(const Graph& graph, int level) {
@@ -55,11 +66,12 @@ std::pair<std::vector<Group>, std::vector<std::pair<int, int>>> build_collapsed(
         const auto key = collapse_key(node.subflow, level);
         if (key.empty()) {
             node_to_group[i] = static_cast<int>(groups.size());
-            groups.push_back({"standalone_" + std::to_string(i), node.name, false});
+            std::string op_type = node.config ? node.config->operator_type : "";
+            groups.push_back({"standalone_" + std::to_string(i), node.name, false, op_type});
         } else if (!key_to_group.count(key)) {
             key_to_group[key] = static_cast<int>(groups.size());
             node_to_group[i] = static_cast<int>(groups.size());
-            groups.push_back({key, key, true});
+            groups.push_back({key, key, true, ""});
         } else {
             node_to_group[i] = key_to_group[key];
         }
@@ -122,7 +134,15 @@ std::string render_collapsed_dot(const Graph& graph, int level) {
     std::ostringstream oss;
     oss << "digraph pipeline {\n    rankdir=TB;\n    node [shape=box, style=filled, fontname=\"Helvetica\"];\n\n";
     for (std::size_t i = 0; i < groups.size(); ++i) {
-        oss << "    \"g" << i << "\" [label=\"" << groups[i].label << "\", fillcolor=\"" << (groups[i].subflow ? "#BBDEFB" : "#E0E0E0") << "\"];\n";
+        std::string color = "#E0E0E0";
+        if (groups[i].subflow) {
+            color = "#BBDEFB";
+        } else if (!groups[i].operator_type.empty()) {
+            const auto& m = dot_colors_map();
+            auto it = m.find(groups[i].operator_type);
+            if (it != m.end()) color = it->second;
+        }
+        oss << "    \"g" << i << "\" [label=\"" << groups[i].label << "\", fillcolor=\"" << color << "\"];\n";
     }
     oss << "\n";
     for (auto [a, b] : edges) oss << "    \"g" << a << "\" -> \"g" << b << "\";\n";
@@ -135,14 +155,26 @@ std::string render_collapsed_mermaid(const Graph& graph, int level) {
     std::ostringstream oss;
     oss << "graph TB\n";
     for (std::size_t i = 0; i < groups.size(); ++i) {
+        std::string cls = "standalone";
+        if (groups[i].subflow) {
+            cls = "subflow";
+        } else if (!groups[i].operator_type.empty()) {
+            cls = groups[i].operator_type;
+        }
         oss << "    g" << i << "[\"" << groups[i].label << "\"]:::"
-            << (groups[i].subflow ? "subflow" : "standalone") << "\n";
+            << cls << "\n";
     }
     oss << "\n";
     for (auto [a, b] : edges) oss << "    g" << a << " --> g" << b << "\n";
     oss << "\n"
         << "    classDef subflow fill:#BBDEFB,stroke:#1976D2\n"
-        << "    classDef standalone fill:#E0E0E0,stroke:#616161\n";
+        << "    classDef standalone fill:#E0E0E0,stroke:#616161\n"
+        << "    classDef recall fill:#E8F5E9,stroke:#4CAF50\n"
+        << "    classDef transform fill:#E3F2FD,stroke:#2196F3\n"
+        << "    classDef filter fill:#FFF3E0,stroke:#FF9800\n"
+        << "    classDef merge fill:#F3E5F5,stroke:#9C27B0\n"
+        << "    classDef reorder fill:#FFFDE7,stroke:#FFC107\n"
+        << "    classDef observe fill:#F5F5F5,stroke:#9E9E9E\n";
     return oss.str();
 }
 

--- a/pine-cpp/src/runtime/engine.cpp
+++ b/pine-cpp/src/runtime/engine.cpp
@@ -297,15 +297,6 @@ Engine::Engine(Config config, EngineOptions options) : config_(std::move(config)
         }
         operators_.emplace(op_name, std::move(instance));
         // Pre-compute InputFieldSpec for the BuildInput projection layer.
-        // Control operators treat all common_input as defaulted-nil so that
-        // missing fields evaluate to nil instead of causing ExecutionError.
-        if (op_cfg.for_branch_control) {
-            for (const auto& f : op_cfg.metadata.common_input) {
-                if (op_cfg.common_defaults.find(f) == op_cfg.common_defaults.end()) {
-                    op_cfg.common_defaults[f] = JsonValue{};
-                }
-            }
-        }
         input_specs_.emplace(op_name, compute_input_field_spec(op_cfg));
     }
 }

--- a/pine-cpp/src/runtime/engine.cpp
+++ b/pine-cpp/src/runtime/engine.cpp
@@ -255,8 +255,11 @@ Engine& Engine::operator=(Engine&&) noexcept = default;
 
 Engine::Engine(Config config, EngineOptions options) : config_(std::move(config)) {
     bool global_debug = options.debug.has_value() ? *options.debug : config_.debug;
-    if (global_debug) {
-        for (auto& [_, op] : config_.operators) op.debug = true;
+    // Tri-state debug: op-level debug overrides global when explicitly set
+    for (auto& [_, op] : config_.operators) {
+        if (!op.debug.has_value()) {
+            op.debug = global_debug;
+        }
     }
     log_prefix_ = options.log_prefix.has_value() ? *options.log_prefix : config_.log_prefix;
     peak_concurrency_ = std::make_unique<std::atomic<int64_t>>(0);
@@ -747,12 +750,12 @@ std::vector<OpTrace> run_dag(const Config& config,
                     return;
                 }
 
-                if (collect_traces && op.debug) {
+                if (collect_traces && op.debug.value_or(false)) {
                     trace.input_snapshot = snapshot_input(frame, op);
                     trace.has_input_snapshot = true;
                 }
                 parallel_execute(frame, op, operators, out, input_specs.at(op.name), shard_pool);
-                if (collect_traces && op.debug) {
+                if (collect_traces && op.debug.value_or(false)) {
                     trace.output_snapshot = snapshot_output(out);
                     trace.has_output_snapshot = true;
                 }
@@ -769,7 +772,7 @@ std::vector<OpTrace> run_dag(const Config& config,
                 // (µs below 1ms, ms above). Done before apply_output so
                 // the snapshot reflects the inputs that produced this
                 // output.
-                if (op.debug) {
+                if (op.debug.value_or(false)) {
                     auto dur = std::chrono::steady_clock::now() - start;
                     auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(dur).count();
                     std::string dur_str;

--- a/pine-cpp/src/runtime/engine.cpp
+++ b/pine-cpp/src/runtime/engine.cpp
@@ -294,6 +294,15 @@ Engine::Engine(Config config, EngineOptions options) : config_(std::move(config)
         }
         operators_.emplace(op_name, std::move(instance));
         // Pre-compute InputFieldSpec for the BuildInput projection layer.
+        // Control operators treat all common_input as defaulted-nil so that
+        // missing fields evaluate to nil instead of causing ExecutionError.
+        if (op_cfg.for_branch_control) {
+            for (const auto& f : op_cfg.metadata.common_input) {
+                if (op_cfg.common_defaults.find(f) == op_cfg.common_defaults.end()) {
+                    op_cfg.common_defaults[f] = JsonValue{};
+                }
+            }
+        }
         input_specs_.emplace(op_name, compute_input_field_spec(op_cfg));
     }
 }

--- a/pine-cpp/src/runtime/engine.cpp
+++ b/pine-cpp/src/runtime/engine.cpp
@@ -225,7 +225,7 @@ std::unique_ptr<Engine::EngineMetrics> build_engine_metrics(metrics::Provider* p
     });
     em->dag_ops_executed = p->new_histogram({
         {"pine_dag_operators_executed", "Number of operators executed per DAG run.", {}},
-        {1, 5, 10, 20, 50, 100, 200}
+        {1, 2, 5, 10, 15, 20, 25, 30, 40, 50, 75, 100, 150, 200, 300, 450}
     });
     for (const auto& n : op_names) {
         em->op_exec_total->with({n});

--- a/pine-cpp/tests/test_panic.cpp
+++ b/pine-cpp/tests/test_panic.cpp
@@ -30,6 +30,7 @@ constexpr const char* kBadCopyConfig = R"({
       "bad": {
         "type_name": "transform_copy",
         "direction": "common_to_common",
+        "strict_common": ["a"],
         "$metadata": {
           "common_input": ["a"],
           "common_output": ["b"]

--- a/pine-go/internal/config/types.go
+++ b/pine-go/internal/config/types.go
@@ -55,7 +55,7 @@ type OperatorConfig struct {
 	Skip             []string       `json:"-"`
 	Recall               bool           `json:"recall,omitempty"`
 	Sources              []string       `json:"sources,omitempty"`
-	Debug                bool           `json:"debug,omitempty"`
+	Debug                *bool          `json:"debug,omitempty"`
 	ConsumesRowSet       bool           `json:"consumes_row_set,omitempty"`
 	MutatesRowSet        bool           `json:"mutates_row_set,omitempty"`
 	AdditiveWritesRowSet bool           `json:"additive_writes_row_set,omitempty"`

--- a/pine-go/internal/config/types.go
+++ b/pine-go/internal/config/types.go
@@ -61,6 +61,8 @@ type OperatorConfig struct {
 	AdditiveWritesRowSet bool           `json:"additive_writes_row_set,omitempty"`
 	CommonDefaults   map[string]any `json:"common_defaults,omitempty"`
 	ItemDefaults     map[string]any `json:"item_defaults,omitempty"`
+	NullableCommon   []string       `json:"nullable_common,omitempty"`
+	NullableItem     []string       `json:"nullable_item,omitempty"`
 	ForBranchControl bool           `json:"for_branch_control,omitempty"`
 	DataParallel     int            `json:"data_parallel,omitempty"`
 
@@ -88,24 +90,36 @@ type DefaultedField struct {
 type InputFieldSpec struct {
 	StrictCommon    []string
 	DefaultedCommon []DefaultedField
+	NullableCommon  []string
 	StrictItem      []string
 	DefaultedItem   []DefaultedField
+	NullableItem    []string
 }
 
-// ComputeInputFieldSpec creates the InputFieldSpec from metadata, defaults, and skip fields.
-func ComputeInputFieldSpec(meta Metadata, commonDefaults, itemDefaults map[string]any, skip []string) *InputFieldSpec {
+// ComputeInputFieldSpec creates the InputFieldSpec from metadata, defaults, nullable, and skip fields.
+func ComputeInputFieldSpec(meta Metadata, commonDefaults, itemDefaults map[string]any, nullableCommon, nullableItem, skip []string) *InputFieldSpec {
 	spec := &InputFieldSpec{}
 
 	skipSet := make(map[string]struct{}, len(skip))
 	for _, s := range skip {
 		skipSet[s] = struct{}{}
 	}
+	nullableCommonSet := make(map[string]struct{}, len(nullableCommon))
+	for _, f := range nullableCommon {
+		nullableCommonSet[f] = struct{}{}
+	}
+	nullableItemSet := make(map[string]struct{}, len(nullableItem))
+	for _, f := range nullableItem {
+		nullableItemSet[f] = struct{}{}
+	}
 
 	for _, field := range meta.CommonInput {
 		if _, skipped := skipSet[field]; skipped {
 			continue
 		}
-		if d, ok := commonDefaults[field]; ok {
+		if _, nullable := nullableCommonSet[field]; nullable {
+			spec.NullableCommon = append(spec.NullableCommon, field)
+		} else if d, ok := commonDefaults[field]; ok {
 			spec.DefaultedCommon = append(spec.DefaultedCommon, DefaultedField{Name: field, Default: d})
 		} else {
 			spec.StrictCommon = append(spec.StrictCommon, field)
@@ -113,7 +127,9 @@ func ComputeInputFieldSpec(meta Metadata, commonDefaults, itemDefaults map[strin
 	}
 
 	for _, field := range meta.ItemInput {
-		if d, ok := itemDefaults[field]; ok {
+		if _, nullable := nullableItemSet[field]; nullable {
+			spec.NullableItem = append(spec.NullableItem, field)
+		} else if d, ok := itemDefaults[field]; ok {
 			spec.DefaultedItem = append(spec.DefaultedItem, DefaultedField{Name: field, Default: d})
 		} else {
 			spec.StrictItem = append(spec.StrictItem, field)

--- a/pine-go/internal/config/types.go
+++ b/pine-go/internal/config/types.go
@@ -61,8 +61,8 @@ type OperatorConfig struct {
 	AdditiveWritesRowSet bool           `json:"additive_writes_row_set,omitempty"`
 	CommonDefaults   map[string]any `json:"common_defaults,omitempty"`
 	ItemDefaults     map[string]any `json:"item_defaults,omitempty"`
-	NullableCommon   []string       `json:"nullable_common,omitempty"`
-	NullableItem     []string       `json:"nullable_item,omitempty"`
+	StrictCommon     []string       `json:"strict_common,omitempty"`
+	StrictItem       []string       `json:"strict_item,omitempty"`
 	ForBranchControl bool           `json:"for_branch_control,omitempty"`
 	DataParallel     int            `json:"data_parallel,omitempty"`
 
@@ -96,43 +96,44 @@ type InputFieldSpec struct {
 	NullableItem    []string
 }
 
-// ComputeInputFieldSpec creates the InputFieldSpec from metadata, defaults, nullable, and skip fields.
-func ComputeInputFieldSpec(meta Metadata, commonDefaults, itemDefaults map[string]any, nullableCommon, nullableItem, skip []string) *InputFieldSpec {
+// ComputeInputFieldSpec creates the InputFieldSpec from metadata, defaults, strict, and skip fields.
+// Default mode is Nullable (missing → error, nil → pass through). Strict and Defaulted are opt-in.
+func ComputeInputFieldSpec(meta Metadata, commonDefaults, itemDefaults map[string]any, strictCommon, strictItem, skip []string) *InputFieldSpec {
 	spec := &InputFieldSpec{}
 
 	skipSet := make(map[string]struct{}, len(skip))
 	for _, s := range skip {
 		skipSet[s] = struct{}{}
 	}
-	nullableCommonSet := make(map[string]struct{}, len(nullableCommon))
-	for _, f := range nullableCommon {
-		nullableCommonSet[f] = struct{}{}
+	strictCommonSet := make(map[string]struct{}, len(strictCommon))
+	for _, f := range strictCommon {
+		strictCommonSet[f] = struct{}{}
 	}
-	nullableItemSet := make(map[string]struct{}, len(nullableItem))
-	for _, f := range nullableItem {
-		nullableItemSet[f] = struct{}{}
+	strictItemSet := make(map[string]struct{}, len(strictItem))
+	for _, f := range strictItem {
+		strictItemSet[f] = struct{}{}
 	}
 
 	for _, field := range meta.CommonInput {
 		if _, skipped := skipSet[field]; skipped {
 			continue
 		}
-		if _, nullable := nullableCommonSet[field]; nullable {
-			spec.NullableCommon = append(spec.NullableCommon, field)
-		} else if d, ok := commonDefaults[field]; ok {
+		if d, ok := commonDefaults[field]; ok {
 			spec.DefaultedCommon = append(spec.DefaultedCommon, DefaultedField{Name: field, Default: d})
-		} else {
+		} else if _, strict := strictCommonSet[field]; strict {
 			spec.StrictCommon = append(spec.StrictCommon, field)
+		} else {
+			spec.NullableCommon = append(spec.NullableCommon, field)
 		}
 	}
 
 	for _, field := range meta.ItemInput {
-		if _, nullable := nullableItemSet[field]; nullable {
-			spec.NullableItem = append(spec.NullableItem, field)
-		} else if d, ok := itemDefaults[field]; ok {
+		if d, ok := itemDefaults[field]; ok {
 			spec.DefaultedItem = append(spec.DefaultedItem, DefaultedField{Name: field, Default: d})
-		} else {
+		} else if _, strict := strictItemSet[field]; strict {
 			spec.StrictItem = append(spec.StrictItem, field)
+		} else {
+			spec.NullableItem = append(spec.NullableItem, field)
 		}
 	}
 

--- a/pine-go/internal/dag/visualize.go
+++ b/pine-go/internal/dag/visualize.go
@@ -211,7 +211,7 @@ func RenderCollapsedMermaid(g *Graph, level int) string {
 		if group.Group {
 			cls = "subflow"
 		} else if group.OperatorType != "" {
-			cls = group.OperatorType
+			cls = strings.ToLower(group.OperatorType)
 		}
 		fmt.Fprintf(&b, "    %s[\"%s\"]:::%s\n", id, group.Name, cls)
 	}

--- a/pine-go/internal/dag/visualize.go
+++ b/pine-go/internal/dag/visualize.go
@@ -102,8 +102,9 @@ func sanitizeMermaidID(name string) string {
 // Nodes are grouped by truncating their SubFlow path to the first `level`
 // segments (split by "/"). Nodes with empty SubFlow remain independent.
 type collapsedNode struct {
-	Name  string // group key or original node name
-	Group bool   // true if this represents a SubFlow group
+	Name         string // group key or original node name
+	Group        bool   // true if this represents a SubFlow group
+	OperatorType string // non-empty for standalone nodes (preserves type coloring)
 }
 
 type collapsedEdge struct {
@@ -139,7 +140,7 @@ func buildCollapsed(g *Graph, level int) ([]collapsedNode, []collapsedEdge) {
 			if node.SubFlow != "" {
 				groups = append(groups, collapsedNode{Name: collapseKey(node.SubFlow, level), Group: true})
 			} else {
-				groups = append(groups, collapsedNode{Name: node.Name, Group: false})
+				groups = append(groups, collapsedNode{Name: node.Name, Group: false, OperatorType: node.Config.OperatorType})
 			}
 			groupIndex[key] = idx
 			nodeToGroup[node.Index] = idx
@@ -179,6 +180,8 @@ func RenderCollapsedDOT(g *Graph, level int) string {
 		color := "#E0E0E0"
 		if group.Group {
 			color = "#BBDEFB"
+		} else if c, ok := dotColors[types.OperatorType(group.OperatorType)]; ok {
+			color = c
 		}
 		fmt.Fprintf(&b, "    %q [label=%q, fillcolor=%q];\n",
 			fmt.Sprintf("g%d", i), group.Name, color)
@@ -207,6 +210,8 @@ func RenderCollapsedMermaid(g *Graph, level int) string {
 		cls := "standalone"
 		if group.Group {
 			cls = "subflow"
+		} else if group.OperatorType != "" {
+			cls = group.OperatorType
 		}
 		fmt.Fprintf(&b, "    %s[\"%s\"]:::%s\n", id, group.Name, cls)
 	}
@@ -220,6 +225,14 @@ func RenderCollapsedMermaid(g *Graph, level int) string {
 	b.WriteString("\n")
 	b.WriteString("    classDef subflow fill:#BBDEFB,stroke:#1976D2\n")
 	b.WriteString("    classDef standalone fill:#E0E0E0,stroke:#616161\n")
+	for _, opType := range types.AllOperatorTypes {
+		colors, ok := mermaidClasses[opType]
+		if !ok {
+			continue
+		}
+		className := strings.ToLower(string(opType))
+		fmt.Fprintf(&b, "    classDef %s fill:%s,stroke:%s\n", className, colors[0], colors[1])
+	}
 
 	return b.String()
 }

--- a/pine-go/internal/dataframe/column_frame.go
+++ b/pine-go/internal/dataframe/column_frame.go
@@ -86,7 +86,7 @@ func (f *ColumnFrame) BuildInput(
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	totalCommon := len(spec.StrictCommon) + len(spec.DefaultedCommon)
+	totalCommon := len(spec.StrictCommon) + len(spec.DefaultedCommon) + len(spec.NullableCommon)
 	cs := make(map[string]any, totalCommon)
 
 	// Strict common fields: must exist and be non-nil
@@ -106,8 +106,16 @@ func (f *ColumnFrame) BuildInput(
 			cs[df.Name] = v
 		}
 	}
+	// Nullable common fields: missing → error, nil → pass through
+	for _, field := range spec.NullableCommon {
+		v, exists := f.common[field]
+		if !exists {
+			return nil, fmt.Errorf("operator %q: required field %q is missing in common", opName, field)
+		}
+		cs[field] = v
+	}
 
-	totalItem := len(spec.StrictItem) + len(spec.DefaultedItem)
+	totalItem := len(spec.StrictItem) + len(spec.DefaultedItem) + len(spec.NullableItem)
 	its := make([]map[string]any, f.rowCount)
 	for i := 0; i < f.rowCount; i++ {
 		row := make(map[string]any, totalItem)
@@ -128,6 +136,14 @@ func (f *ColumnFrame) BuildInput(
 			} else {
 				row[df.Name] = df.Default
 			}
+		}
+		// Nullable item fields: missing → error, nil → pass through
+		for _, field := range spec.NullableItem {
+			col, colExists := f.columns[field]
+			if !colExists || !f.present[field][i] {
+				return nil, fmt.Errorf("operator %q: required field %q is missing on item[%d]", opName, field, i)
+			}
+			row[field] = col[i]
 		}
 
 		its[i] = row

--- a/pine-go/internal/dataframe/row_frame.go
+++ b/pine-go/internal/dataframe/row_frame.go
@@ -71,7 +71,7 @@ func (f *RowFrame) BuildInput(
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	totalCommon := len(spec.StrictCommon) + len(spec.DefaultedCommon)
+	totalCommon := len(spec.StrictCommon) + len(spec.DefaultedCommon) + len(spec.NullableCommon)
 	cs := make(map[string]any, totalCommon)
 
 	for _, field := range spec.StrictCommon {
@@ -89,8 +89,15 @@ func (f *RowFrame) BuildInput(
 			cs[df.Name] = v
 		}
 	}
+	for _, field := range spec.NullableCommon {
+		v, exists := f.common[field]
+		if !exists {
+			return nil, fmt.Errorf("operator %q: required field %q is missing in common", opName, field)
+		}
+		cs[field] = v
+	}
 
-	totalItem := len(spec.StrictItem) + len(spec.DefaultedItem)
+	totalItem := len(spec.StrictItem) + len(spec.DefaultedItem) + len(spec.NullableItem)
 	its := make([]map[string]any, len(f.items))
 	for i, item := range f.items {
 		row := make(map[string]any, totalItem)
@@ -109,6 +116,13 @@ func (f *RowFrame) BuildInput(
 			} else {
 				row[df.Name] = v
 			}
+		}
+		for _, field := range spec.NullableItem {
+			v, exists := item[field]
+			if !exists {
+				return nil, fmt.Errorf("operator %q: required field %q is missing on item[%d]", opName, field, i)
+			}
+			row[field] = v
 		}
 
 		its[i] = row

--- a/pine-go/internal/registry/registry.go
+++ b/pine-go/internal/registry/registry.go
@@ -21,6 +21,8 @@ var reservedKeys = map[string]struct{}{
 	"additive_writes_row_set": {},
 	"common_defaults":        {},
 	"item_defaults":          {},
+	"nullable_common":        {},
+	"nullable_item":          {},
 	"for_branch_control":     {},
 	"data_parallel":          {},
 }

--- a/pine-go/internal/registry/registry.go
+++ b/pine-go/internal/registry/registry.go
@@ -21,8 +21,8 @@ var reservedKeys = map[string]struct{}{
 	"additive_writes_row_set": {},
 	"common_defaults":        {},
 	"item_defaults":          {},
-	"nullable_common":        {},
-	"nullable_item":          {},
+	"strict_common":          {},
+	"strict_item":            {},
 	"for_branch_control":     {},
 	"data_parallel":          {},
 }

--- a/pine-go/internal/runtime/engine_metrics.go
+++ b/pine-go/internal/runtime/engine_metrics.go
@@ -81,7 +81,7 @@ func NewEngineMetrics(p metrics.Provider) *EngineMetrics {
 				Name: "pine_dag_operators_executed",
 				Help: "Number of operators executed (not skipped or cancelled) per DAG run.",
 			},
-			Buckets: []float64{1, 5, 10, 20, 50, 100, 200},
+			Buckets: []float64{1, 2, 5, 10, 15, 20, 25, 30, 40, 50, 75, 100, 150, 200, 300, 450},
 		}),
 	}
 }

--- a/pine-go/internal/runtime/parallel_test.go
+++ b/pine-go/internal/runtime/parallel_test.go
@@ -302,7 +302,7 @@ func TestRunDataParallelTransform(t *testing.T) {
 			OperatorType: "Transform",
 			DataParallel: 3,
 			Meta:         config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}},
-			InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}}, nil, nil, nil),
+			InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}}, nil, nil, nil, nil, nil),
 		},
 	}
 
@@ -339,7 +339,7 @@ func TestRunDataParallelWarning(t *testing.T) {
 			OperatorType: "Transform",
 			DataParallel: 3,
 			Meta:         config.Metadata{ItemInput: []string{"id"}, ItemOutput: []string{"seen"}},
-			InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"id"}, ItemOutput: []string{"seen"}}, nil, nil, nil),
+			InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"id"}, ItemOutput: []string{"seen"}}, nil, nil, nil, nil, nil),
 		},
 	}
 
@@ -404,7 +404,7 @@ func TestDataParallelEquivalence(t *testing.T) {
 			OperatorType: "Transform",
 			DataParallel: 1,
 			Meta:         config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}},
-			InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}}, nil, nil, nil),
+			InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}}, nil, nil, nil, nil, nil),
 		},
 	}
 
@@ -430,7 +430,7 @@ func TestDataParallelEquivalence(t *testing.T) {
 					OperatorType: "Transform",
 					DataParallel: shards,
 					Meta:         config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}},
-					InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}}, nil, nil, nil),
+					InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}}, nil, nil, nil, nil, nil),
 				},
 			}
 
@@ -480,7 +480,7 @@ func FuzzDataParallelEquivalence(f *testing.F) {
 					OperatorType: "Transform",
 					DataParallel: 1,
 					Meta:         config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}},
-					InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}}, nil, nil, nil),
+					InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}}, nil, nil, nil, nil, nil),
 				},
 			},
 		})
@@ -498,7 +498,7 @@ func FuzzDataParallelEquivalence(f *testing.F) {
 					OperatorType: "Transform",
 					DataParallel: shards,
 					Meta:         config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}},
-					InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}}, nil, nil, nil),
+					InputSpec:    config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"doubled"}}, nil, nil, nil, nil, nil),
 				},
 			},
 		})

--- a/pine-go/internal/runtime/scheduler.go
+++ b/pine-go/internal/runtime/scheduler.go
@@ -132,7 +132,7 @@ func Run(ctx context.Context, plan *Plan, frame dataframe.Frame, stats *Stats, e
 
 			// Capture input snapshot for debug operators
 			var inputSnapshot map[string]any
-			if cop.Config.Debug {
+			if cop.Config.Debug != nil && *cop.Config.Debug {
 				inputSnapshot = snapshotInput(input)
 			}
 
@@ -216,7 +216,7 @@ func Run(ctx context.Context, plan *Plan, frame dataframe.Frame, stats *Stats, e
 
 			// Capture output snapshot for debug operators
 			var outputSnapshot map[string]any
-			if cop.Config.Debug {
+			if cop.Config.Debug != nil && *cop.Config.Debug {
 				outputSnapshot = snapshotOutput(output)
 				inputSize := input.ItemCount()
 				outputSize := inputSize + len(output.GetAddedItems()) - len(output.GetRemovedItems())

--- a/pine-go/internal/runtime/scheduler_test.go
+++ b/pine-go/internal/runtime/scheduler_test.go
@@ -194,7 +194,7 @@ func TestRunSimpleChain(t *testing.T) {
 		Config: config.OperatorConfig{
 			TypeName:  "rw",
 			Meta:      config.Metadata{CommonInput: []string{"x"}, CommonOutput: []string{"y"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"x"}, CommonOutput: []string{"y"}}, nil, nil, nil),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"x"}, CommonOutput: []string{"y"}}, nil, nil, nil, nil, nil),
 		},
 	}
 
@@ -289,7 +289,7 @@ func TestRunSkipTrue(t *testing.T) {
 			TypeName:  "set",
 			Meta:      config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"executed"}},
 			Skip:      []string{"_if_1"},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"executed"}}, nil, nil, []string{"_if_1"}),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"executed"}}, nil, nil, nil, nil, []string{"_if_1"}),
 		},
 	}
 
@@ -338,7 +338,7 @@ func TestRunSkipFalse(t *testing.T) {
 			TypeName:  "set",
 			Meta:      config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"executed"}},
 			Skip:      []string{"_if_1"},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"executed"}}, nil, nil, []string{"_if_1"}),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"executed"}}, nil, nil, nil, nil, []string{"_if_1"}),
 		},
 	}
 
@@ -372,7 +372,7 @@ func TestRunSkipMultiple(t *testing.T) {
 		Config: config.OperatorConfig{
 			TypeName:  "set",
 			Meta:      config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"_if_2"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"_if_2"}}, nil, nil, nil),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"_if_2"}}, nil, nil, nil, nil, nil),
 		},
 	}
 	branch := &CompiledOperator{
@@ -382,7 +382,7 @@ func TestRunSkipMultiple(t *testing.T) {
 			TypeName:  "set",
 			Meta:      config.Metadata{CommonInput: []string{"_if_1", "_if_2"}, CommonOutput: []string{"executed"}},
 			Skip:      []string{"_if_1", "_if_2"},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1", "_if_2"}, CommonOutput: []string{"executed"}}, nil, nil, []string{"_if_1", "_if_2"}),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1", "_if_2"}, CommonOutput: []string{"executed"}}, nil, nil, nil, nil, []string{"_if_1", "_if_2"}),
 		},
 	}
 
@@ -428,7 +428,7 @@ func TestRunFatalError(t *testing.T) {
 		Config: config.OperatorConfig{
 			TypeName:  "set",
 			Meta:      config.Metadata{CommonInput: []string{"x"}, CommonOutput: []string{"y"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"x"}, CommonOutput: []string{"y"}}, nil, nil, nil),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"x"}, CommonOutput: []string{"y"}}, nil, nil, nil, nil, nil),
 		},
 	}
 
@@ -470,7 +470,7 @@ func TestRunApplyOutputErrorRecordsErrorStats(t *testing.T) {
 		Config: config.OperatorConfig{
 			TypeName:  "filter",
 			Meta:      config.Metadata{ItemInput: []string{"remove"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"remove"}}, nil, nil, nil),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"remove"}}, nil, nil, nil, nil, nil),
 		},
 	}
 	plan := buildPlan(t, []string{"bad_apply"}, map[string]*CompiledOperator{
@@ -513,7 +513,7 @@ func TestRunSkipFieldFilteredFromInput(t *testing.T) {
 			TypeName:  "capture",
 			Skip:      []string{"_if_1"},
 			Meta:      config.Metadata{CommonInput: []string{"_if_1", "user_id"}, CommonOutput: []string{"captured"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1", "user_id"}, CommonOutput: []string{"captured"}}, nil, nil, []string{"_if_1"}),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1", "user_id"}, CommonOutput: []string{"captured"}}, nil, nil, nil, nil, []string{"_if_1"}),
 		},
 	}
 
@@ -570,7 +570,7 @@ func TestRunSkipMultipleAllFalse(t *testing.T) {
 		Config: config.OperatorConfig{
 			TypeName:  "set",
 			Meta:      config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"_if_2"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"_if_2"}}, nil, nil, nil),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"_if_2"}}, nil, nil, nil, nil, nil),
 		},
 	}
 	branch := &CompiledOperator{
@@ -580,7 +580,7 @@ func TestRunSkipMultipleAllFalse(t *testing.T) {
 			TypeName:  "set",
 			Meta:      config.Metadata{CommonInput: []string{"_if_1", "_if_2"}, CommonOutput: []string{"executed"}},
 			Skip:      []string{"_if_1", "_if_2"},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1", "_if_2"}, CommonOutput: []string{"executed"}}, nil, nil, []string{"_if_1", "_if_2"}),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1", "_if_2"}, CommonOutput: []string{"executed"}}, nil, nil, nil, nil, []string{"_if_1", "_if_2"}),
 		},
 	}
 
@@ -630,7 +630,7 @@ func TestRunSkipMultipleFieldsFilteredFromInput(t *testing.T) {
 			ForBranchControl: true,
 			Meta:             config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"_if_2"}},
 			Skip:             []string{"_if_1"},
-			InputSpec:        config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"_if_2"}}, nil, nil, []string{"_if_1"}),
+			InputSpec:        config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1"}, CommonOutput: []string{"_if_2"}}, nil, nil, nil, nil, []string{"_if_1"}),
 		},
 	}
 	capture := &captureKeysOp{}
@@ -641,7 +641,7 @@ func TestRunSkipMultipleFieldsFilteredFromInput(t *testing.T) {
 			TypeName:  "capture",
 			Skip:      []string{"_if_1", "_if_2"},
 			Meta:      config.Metadata{CommonInput: []string{"_if_1", "_if_2", "user_id"}, CommonOutput: []string{"captured"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1", "_if_2", "user_id"}, CommonOutput: []string{"captured"}}, nil, nil, []string{"_if_1", "_if_2"}),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"_if_1", "_if_2", "user_id"}, CommonOutput: []string{"captured"}}, nil, nil, nil, nil, []string{"_if_1", "_if_2"}),
 		},
 	}
 
@@ -716,7 +716,7 @@ func TestRunWarningContinues(t *testing.T) {
 		Config: config.OperatorConfig{
 			TypeName:  "set",
 			Meta:      config.Metadata{CommonInput: []string{"fallback"}, CommonOutput: []string{"after_warning"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"fallback"}, CommonOutput: []string{"after_warning"}}, nil, nil, nil),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"fallback"}, CommonOutput: []string{"after_warning"}}, nil, nil, nil, nil, nil),
 		},
 	}
 
@@ -783,7 +783,7 @@ func TestRunFilterRemovesItems(t *testing.T) {
 		Config: config.OperatorConfig{
 			TypeName:  "filter",
 			Meta:      config.Metadata{ItemInput: []string{"id", "remove"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"id", "remove"}}, nil, nil, nil),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"id", "remove"}}, nil, nil, nil, nil, nil),
 		},
 	}
 
@@ -813,7 +813,7 @@ func TestRunReorderReverses(t *testing.T) {
 		Config: config.OperatorConfig{
 			TypeName:  "reorder",
 			Meta:      config.Metadata{ItemInput: []string{"id"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"id"}}, nil, nil, nil),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{ItemInput: []string{"id"}}, nil, nil, nil, nil, nil),
 		},
 	}
 

--- a/pine-go/internal/runtime/stats_test.go
+++ b/pine-go/internal/runtime/stats_test.go
@@ -109,7 +109,7 @@ func TestStatsIntegrationWithRun(t *testing.T) {
 		Config: config.OperatorConfig{
 			TypeName:  "rw",
 			Meta:      config.Metadata{CommonInput: []string{"x"}, CommonOutput: []string{"y"}},
-			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"x"}, CommonOutput: []string{"y"}}, nil, nil, nil),
+			InputSpec: config.ComputeInputFieldSpec(config.Metadata{CommonInput: []string{"x"}, CommonOutput: []string{"y"}}, nil, nil, nil, nil, nil),
 		},
 	}
 

--- a/pine-go/pine.go
+++ b/pine-go/pine.go
@@ -111,9 +111,12 @@ func NewEngine(jsonConfig []byte, opts ...Option) (*Engine, error) {
 	compiledOps := make([]*runtime.CompiledOperator, len(sequence))
 	for i, name := range sequence {
 		opCfg := cfg.PipelineConfig.Operators[name]
-		if globalDebug {
-			opCfg.Debug = true
+		// Tri-state debug: op.Debug overrides global when explicitly set
+		effectiveDebug := globalDebug
+		if opCfg.Debug != nil {
+			effectiveDebug = *opCfg.Debug
 		}
+		opCfg.Debug = &effectiveDebug
 		op, schema, err := registry.BuildOperator(opCfg.TypeName, opCfg.RawParams)
 		if err != nil {
 			return nil, err
@@ -164,7 +167,7 @@ func NewEngine(jsonConfig []byte, opts ...Option) (*Engine, error) {
 		}
 		// If the operator wants debug info, provide it
 		if da, ok := op.(types.DebugAware); ok {
-			da.SetDebugInfo(name, opCfg.Debug)
+			da.SetDebugInfo(name, effectiveDebug)
 		}
 		// If the operator records external metrics, inject the provider
 		if ma, ok := op.(types.MetricsAware); ok {

--- a/pine-go/pine.go
+++ b/pine-go/pine.go
@@ -170,7 +170,20 @@ func NewEngine(jsonConfig []byte, opts ...Option) (*Engine, error) {
 		if ma, ok := op.(types.MetricsAware); ok {
 			ma.SetMetricsProvider(mp)
 		}
-		// Pre-compute InputFieldSpec for BuildInput
+		// Pre-compute InputFieldSpec for BuildInput.
+		// Control operators (for_branch_control) treat all common_input as
+		// defaulted-nil so that missing fields evaluate to nil instead of
+		// causing an ExecutionError — the branch condition simply won't match.
+		if opCfg.ForBranchControl {
+			if opCfg.CommonDefaults == nil {
+				opCfg.CommonDefaults = make(map[string]any)
+			}
+			for _, f := range opCfg.Meta.CommonInput {
+				if _, exists := opCfg.CommonDefaults[f]; !exists {
+					opCfg.CommonDefaults[f] = nil
+				}
+			}
+		}
 		opCfg.InputSpec = config.ComputeInputFieldSpec(opCfg.Meta, opCfg.CommonDefaults, opCfg.ItemDefaults, opCfg.Skip)
 		compiledOps[i] = &runtime.CompiledOperator{
 			Name:     name,

--- a/pine-go/pine.go
+++ b/pine-go/pine.go
@@ -174,20 +174,7 @@ func NewEngine(jsonConfig []byte, opts ...Option) (*Engine, error) {
 			ma.SetMetricsProvider(mp)
 		}
 		// Pre-compute InputFieldSpec for BuildInput.
-		// Control operators (for_branch_control) treat all common_input as
-		// defaulted-nil so that missing fields evaluate to nil instead of
-		// causing an ExecutionError — the branch condition simply won't match.
-		if opCfg.ForBranchControl {
-			if opCfg.CommonDefaults == nil {
-				opCfg.CommonDefaults = make(map[string]any)
-			}
-			for _, f := range opCfg.Meta.CommonInput {
-				if _, exists := opCfg.CommonDefaults[f]; !exists {
-					opCfg.CommonDefaults[f] = nil
-				}
-			}
-		}
-		opCfg.InputSpec = config.ComputeInputFieldSpec(opCfg.Meta, opCfg.CommonDefaults, opCfg.ItemDefaults, opCfg.NullableCommon, opCfg.NullableItem, opCfg.Skip)
+		opCfg.InputSpec = config.ComputeInputFieldSpec(opCfg.Meta, opCfg.CommonDefaults, opCfg.ItemDefaults, opCfg.StrictCommon, opCfg.StrictItem, opCfg.Skip)
 		compiledOps[i] = &runtime.CompiledOperator{
 			Name:     name,
 			Instance: op,

--- a/pine-go/pine.go
+++ b/pine-go/pine.go
@@ -187,7 +187,7 @@ func NewEngine(jsonConfig []byte, opts ...Option) (*Engine, error) {
 				}
 			}
 		}
-		opCfg.InputSpec = config.ComputeInputFieldSpec(opCfg.Meta, opCfg.CommonDefaults, opCfg.ItemDefaults, opCfg.Skip)
+		opCfg.InputSpec = config.ComputeInputFieldSpec(opCfg.Meta, opCfg.CommonDefaults, opCfg.ItemDefaults, opCfg.NullableCommon, opCfg.NullableItem, opCfg.Skip)
 		compiledOps[i] = &runtime.CompiledOperator{
 			Name:     name,
 			Instance: op,

--- a/pine-java/checkstyle.xml
+++ b/pine-java/checkstyle.xml
@@ -44,5 +44,6 @@
 
     <module name="NoFinalizer"/>
     <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="OneStatementPerLine"/>
   </module>
 </module>

--- a/pine-java/pom.xml
+++ b/pine-java/pom.xml
@@ -123,7 +123,7 @@
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
-                    <failOnViolation>false</failOnViolation>
+                    <failOnViolation>true</failOnViolation>
                     <violationSeverity>warning</violationSeverity>
                 </configuration>
                 <executions>

--- a/pine-java/src/main/java/page/liam/pine/Codegen.java
+++ b/pine-java/src/main/java/page/liam/pine/Codegen.java
@@ -231,7 +231,10 @@ public class Codegen {
         StringBuilder sb = new StringBuilder();
         boolean upper = true;
         for (char c : s.toCharArray()) {
-            if (c == '_') { upper = true; continue; }
+            if (c == '_') {
+                upper = true;
+                continue;
+            }
             if (upper && c >= 'a' && c <= 'z') {
                 sb.append((char)(c - 'a' + 'A'));
                 upper = false;
@@ -276,14 +279,30 @@ public class Codegen {
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
             switch (c) {
-                case '\\': sb.append("\\\\"); break;
-                case '"':  sb.append("\\\""); break;
-                case '\n': sb.append("\\n"); break;
-                case '\r': sb.append("\\r"); break;
-                case '\t': sb.append("\\t"); break;
-                case '\0': sb.append("\\0"); break;
-                case '\b': sb.append("\\b"); break;
-                case '\f': sb.append("\\f"); break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '\0':
+                    sb.append("\\0");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
                 default:
                     if (c < 0x20 || (c >= 0x7f && c <= 0x9f)) {
                         sb.append(String.format("\\u%04x", (int) c));

--- a/pine-java/src/main/java/page/liam/pine/ColumnFrame.java
+++ b/pine-java/src/main/java/page/liam/pine/ColumnFrame.java
@@ -88,6 +88,14 @@ public class ColumnFrame implements Frame {
                     cs.put(df.name, v);
                 }
             }
+            // Nullable common fields: missing -> error, nil -> pass through
+            for (String field : spec.nullableCommon) {
+                if (!common.containsKey(field)) {
+                    throw new PineErrors.OperatorException(
+                            "operator \"" + opName + "\": required field \"" + field + "\" is missing in common");
+                }
+                cs.put(field, common.get(field));
+            }
 
             List<Map<String, Object>> its = new ArrayList<>(rowCount);
             for (int i = 0; i < rowCount; i++) {
@@ -112,6 +120,16 @@ public class ColumnFrame implements Frame {
                     } else {
                         row.put(df.name, df.defaultValue);
                     }
+                }
+                // Nullable item fields: missing -> error, nil -> pass through
+                for (String field : spec.nullableItem) {
+                    Object[] col = columns.get(field);
+                    BitSet bits = presenceByField.get(field);
+                    if (col == null || bits == null || !bits.get(i)) {
+                        throw new PineErrors.OperatorException(
+                                "operator \"" + opName + "\": required field \"" + field + "\" is missing on item[" + i + "]");
+                    }
+                    row.put(field, col[i]);
                 }
 
                 its.add(row);

--- a/pine-java/src/main/java/page/liam/pine/Config.java
+++ b/pine-java/src/main/java/page/liam/pine/Config.java
@@ -311,7 +311,8 @@ public class Config {
         public List<String> skip;
         public boolean recall;
         public List<String> sources;
-        public Boolean debug;        public boolean consumesRowSet;
+        public Boolean debug;
+        public boolean consumesRowSet;
         public boolean mutatesRowSet;
         public boolean additiveWritesRowSet;
         public boolean forBranchControl;

--- a/pine-java/src/main/java/page/liam/pine/Config.java
+++ b/pine-java/src/main/java/page/liam/pine/Config.java
@@ -106,7 +106,7 @@ public class Config {
         OperatorConfig opCfg = new OperatorConfig();
         opCfg.typeName = node.has("type_name") ? node.get("type_name").asText() : "";
         opCfg.recall = node.has("recall") && node.get("recall").asBoolean();
-        opCfg.debug = node.has("debug") && node.get("debug").asBoolean();
+        opCfg.debug = node.has("debug") ? node.get("debug").asBoolean() : null;
         opCfg.consumesRowSet = node.has("consumes_row_set") && node.get("consumes_row_set").asBoolean();
         opCfg.mutatesRowSet = node.has("mutates_row_set") && node.get("mutates_row_set").asBoolean();
         opCfg.additiveWritesRowSet = node.has("additive_writes_row_set") && node.get("additive_writes_row_set").asBoolean();
@@ -303,8 +303,7 @@ public class Config {
         public List<String> skip;
         public boolean recall;
         public List<String> sources;
-        public boolean debug;
-        public boolean consumesRowSet;
+        public Boolean debug;        public boolean consumesRowSet;
         public boolean mutatesRowSet;
         public boolean additiveWritesRowSet;
         public boolean forBranchControl;

--- a/pine-java/src/main/java/page/liam/pine/Config.java
+++ b/pine-java/src/main/java/page/liam/pine/Config.java
@@ -13,7 +13,7 @@ public class Config {
     private static final Set<String> RESERVED_KEYS = new HashSet<>(Arrays.asList(
             "type_name", "$metadata", "$code_info", "skip", "recall", "sources",
             "debug", "consumes_row_set", "mutates_row_set", "additive_writes_row_set",
-            "common_defaults", "item_defaults", "for_branch_control", "data_parallel"
+            "common_defaults", "item_defaults", "strict_common", "strict_item", "for_branch_control", "data_parallel"
     ));
 
     public String pineappleVersion;
@@ -155,6 +155,14 @@ public class Config {
         opCfg.itemDefaults = node.has("item_defaults")
                 ? mapper.convertValue(node.get("item_defaults"), new TypeReference<Map<String, Object>>() {})
                 : Collections.emptyMap();
+
+        // Parse strict_common and strict_item
+        opCfg.strictCommon = node.has("strict_common")
+                ? readStringList(node, "strict_common")
+                : Collections.emptyList();
+        opCfg.strictItem = node.has("strict_item")
+                ? readStringList(node, "strict_item")
+                : Collections.emptyList();
 
         // Extract raw params (non-reserved keys)
         opCfg.rawParams = new LinkedHashMap<>();
@@ -310,6 +318,8 @@ public class Config {
         public int dataParallel = 1;
         public Map<String, Object> commonDefaults = Collections.emptyMap();
         public Map<String, Object> itemDefaults = Collections.emptyMap();
+        public List<String> strictCommon = Collections.emptyList();
+        public List<String> strictItem = Collections.emptyList();
         public Map<String, Object> rawParams;
         public String operatorType; // populated at engine build time
         public InputFieldSpec inputSpec; // pre-computed at engine build time

--- a/pine-java/src/main/java/page/liam/pine/DAGVisualizer.java
+++ b/pine-java/src/main/java/page/liam/pine/DAGVisualizer.java
@@ -136,7 +136,16 @@ public class DAGVisualizer {
 
         for (int i = 0; i < cg.groups.size(); i++) {
             CollapsedNode group = cg.groups.get(i);
-            String color = group.isGroup ? "#BBDEFB" : "#E0E0E0";
+            String color = "#E0E0E0";
+            if (group.isGroup) {
+                color = "#BBDEFB";
+            } else if (group.operatorType != null && !group.operatorType.isEmpty()) {
+                OperatorType resolved = resolveType(group.operatorType);
+                String typeColor = DOT_COLORS.get(resolved);
+                if (typeColor != null) {
+                    color = typeColor;
+                }
+            }
             String id = "g" + i;
             b.append("    ")
              .append(quote(id))
@@ -175,7 +184,12 @@ public class DAGVisualizer {
         for (int i = 0; i < cg.groups.size(); i++) {
             CollapsedNode group = cg.groups.get(i);
             String id = "g" + i;
-            String cls = group.isGroup ? "subflow" : "standalone";
+            String cls = "standalone";
+            if (group.isGroup) {
+                cls = "subflow";
+            } else if (group.operatorType != null && !group.operatorType.isEmpty()) {
+                cls = group.operatorType;
+            }
             b.append("    ")
              .append(id)
              .append("[\"").append(group.name).append("\"]")
@@ -194,6 +208,16 @@ public class DAGVisualizer {
         b.append("\n");
         b.append("    classDef subflow fill:#BBDEFB,stroke:#1976D2\n");
         b.append("    classDef standalone fill:#E0E0E0,stroke:#616161\n");
+        for (OperatorType opType : OperatorType.values()) {
+            String[] colors = MERMAID_CLASSES.get(opType);
+            if (colors != null) {
+                String className = opType.name().toLowerCase();
+                b.append("    classDef ").append(className)
+                 .append(" fill:").append(colors[0])
+                 .append(",stroke:").append(colors[1])
+                 .append("\n");
+            }
+        }
 
         return b.toString();
     }
@@ -271,7 +295,8 @@ public class DAGVisualizer {
                 idx = groups.size();
                 boolean isGroup = node.subFlow != null && !node.subFlow.isEmpty();
                 String name = isGroup ? collapseKey(node.subFlow, level) : node.name;
-                groups.add(new CollapsedNode(name, isGroup));
+                String opType = isGroup ? "" : (node.config != null ? node.config.operatorType : "");
+                groups.add(new CollapsedNode(name, isGroup, opType));
                 groupIndex.put(key, idx);
                 nodeToGroup.put(node.index, idx);
             }
@@ -303,10 +328,12 @@ public class DAGVisualizer {
     private static class CollapsedNode {
         final String name;
         final boolean isGroup;
+        final String operatorType; // non-empty for standalone nodes (preserves type coloring)
 
-        CollapsedNode(String name, boolean isGroup) {
+        CollapsedNode(String name, boolean isGroup, String operatorType) {
             this.name = name;
             this.isGroup = isGroup;
+            this.operatorType = operatorType;
         }
     }
 

--- a/pine-java/src/main/java/page/liam/pine/DataFrame.java
+++ b/pine-java/src/main/java/page/liam/pine/DataFrame.java
@@ -79,6 +79,14 @@ public class DataFrame implements Frame {
                     cs.put(df.name, v);
                 }
             }
+            // Nullable common fields: missing -> error, nil -> pass through
+            for (String field : spec.nullableCommon) {
+                if (!common.containsKey(field)) {
+                    throw new PineErrors.OperatorException(
+                            "operator \"" + opName + "\": required field \"" + field + "\" is missing in common");
+                }
+                cs.put(field, common.get(field));
+            }
 
             List<Map<String, Object>> its = new ArrayList<>(items.size());
             for (int i = 0; i < items.size(); i++) {
@@ -102,6 +110,14 @@ public class DataFrame implements Frame {
                     } else {
                         row.put(df.name, v);
                     }
+                }
+                // Nullable item fields: missing -> error, nil -> pass through
+                for (String field : spec.nullableItem) {
+                    if (!item.containsKey(field)) {
+                        throw new PineErrors.OperatorException(
+                                "operator \"" + opName + "\": required field \"" + field + "\" is missing on item[" + i + "]");
+                    }
+                    row.put(field, item.get(field));
                 }
 
                 its.add(row);

--- a/pine-java/src/main/java/page/liam/pine/Engine.java
+++ b/pine-java/src/main/java/page/liam/pine/Engine.java
@@ -198,7 +198,15 @@ public class Engine {
 
             compiledOps.add(new CompiledOperator(name, op, opCfg, effectiveDebug, effectiveRecall, effectiveDataParallel, effectiveOperatorType));
 
-            // Pre-compute InputFieldSpec for BuildInput
+            // Pre-compute InputFieldSpec for BuildInput.
+            // Control operators treat all common_input as defaulted-nil so that
+            // missing fields evaluate to nil instead of causing ExecutionError.
+            if (opCfg.forBranchControl) {
+                opCfg.commonDefaults = new java.util.HashMap<>(opCfg.commonDefaults);
+                for (String f : opCfg.metadata.commonInput) {
+                    opCfg.commonDefaults.putIfAbsent(f, null);
+                }
+            }
             opCfg.inputSpec = InputFieldSpec.compute(opCfg.metadata, opCfg.commonDefaults, opCfg.itemDefaults, opCfg.skip);
         }
 

--- a/pine-java/src/main/java/page/liam/pine/Engine.java
+++ b/pine-java/src/main/java/page/liam/pine/Engine.java
@@ -120,7 +120,7 @@ public class Engine {
         for (String name : sequence) {
             Config.OperatorConfig opCfg = cfg.pipelineConfig.operators.get(name);
 
-            boolean effectiveDebug = globalDebug || opCfg.debug;
+            boolean effectiveDebug = opCfg.debug != null ? opCfg.debug : globalDebug;
 
             Operator op = Registry.global().buildOperator(opCfg.typeName, opCfg.rawParams);
             OperatorType opType = Registry.global().getType(opCfg.typeName)

--- a/pine-java/src/main/java/page/liam/pine/Engine.java
+++ b/pine-java/src/main/java/page/liam/pine/Engine.java
@@ -199,15 +199,7 @@ public class Engine {
             compiledOps.add(new CompiledOperator(name, op, opCfg, effectiveDebug, effectiveRecall, effectiveDataParallel, effectiveOperatorType));
 
             // Pre-compute InputFieldSpec for BuildInput.
-            // Control operators treat all common_input as defaulted-nil so that
-            // missing fields evaluate to nil instead of causing ExecutionError.
-            if (opCfg.forBranchControl) {
-                opCfg.commonDefaults = new java.util.HashMap<>(opCfg.commonDefaults);
-                for (String f : opCfg.metadata.commonInput) {
-                    opCfg.commonDefaults.putIfAbsent(f, null);
-                }
-            }
-            opCfg.inputSpec = InputFieldSpec.compute(opCfg.metadata, opCfg.commonDefaults, opCfg.itemDefaults, opCfg.skip);
+            opCfg.inputSpec = InputFieldSpec.compute(opCfg.metadata, opCfg.commonDefaults, opCfg.itemDefaults, opCfg.strictCommon, opCfg.strictItem, opCfg.skip);
         }
 
         DAG dag = DAG.build(sequence, cfg.pipelineConfig.operators, opToSubFlow);

--- a/pine-java/src/main/java/page/liam/pine/EngineMetrics.java
+++ b/pine-java/src/main/java/page/liam/pine/EngineMetrics.java
@@ -27,7 +27,7 @@ public class EngineMetrics {
         this.dagExecDuration = provider.newHistogram(new HistogramOpts("pine_dag_execution_duration_seconds", "DAG execution duration",
                 new double[]{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0}));
         this.dagOpsExecuted = provider.newHistogram(new HistogramOpts("pine_dag_operators_executed", "Operators executed per DAG run",
-                new double[]{1, 5, 10, 20, 50, 100, 200}));
+                new double[]{1, 2, 5, 10, 15, 20, 25, 30, 40, 50, 75, 100, 150, 200, 300, 450}));
     }
 
     public void preInitOperators(List<String> opNames) {

--- a/pine-java/src/main/java/page/liam/pine/InputFieldSpec.java
+++ b/pine-java/src/main/java/page/liam/pine/InputFieldSpec.java
@@ -3,21 +3,30 @@ package page.liam.pine;
 import java.util.*;
 
 /**
- * Separates input fields into strict (error on nil/missing) and
- * defaulted (substitute default on nil/missing). Computed once at engine build time.
+ * Separates input fields into strict (error on nil/missing),
+ * defaulted (substitute default on nil/missing), and
+ * nullable (missing -> error, explicit nil -> pass through).
+ * Default mode is Nullable. Strict and Defaulted are opt-in.
+ * Computed once at engine build time.
  */
 public class InputFieldSpec {
     public final List<String> strictCommon;
     public final List<DefaultedField> defaultedCommon;
+    public final List<String> nullableCommon;
     public final List<String> strictItem;
     public final List<DefaultedField> defaultedItem;
+    public final List<String> nullableItem;
 
     public InputFieldSpec(List<String> strictCommon, List<DefaultedField> defaultedCommon,
-                          List<String> strictItem, List<DefaultedField> defaultedItem) {
+                          List<String> nullableCommon,
+                          List<String> strictItem, List<DefaultedField> defaultedItem,
+                          List<String> nullableItem) {
         this.strictCommon = strictCommon;
         this.defaultedCommon = defaultedCommon;
+        this.nullableCommon = nullableCommon;
         this.strictItem = strictItem;
         this.defaultedItem = defaultedItem;
+        this.nullableItem = nullableItem;
     }
 
     /**
@@ -34,44 +43,59 @@ public class InputFieldSpec {
     }
 
     /**
-     * Creates the InputFieldSpec from metadata, defaults, and skip fields.
+     * Creates the InputFieldSpec from metadata, defaults, strict lists, and skip fields.
+     * Default mode is Nullable (missing -> error, nil -> pass through).
+     * Strict and Defaulted are opt-in.
      * Fields in the defaults map become "defaulted" (substitute default on nil/missing).
-     * Fields NOT in defaults become "strict" (error on nil/missing).
+     * Fields in the strict list become "strict" (error on nil/missing).
+     * Remaining fields become "nullable" (missing -> error, explicit nil -> pass through).
      */
     public static InputFieldSpec compute(Config.Metadata meta,
                                          Map<String, Object> commonDefaults,
                                          Map<String, Object> itemDefaults,
+                                         List<String> strictCommonList,
+                                         List<String> strictItemList,
                                          List<String> skip) {
         Set<String> skipSet = new HashSet<>(skip);
+        Set<String> strictCommonSet = new HashSet<>(strictCommonList);
+        Set<String> strictItemSet = new HashSet<>(strictItemList);
 
         List<String> strictCommon = new ArrayList<>();
         List<DefaultedField> defaultedCommon = new ArrayList<>();
+        List<String> nullableCommon = new ArrayList<>();
         for (String field : meta.commonInput) {
             if (skipSet.contains(field)) {
                 continue;
             }
             if (commonDefaults.containsKey(field)) {
                 defaultedCommon.add(new DefaultedField(field, commonDefaults.get(field)));
-            } else {
+            } else if (strictCommonSet.contains(field)) {
                 strictCommon.add(field);
+            } else {
+                nullableCommon.add(field);
             }
         }
 
         List<String> strictItem = new ArrayList<>();
         List<DefaultedField> defaultedItem = new ArrayList<>();
+        List<String> nullableItem = new ArrayList<>();
         for (String field : meta.itemInput) {
             if (itemDefaults.containsKey(field)) {
                 defaultedItem.add(new DefaultedField(field, itemDefaults.get(field)));
-            } else {
+            } else if (strictItemSet.contains(field)) {
                 strictItem.add(field);
+            } else {
+                nullableItem.add(field);
             }
         }
 
         return new InputFieldSpec(
                 Collections.unmodifiableList(strictCommon),
                 Collections.unmodifiableList(defaultedCommon),
+                Collections.unmodifiableList(nullableCommon),
                 Collections.unmodifiableList(strictItem),
-                Collections.unmodifiableList(defaultedItem)
+                Collections.unmodifiableList(defaultedItem),
+                Collections.unmodifiableList(nullableItem)
         );
     }
 }

--- a/pine-java/src/main/java/page/liam/pine/operators/TransformRedisGet.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/TransformRedisGet.java
@@ -101,9 +101,15 @@ public class TransformRedisGet extends AbstractOperator implements ConcurrentSaf
         } catch (Exception e) {
             String redisCmd;
             switch (dataType) {
-                case "set": redisCmd = "SMembers"; break;
-                case "list": redisCmd = "LRange"; break;
-                default: redisCmd = "Get"; break;
+                case "set":
+                    redisCmd = "SMembers";
+                    break;
+                case "list":
+                    redisCmd = "LRange";
+                    break;
+                default:
+                    redisCmd = "Get";
+                    break;
             }
             output.setWarning(new PineErrors.OperatorException(
                     "transform_redis_get: " + redisCmd + "(" + key + "): " + e.getMessage(), e));

--- a/pine-python/pine/config.py
+++ b/pine-python/pine/config.py
@@ -10,6 +10,7 @@ RESERVED_KEYS = frozenset({
     "type_name", "$metadata", "$code_info", "skip", "recall", "sources",
     "debug", "consumes_row_set", "mutates_row_set",
     "additive_writes_row_set", "common_defaults", "item_defaults",
+    "strict_common", "strict_item",
     "for_branch_control", "data_parallel",
 })
 
@@ -39,6 +40,8 @@ class OperatorConfig:
     data_parallel: int = 1
     common_defaults: dict[str, Any] = field(default_factory=dict)
     item_defaults: dict[str, Any] = field(default_factory=dict)
+    strict_common: list[str] = field(default_factory=list)
+    strict_item: list[str] = field(default_factory=list)
     raw_params: dict[str, Any] = field(default_factory=dict)
     operator_type: str = ""
     input_spec: InputFieldSpec | None = None
@@ -53,45 +56,67 @@ class DefaultedField:
 
 
 class InputFieldSpec:
-    """Resolved input field specification with defaults and strict fields."""
+    """Resolved input field specification with defaults, strict, and nullable fields."""
 
-    __slots__ = ("strict_common", "defaulted_common", "strict_item", "defaulted_item")
+    __slots__ = (
+        "strict_common", "defaulted_common", "nullable_common",
+        "strict_item", "defaulted_item", "nullable_item",
+    )
 
     def __init__(
         self,
         strict_common: list[str],
         defaulted_common: list[DefaultedField],
+        nullable_common: list[str],
         strict_item: list[str],
         defaulted_item: list[DefaultedField],
+        nullable_item: list[str],
     ):
         self.strict_common = strict_common
         self.defaulted_common = defaulted_common
+        self.nullable_common = nullable_common
         self.strict_item = strict_item
         self.defaulted_item = defaulted_item
+        self.nullable_item = nullable_item
 
     @staticmethod
-    def compute(metadata: "Metadata", common_defaults: dict[str, Any],
-                item_defaults: dict[str, Any], skip: list[str]) -> "InputFieldSpec":
+    def compute(
+        metadata: "Metadata",
+        common_defaults: dict[str, Any],
+        item_defaults: dict[str, Any],
+        strict_common: list[str],
+        strict_item: list[str],
+        skip: list[str],
+    ) -> "InputFieldSpec":
         skip_set = set(skip)
-        strict_common: list[str] = []
-        defaulted_common: list[DefaultedField] = []
+        strict_common_set = set(strict_common)
+        strict_item_set = set(strict_item)
+
+        s_common: list[str] = []
+        d_common: list[DefaultedField] = []
+        n_common: list[str] = []
         for f in metadata.common_input:
             if f in skip_set:
                 continue
             if f in common_defaults:
-                defaulted_common.append(DefaultedField(f, common_defaults[f]))
+                d_common.append(DefaultedField(f, common_defaults[f]))
+            elif f in strict_common_set:
+                s_common.append(f)
             else:
-                strict_common.append(f)
+                n_common.append(f)
 
-        strict_item: list[str] = []
-        defaulted_item: list[DefaultedField] = []
+        s_item: list[str] = []
+        d_item: list[DefaultedField] = []
+        n_item: list[str] = []
         for f in metadata.item_input:
             if f in item_defaults:
-                defaulted_item.append(DefaultedField(f, item_defaults[f]))
+                d_item.append(DefaultedField(f, item_defaults[f]))
+            elif f in strict_item_set:
+                s_item.append(f)
             else:
-                strict_item.append(f)
+                n_item.append(f)
 
-        return InputFieldSpec(strict_common, defaulted_common, strict_item, defaulted_item)
+        return InputFieldSpec(s_common, d_common, n_common, s_item, d_item, n_item)
 
 
 class SubFlowRef:
@@ -264,6 +289,8 @@ def _parse_operator_config(node: dict[str, Any]) -> OperatorConfig:
 
     op_cfg.common_defaults = node.get("common_defaults", {})
     op_cfg.item_defaults = node.get("item_defaults", {})
+    op_cfg.strict_common = node.get("strict_common", [])
+    op_cfg.strict_item = node.get("strict_item", [])
 
     op_cfg.raw_params = {}
     for key, value in node.items():

--- a/pine-python/pine/config.py
+++ b/pine-python/pine/config.py
@@ -31,7 +31,7 @@ class OperatorConfig:
     skip: list[str] = field(default_factory=list)
     recall: bool = False
     sources: list[str] = field(default_factory=list)
-    debug: bool = False
+    debug: bool | None = None
     consumes_row_set: bool = False
     mutates_row_set: bool = False
     additive_writes_row_set: bool = False
@@ -240,7 +240,7 @@ def _parse_operator_config(node: dict[str, Any]) -> OperatorConfig:
     op_cfg = OperatorConfig()
     op_cfg.type_name = node.get("type_name", "")
     op_cfg.recall = node.get("recall", False)
-    op_cfg.debug = node.get("debug", False)
+    op_cfg.debug = node.get("debug") if "debug" in node else None
     op_cfg.consumes_row_set = node.get("consumes_row_set", False)
     op_cfg.mutates_row_set = node.get("mutates_row_set", False)
     op_cfg.additive_writes_row_set = node.get("additive_writes_row_set", False)

--- a/pine-python/pine/engine.py
+++ b/pine-python/pine/engine.py
@@ -230,16 +230,9 @@ class Engine:
                     )
 
             # Pre-compute InputFieldSpec.
-            # Control operators treat all common_input as defaulted-nil so that
-            # missing fields evaluate to None instead of raising ExecutionError.
-            if op_cfg.for_branch_control:
-                if op_cfg.common_defaults is None:
-                    op_cfg.common_defaults = {}
-                for f in op_cfg.metadata.common_input:
-                    if f not in op_cfg.common_defaults:
-                        op_cfg.common_defaults[f] = None
             op_cfg.input_spec = InputFieldSpec.compute(
-                op_cfg.metadata, op_cfg.common_defaults, op_cfg.item_defaults, op_cfg.skip
+                op_cfg.metadata, op_cfg.common_defaults, op_cfg.item_defaults,
+                op_cfg.strict_common, op_cfg.strict_item, op_cfg.skip,
             )
 
             compiled_ops.append(CompiledOperator(

--- a/pine-python/pine/engine.py
+++ b/pine-python/pine/engine.py
@@ -17,6 +17,7 @@ from typing import Any, Self
 from pine.cancellation import CancellationToken
 from pine.config import Config, InputFieldSpec, OperatorConfig
 from pine.dag import DAG
+from pine.engine_metrics import EngineMetrics
 from pine.errors import (
     ConfigError,
     ExecutionError,
@@ -26,6 +27,7 @@ from pine.errors import (
     ValidationError,
 )
 from pine.frame import Frame
+from pine.metrics import Nop as _metrics_nop
 from pine.operator import (
     AdditiveWritesRowSet,
     ConcurrentSafe,
@@ -89,6 +91,7 @@ class Engine:
         metrics_provider: Any | None,
         storage_mode: str,
         stats: _Stats,
+        engine_metrics: EngineMetrics | None = None,
     ):
         self._operators = compiled_operators
         self._dag = dag
@@ -97,6 +100,7 @@ class Engine:
         self._metrics_provider = metrics_provider
         self._storage_mode = storage_mode
         self._stats = stats
+        self._engine_metrics = engine_metrics
         self._pool_size = max((os.cpu_count() or 1) * 2, 4)
 
     # ------------------------------------------------------------------
@@ -269,6 +273,11 @@ class Engine:
         engine_stats = _Stats()
         engine_stats.pre_init_operators([cop.name for cop in compiled_ops])
 
+        # Create engine metrics from the provider (NopProvider if none supplied).
+        provider = metrics_provider if metrics_provider is not None else _metrics_nop()
+        em = EngineMetrics(provider)
+        em.pre_init_operators([cop.name for cop in compiled_ops])
+
         return cls(
             compiled_operators=compiled_ops,
             dag=dag,
@@ -277,6 +286,7 @@ class Engine:
             metrics_provider=metrics_provider,
             storage_mode=cfg.storage_mode,
             stats=engine_stats,
+            engine_metrics=em,
         )
 
     # ------------------------------------------------------------------
@@ -321,7 +331,11 @@ class Engine:
         frame = Frame.create(self._storage_mode, common, items)
         n = len(self._operators)
 
+        dag_start = time.perf_counter()
         self._stats.record_run()
+        em = self._engine_metrics
+        if em is not None:
+            em.scheduler_runs.inc()
 
         # Per-operator futures for DAG-based scheduling
         futures: list[Future[None]] = [Future() for _ in range(n)]
@@ -415,6 +429,8 @@ class Engine:
                     skipped=True,
                 )
                 self._stats.record_skip(cop.name)
+                if em is not None:
+                    em.op_skip_total.with_(cop.name).inc()
                 return
 
             # Build input (uses precomputed InputFieldSpec)
@@ -434,6 +450,8 @@ class Engine:
                 active[0] += 1
                 current = active[0]
             self._stats.record_concurrency(current)
+            if em is not None:
+                em.active_ops.add(1)
 
             # Execute
             output: OperatorOutput | None = None
@@ -454,6 +472,8 @@ class Engine:
             # Decrement active
             with active_lk:
                 active[0] -= 1
+            if em is not None:
+                em.active_ops.add(-1)
 
             # Validate output type constraints
             if exec_err is None and output is not None:
@@ -473,6 +493,9 @@ class Engine:
                     input_snapshot=input_snapshot,
                 )
                 self._stats.record_error(cop.name, duration_ns)
+                if em is not None:
+                    em.op_error_total.with_(cop.name).inc()
+                    em.op_exec_duration.with_(cop.name).observe(duration_ns / 1e9)
                 # Classify error. Preserve the original exception object as
                 # __cause__ so downstream code can walk the chain via
                 # ``err.__cause__`` (mirrors Go errors.As / pine-cpp
@@ -530,6 +553,9 @@ class Engine:
                     output_snapshot=output_snapshot,
                 )
                 self._stats.record_error(cop.name, duration_ns)
+                if em is not None:
+                    em.op_error_total.with_(cop.name).inc()
+                    em.op_exec_duration.with_(cop.name).observe(duration_ns / 1e9)
                 # ExecutionError thrown from apply_output (NaN/Inf validation,
                 # SetItemOrder permutation check) already carries the operator
                 # name and a structured `operator "X": <segment>: <msg>` body
@@ -570,6 +596,9 @@ class Engine:
                 output_snapshot=output_snapshot,
             )
             self._stats.record_exec(cop.name, duration_ns)
+            if em is not None:
+                em.op_exec_total.with_(cop.name).inc()
+                em.op_exec_duration.with_(cop.name).observe(duration_ns / 1e9)
 
         # Submit all operators to thread pool
         with ThreadPoolExecutor(max_workers=self._pool_size) as pool:
@@ -583,6 +612,17 @@ class Engine:
 
         # Collect non-null traces
         trace_list = [t for t in traces if t is not None]
+
+        # Record DAG-level metrics
+        if em is not None:
+            dag_duration = time.perf_counter() - dag_start
+            em.dag_exec_duration.observe(dag_duration)
+            if fatal_error[0] is not None:
+                em.dag_exec_total.with_("error").inc()
+            else:
+                em.dag_exec_total.with_("success").inc()
+            executed = sum(1 for t in trace_list if not t.skipped)
+            em.dag_ops_executed.observe(float(executed))
 
         # Project result
         result_common = frame.to_result_common(self._contract.common_output)

--- a/pine-python/pine/engine.py
+++ b/pine-python/pine/engine.py
@@ -229,7 +229,15 @@ class Engine:
                         f'(type "{op_cfg.type_name}" does not)'
                     )
 
-            # Pre-compute InputFieldSpec
+            # Pre-compute InputFieldSpec.
+            # Control operators treat all common_input as defaulted-nil so that
+            # missing fields evaluate to None instead of raising ExecutionError.
+            if op_cfg.for_branch_control:
+                if op_cfg.common_defaults is None:
+                    op_cfg.common_defaults = {}
+                for f in op_cfg.metadata.common_input:
+                    if f not in op_cfg.common_defaults:
+                        op_cfg.common_defaults[f] = None
             op_cfg.input_spec = InputFieldSpec.compute(
                 op_cfg.metadata, op_cfg.common_defaults, op_cfg.item_defaults, op_cfg.skip
             )

--- a/pine-python/pine/engine.py
+++ b/pine-python/pine/engine.py
@@ -173,7 +173,7 @@ class Engine:
                     f'operator "{name}": Recall type must implement AdditiveWritesRowSet'
                 )
 
-            effective_debug = global_debug or op_cfg.debug
+            effective_debug = op_cfg.debug if op_cfg.debug is not None else global_debug
             effective_recall = op_cfg.recall or op_type == OperatorType.RECALL
 
             # Injection: MetadataAware -> DebugAware -> MetricsAware -> ResourceAware

--- a/pine-python/pine/engine_metrics.py
+++ b/pine-python/pine/engine_metrics.py
@@ -1,0 +1,93 @@
+"""Engine-level metrics mirroring pine-go/internal/runtime/engine_metrics.go.
+
+Created once at Engine.create() time from a metrics.Provider.  All metric
+handles are pre-created so the request hot-path never allocates new handles.
+"""
+from __future__ import annotations
+
+from pine.metrics import (
+    Counter,
+    Gauge,
+    Histogram,
+    HistogramOpts,
+    MetricOpts,
+    Provider,
+)
+
+
+class EngineMetrics:
+    """Pre-created metric handles for the scheduler and per-operator recording."""
+
+    __slots__ = (
+        "scheduler_runs",
+        "active_ops",
+        "op_exec_total",
+        "op_exec_duration",
+        "op_skip_total",
+        "op_error_total",
+        "dag_exec_total",
+        "dag_exec_duration",
+        "dag_ops_executed",
+    )
+
+    def __init__(self, provider: Provider) -> None:
+        op_labels = ("operator",)
+
+        self.scheduler_runs: Counter = provider.new_counter(MetricOpts(
+            name="pine_scheduler_runs_total",
+            help="Total number of DAG scheduler runs.",
+        ))
+        self.active_ops: Gauge = provider.new_gauge(MetricOpts(
+            name="pine_operator_active",
+            help="Number of operators currently executing.",
+        ))
+        self.op_exec_total: Counter = provider.new_counter(MetricOpts(
+            name="pine_operator_exec_total",
+            help="Total successful operator executions.",
+            label_names=op_labels,
+        ))
+        self.op_exec_duration: Histogram = provider.new_histogram(HistogramOpts(
+            name="pine_operator_exec_duration_seconds",
+            help="Operator execution duration in seconds.",
+            buckets=(0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0),
+            label_names=op_labels,
+        ))
+        self.op_skip_total: Counter = provider.new_counter(MetricOpts(
+            name="pine_operator_skip_total",
+            help="Total skipped operator executions.",
+            label_names=op_labels,
+        ))
+        self.op_error_total: Counter = provider.new_counter(MetricOpts(
+            name="pine_operator_error_total",
+            help="Total failed operator executions.",
+            label_names=op_labels,
+        ))
+        self.dag_exec_total: Counter = provider.new_counter(MetricOpts(
+            name="pine_dag_executions_total",
+            help="Total DAG executions.",
+            label_names=("status",),
+        ))
+        self.dag_exec_duration: Histogram = provider.new_histogram(HistogramOpts(
+            name="pine_dag_execution_duration_seconds",
+            help="DAG execution duration in seconds.",
+            buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+        ))
+        self.dag_ops_executed: Histogram = provider.new_histogram(HistogramOpts(
+            name="pine_dag_operators_executed",
+            help="Number of operators executed (not skipped or cancelled) per DAG run.",
+            buckets=(1, 2, 5, 10, 15, 20, 25, 30, 40, 50, 75, 100, 150, 200, 300, 450),
+        ))
+
+    def pre_init_operators(self, op_names: list[str]) -> None:
+        """Pre-initialize labeled time series for all known operators.
+
+        Ensures metrics backends (e.g. Prometheus) expose them from startup
+        with zero values, rather than only after the first observation.
+        """
+        for name in op_names:
+            self.op_exec_total.with_(name)
+            self.op_exec_duration.with_(name)
+            self.op_skip_total.with_(name)
+            self.op_error_total.with_(name)
+        self.dag_exec_total.with_("success")
+        self.dag_exec_total.with_("error")

--- a/pine-python/pine/frame.py
+++ b/pine-python/pine/frame.py
@@ -115,6 +115,14 @@ class ColumnFrame(Frame):
                     common_snapshot[df.name] = self._common[df.name]
                 else:
                     common_snapshot[df.name] = df.default
+            # Nullable common fields: missing → error, nil → pass through
+            for field in spec.nullable_common:
+                if field not in self._common:
+                    raise ExecutionError(
+                        op_name,
+                        f'required field "{field}" is missing in common',
+                    )
+                common_snapshot[field] = self._common[field]
 
             items_snapshot: list[dict[str, Any]] = []
             for i in range(self._row_count):
@@ -139,6 +147,16 @@ class ColumnFrame(Frame):
                         row[df.name] = col[i]
                     else:
                         row[df.name] = df.default
+                # Nullable item fields: !present → error, present && nil → pass through
+                for field in spec.nullable_item:
+                    col = self._columns.get(field)
+                    pres = self._presence.get(field)
+                    if col is None or pres is None or not pres[i]:
+                        raise ExecutionError(
+                            op_name,
+                            f'required field "{field}" is missing on item[{i}]',
+                        )
+                    row[field] = col[i]
 
                 items_snapshot.append(row)
 
@@ -345,6 +363,13 @@ class RowFrame(Frame):
                     common_snapshot[df.name] = self._common[df.name]
                 else:
                     common_snapshot[df.name] = df.default
+            for field in spec.nullable_common:
+                if field not in self._common:
+                    raise ExecutionError(
+                        op_name,
+                        f'required field "{field}" is missing in common',
+                    )
+                common_snapshot[field] = self._common[field]
 
             items_snapshot: list[dict[str, Any]] = []
             for i, row in enumerate(self._items):
@@ -362,6 +387,13 @@ class RowFrame(Frame):
                         snap[df.name] = row[df.name]
                     else:
                         snap[df.name] = df.default
+                for field in spec.nullable_item:
+                    if field not in row:
+                        raise ExecutionError(
+                            op_name,
+                            f'required field "{field}" is missing on item[{i}]',
+                        )
+                    snap[field] = row[field]
                 items_snapshot.append(snap)
 
             return OperatorInput(common_snapshot, items_snapshot)

--- a/pine-python/pine/visualize.py
+++ b/pine-python/pine/visualize.py
@@ -82,6 +82,7 @@ class _CollapsedGroup:
     key: str
     label: str
     is_subflow: bool
+    operator_type: str = ""  # non-empty for standalone nodes (preserves type coloring)
     node_indices: list[int] = field(default_factory=list)
 
 
@@ -107,6 +108,7 @@ def _build_collapsed(dag: DAG, level: int) -> tuple[list[_CollapsedGroup], list[
                 key=f"_standalone_{node.index}",
                 label=node.name,
                 is_subflow=False,
+                operator_type=node.config.operator_type,
                 node_indices=[node.index],
             ))
             node_to_group.append(gidx)
@@ -150,7 +152,11 @@ def render_collapsed_dot(dag: DAG, level: int) -> str:
     lines.append("")
 
     for i, group in enumerate(groups):
-        color = "#BBDEFB" if group.is_subflow else "#E0E0E0"
+        color = "#E0E0E0"
+        if group.is_subflow:
+            color = "#BBDEFB"
+        elif group.operator_type:
+            color = _DOT_FILL_COLORS.get(group.operator_type, "#E0E0E0")
         lines.append(f'    "g{i}" [label="{group.label}", fillcolor="{color}"];')
 
     lines.append("")
@@ -169,7 +175,11 @@ def render_collapsed_mermaid(dag: DAG, level: int) -> str:
     lines.append("graph TB")
 
     for i, group in enumerate(groups):
-        cls = "subflow" if group.is_subflow else "standalone"
+        cls = "standalone"
+        if group.is_subflow:
+            cls = "subflow"
+        elif group.operator_type:
+            cls = group.operator_type
         lines.append(f'    g{i}["{group.label}"]:::{cls}')
 
     lines.append("")
@@ -180,5 +190,7 @@ def render_collapsed_mermaid(dag: DAG, level: int) -> str:
     lines.append("")
     lines.append("    classDef subflow fill:#BBDEFB,stroke:#1976D2")
     lines.append("    classDef standalone fill:#E0E0E0,stroke:#616161")
+    for cd in _MERMAID_CLASS_DEFS:
+        lines.append(f"    {cd}")
 
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary

Systematically resolves all 9 open issues (#30–#38) plus 2 newly discovered gaps, totaling 11 items across 34 commits.

### P1 — Runtime correctness

- **#38** SubFlow if/else Lua evaluate references short control-field name — `_rename_field` now also replaces Lua variable references using `_G["namespaced_field"]` syntax (Lua 5.1 compatible)
- **#30** if\_/else\_if\_ control operators should not strict-validate common\_input — superseded by #32's Nullable-default semantics

### P2 — Design improvements

- **#33** Per-operator debug override with tri-state inheritance — `OperatorConfig.Debug` changed from `bool` to nullable (`*bool` / `Boolean` / `Optional[bool]` / `std::optional<bool>`); explicit op-level setting overrides global, unset inherits
- **#32** Default Nullable field mode with opt-in Strict — `InputFieldSpec` default changes from Strict (nil→error) to Nullable (missing→error, nil→pass-through); new `strict_common`/`strict_item` JSON fields for opt-in strict; `common_defaults`/`item_defaults` unchanged
- **#31** Apple DSL `unique_name()` excludes `code_info` from hash — uses explicit semantic tuple, file moves no longer change operator names
- **#37** SubFlow input/output contract declaration — `SubFlow.__init__` accepts optional `common_input`/`common_output`/`item_input`/`item_output`/`required_resources`; `compile()` validates `required_resources` against parent Flow

### P3 — Lower priority

- **#36** Collapsed DAG view preserves operator-type coloring for standalone nodes — all four runtimes synced
- **#35** Refine `pine_dag_operators_executed` histogram buckets — 7→16 buckets across Go/Java/C++
- **#34** Already fixed (Python cause chain) — close only

### Newly discovered & fixed

- **NEW-1** pine-python was missing engine-level histograms (`pine_dag_operators_executed` etc.) — added `EngineMetrics` class mirroring Go/Java/C++
- **NEW-2** #36 collapsed DAG coloring was Go-only — synced to Java/Python/C++; also fixed Go mermaid class names to use lowercase

### Additional bug found during testing

- `_ENV` → `_G` fix in `apple/compiler.py` — `_ENV` is Lua 5.2+, all pineapple runtimes use Lua 5.1

## Commit structure (34 commits)

All commits are strictly single-domain (one language per commit).

| Domain | Commits | Scope |
|--------|---------|-------|
| apple | 5 | SubFlow Lua fix, `_G` fix, unique\_name, SubFlow contract, lint |
| pine-go | 7 | #30 defaulted-nil, #33 tri-state, #35 histogram, #36 coloring, #32 Nullable |
| pine-java | 5 | #30, #33, #35, #32, #36 |
| pine-python | 5 | #30, #33, #32, #36, EngineMetrics |
| pine-cpp | 5 | #30, #33, #35, #32, #36, has\_common fix |
| fixtures | 4 | control\_op\_nil, nullable modes, subflow\_if\_else |
| test | 1 | unique\_name + SubFlow contract tests |

## Test plan

- [x] Python lint (ruff): 0 errors
- [x] Apple DSL tests: 133/133
- [x] Pine-Python tests: 90/90
- [x] Go lint (golangci-lint): 0 issues
- [x] Go tests: all pass
- [x] Java tests: 179/179
- [x] C++ build (-Werror): pass
- [x] C++ tests (doctest): 145/145
- [x] Cross-validate execution parity: 89/89 × 3 (J/P/C)
- [x] Cross-validate render-dag: 184/184 × 3
- [x] Cross-validate error/server/metrics/etc: all pass

Closes #30, closes #31, closes #32, closes #33, closes #34, closes #35, closes #36, closes #37, closes #38