### PR TITLE
chore: clang-format + extend pre-push lint to all modules

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,7 +15,7 @@ fi
 errors=""
 
 # Python lint — apple
-if [ -d "apple" ]; then
+if [ -d "apple" ] && command -v ruff &>/dev/null; then
   py_out=$(ruff check apple/ 2>&1)
   if [ $? -ne 0 ]; then
     errors+="=== ruff check apple/ ===\n${py_out}\n\n"
@@ -23,7 +23,7 @@ if [ -d "apple" ]; then
 fi
 
 # Python lint — pine-python
-if [ -d "pine-python" ]; then
+if [ -d "pine-python" ] && command -v ruff &>/dev/null; then
   pyp_out=$(ruff check pine-python/ 2>&1)
   if [ $? -ne 0 ]; then
     errors+="=== ruff check pine-python/ ===\n${pyp_out}\n\n"
@@ -31,7 +31,7 @@ if [ -d "pine-python" ]; then
 fi
 
 # Go lint
-if [ -f "pine-go/go.mod" ]; then
+if [ -f "pine-go/go.mod" ] && command -v golangci-lint &>/dev/null; then
   go_out=$(cd pine-go && golangci-lint run ./... 2>&1)
   if [ $? -ne 0 ]; then
     errors+="=== golangci-lint run ./... ===\n${go_out}\n\n"
@@ -39,7 +39,7 @@ if [ -f "pine-go/go.mod" ]; then
 fi
 
 # Java lint
-if [ -f "pine-java/pom.xml" ]; then
+if [ -f "pine-java/pom.xml" ] && command -v mvn &>/dev/null; then
   java_out=$(cd pine-java && mvn checkstyle:check -B -q 2>&1)
   if [ $? -ne 0 ]; then
     errors+="=== mvn checkstyle:check ===\n${java_out}\n\n"
@@ -48,8 +48,9 @@ fi
 
 # C++ format
 if [ -d "pine-cpp" ] && command -v clang-format &>/dev/null; then
-  cpp_out=$(find pine-cpp -type f \( -name '*.cpp' -o -name '*.hpp' \) -not -path '*/build*' \
-    | xargs clang-format --dry-run --Werror 2>&1)
+  cpp_out=$(find pine-cpp -type d \( -name 'build' -o -name 'build-*' \) -prune \
+    -o -type f \( -name '*.cpp' -o -name '*.hpp' \) -print0 \
+    | xargs -0 clang-format --dry-run --Werror 2>&1)
   if [ $? -ne 0 ]; then
     errors+="=== clang-format ===\n${cpp_out}\n\n"
   fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,11 +14,19 @@ fi
 
 errors=""
 
-# Python lint
+# Python lint — apple
 if [ -d "apple" ]; then
   py_out=$(ruff check apple/ 2>&1)
   if [ $? -ne 0 ]; then
     errors+="=== ruff check apple/ ===\n${py_out}\n\n"
+  fi
+fi
+
+# Python lint — pine-python
+if [ -d "pine-python" ]; then
+  pyp_out=$(ruff check pine-python/ 2>&1)
+  if [ $? -ne 0 ]; then
+    errors+="=== ruff check pine-python/ ===\n${pyp_out}\n\n"
   fi
 fi
 
@@ -27,6 +35,23 @@ if [ -f "pine-go/go.mod" ]; then
   go_out=$(cd pine-go && golangci-lint run ./... 2>&1)
   if [ $? -ne 0 ]; then
     errors+="=== golangci-lint run ./... ===\n${go_out}\n\n"
+  fi
+fi
+
+# Java lint
+if [ -f "pine-java/pom.xml" ]; then
+  java_out=$(cd pine-java && mvn checkstyle:check -B -q 2>&1)
+  if [ $? -ne 0 ]; then
+    errors+="=== mvn checkstyle:check ===\n${java_out}\n\n"
+  fi
+fi
+
+# C++ format
+if [ -d "pine-cpp" ] && command -v clang-format &>/dev/null; then
+  cpp_out=$(find pine-cpp -type f \( -name '*.cpp' -o -name '*.hpp' \) -not -path '*/build*' \
+    | xargs clang-format --dry-run --Werror 2>&1)
+  if [ $? -ne 0 ]; then
+    errors+="=== clang-format ===\n${cpp_out}\n\n"
   fi
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -60,4 +60,5 @@ if [ -n "$errors" ]; then
   exit 1
 fi
 
+echo "pre-push: all lint checks passed."
 exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ pine-cpp/build-tests/
 pine-cpp/build-werror/
 pine-cpp/build-lint/
 pine-cpp/build/
+.clang-format.preferred

--- a/pine-cpp/.clang-format
+++ b/pine-cpp/.clang-format
@@ -57,7 +57,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat: false
 FixNamespaceComments: true
 ForEachMacros:
@@ -117,7 +117,7 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
-Standard: Auto
+Standard: Latest
 TabWidth: 8
 UseCRLF: false
 UseTab: Never

--- a/pine-cpp/.clang-format
+++ b/pine-cpp/.clang-format
@@ -1,0 +1,123 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+InsertBraces: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+ColumnLimit: 110
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^"pine/'
+    Priority: 1
+    SortPriority: 0
+  - Regex: '^<.*\.h>'
+    Priority: 2
+    SortPriority: 0
+  - Regex: '^<.*'
+    Priority: 3
+    SortPriority: 0
+  - Regex: '.*'
+    Priority: 4
+    SortPriority: 0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard: Auto
+TabWidth: 8
+UseCRLF: false
+UseTab: Never

--- a/pine-cpp/cmd/pineapple-cause-chain-probe/main.cpp
+++ b/pine-cpp/cmd/pineapple-cause-chain-probe/main.cpp
@@ -7,8 +7,8 @@
 //   FAIL:<reason>
 // on stdout. cross-validate Section 15 asserts byte-identical stdout
 // across pine-go / pine-java / pine-python / pine-cpp probes.
-#include "pine/pine.hpp"
 #include "pine/error_chain.hpp"
+#include "pine/pine.hpp"
 
 #include <exception>
 #include <iostream>
@@ -18,28 +18,28 @@
 namespace {
 
 class FakeRedisError : public std::runtime_error {
-public:
-    explicit FakeRedisError(const std::string& key)
-        : std::runtime_error("key=" + key + " not found") {}
+ public:
+  explicit FakeRedisError(const std::string& key) : std::runtime_error("key=" + key + " not found") {
+  }
 };
 
 }  // namespace
 
 int main() {
+  try {
     try {
-        try {
-            throw FakeRedisError("user:42");
-        } catch (...) {
-            std::throw_with_nested(pine::ExecutionError("redis_getter", "lookup failed"));
-        }
-    } catch (const pine::ExecutionError& outer) {
-        if (const FakeRedisError* recovered = pine::error_as<FakeRedisError>(outer)) {
-            std::cout << "PASS:" << recovered->what() << "\n";
-            return 0;
-        }
-        std::cout << "FAIL:pine::error_as did not recover FakeRedisError from ExecutionError chain\n";
-        return 1;
+      throw FakeRedisError("user:42");
+    } catch (...) {
+      std::throw_with_nested(pine::ExecutionError("redis_getter", "lookup failed"));
     }
-    std::cout << "FAIL:ExecutionError was not caught\n";
+  } catch (const pine::ExecutionError& outer) {
+    if (const FakeRedisError* recovered = pine::error_as<FakeRedisError>(outer)) {
+      std::cout << "PASS:" << recovered->what() << "\n";
+      return 0;
+    }
+    std::cout << "FAIL:pine::error_as did not recover FakeRedisError from ExecutionError chain\n";
     return 1;
+  }
+  std::cout << "FAIL:ExecutionError was not caught\n";
+  return 1;
 }

--- a/pine-cpp/cmd/pineapple-codegen/main.cpp
+++ b/pine-cpp/cmd/pineapple-codegen/main.cpp
@@ -5,28 +5,29 @@
 #include <iostream>
 
 int main(int argc, char* argv[]) {
-    std::string schema_path;
+  std::string schema_path;
 
-    for (int i = 1; i < argc; ++i) {
-        if ((std::strcmp(argv[i], "-schema-json") == 0 || std::strcmp(argv[i], "--schema-json") == 0) && i + 1 < argc) {
-            schema_path = argv[++i];
-        }
+  for (int i = 1; i < argc; ++i) {
+    if ((std::strcmp(argv[i], "-schema-json") == 0 || std::strcmp(argv[i], "--schema-json") == 0) &&
+        i + 1 < argc) {
+      schema_path = argv[++i];
     }
+  }
 
-    if (schema_path.empty()) {
-        std::cerr << "Usage: pineapple-codegen -schema-json <path>\n";
-        return 1;
-    }
+  if (schema_path.empty()) {
+    std::cerr << "Usage: pineapple-codegen -schema-json <path>\n";
+    return 1;
+  }
 
-    std::string json = pine::export_schema_json();
+  std::string json = pine::export_schema_json();
 
-    std::ofstream out(schema_path);
-    if (!out) {
-        std::cerr << "Error: cannot open file for writing: " << schema_path << "\n";
-        return 1;
-    }
-    out << json;
-    out.close();
+  std::ofstream out(schema_path);
+  if (!out) {
+    std::cerr << "Error: cannot open file for writing: " << schema_path << "\n";
+    return 1;
+  }
+  out << json;
+  out.close();
 
-    return 0;
+  return 0;
 }

--- a/pine-cpp/cmd/pineapple-render-dag/main.cpp
+++ b/pine-cpp/cmd/pineapple-render-dag/main.cpp
@@ -6,43 +6,47 @@
 #include <string>
 
 int main(int argc, char** argv) {
-    std::string config_path;
-    std::string format = "dot";
-    int collapse = 0;
-    for (int i = 1; i < argc; ++i) {
-        std::string arg = argv[i];
-        if (arg == "-config" && i + 1 < argc) config_path = argv[++i];
-        else if (arg == "-format" && i + 1 < argc) format = argv[++i];
-        else if (arg == "-collapse" && i + 1 < argc) collapse = std::stoi(argv[++i]);
+  std::string config_path;
+  std::string format = "dot";
+  int collapse = 0;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "-config" && i + 1 < argc) {
+      config_path = argv[++i];
+    } else if (arg == "-format" && i + 1 < argc) {
+      format = argv[++i];
+    } else if (arg == "-collapse" && i + 1 < argc) {
+      collapse = std::stoi(argv[++i]);
     }
-    if (config_path.empty()) {
-        std::cerr << "Usage: pineapple-render-dag -config <path> [-format dot|mermaid] [-collapse N]\n";
-        return 1;
-    }
+  }
+  if (config_path.empty()) {
+    std::cerr << "Usage: pineapple-render-dag -config <path> [-format dot|mermaid] [-collapse N]\n";
+    return 1;
+  }
 
-    // Mirrors pine-go cmd/pineapple-dag/main.go: per-phase stderr prefixes.
-    std::ifstream f(config_path);
-    if (!f) {
-        std::cerr << "error reading config: " << config_path << "\n";
-        return 1;
-    }
-    std::ostringstream oss;
-    oss << f.rdbuf();
-    std::string config_data = oss.str();
+  // Mirrors pine-go cmd/pineapple-dag/main.go: per-phase stderr prefixes.
+  std::ifstream f(config_path);
+  if (!f) {
+    std::cerr << "error reading config: " << config_path << "\n";
+    return 1;
+  }
+  std::ostringstream oss;
+  oss << f.rdbuf();
+  std::string config_data = oss.str();
 
-    std::unique_ptr<pine::Engine> engine;
-    try {
-        engine = std::make_unique<pine::Engine>(pine::load_config_from_json(config_data));
-    } catch (const std::exception& err) {
-        std::cerr << "error creating engine: " << err.what() << "\n";
-        return 1;
-    }
+  std::unique_ptr<pine::Engine> engine;
+  try {
+    engine = std::make_unique<pine::Engine>(pine::load_config_from_json(config_data));
+  } catch (const std::exception& err) {
+    std::cerr << "error creating engine: " << err.what() << "\n";
+    return 1;
+  }
 
-    try {
-        std::cout << engine->render_dag(format, collapse);
-        return 0;
-    } catch (const std::exception& err) {
-        std::cerr << "error rendering DAG: " << err.what() << "\n";
-        return 1;
-    }
+  try {
+    std::cout << engine->render_dag(format, collapse);
+    return 0;
+  } catch (const std::exception& err) {
+    std::cerr << "error rendering DAG: " << err.what() << "\n";
+    return 1;
+  }
 }

--- a/pine-cpp/cmd/pineapple-run/main.cpp
+++ b/pine-cpp/cmd/pineapple-run/main.cpp
@@ -10,105 +10,126 @@ namespace {
 
 // Read file contents as a string. Returns true on success.
 bool read_file_to_string(const std::string& path, std::string& out) {
-    std::ifstream f(path);
-    if (!f) return false;
-    std::ostringstream oss;
-    oss << f.rdbuf();
-    out = oss.str();
-    return true;
+  std::ifstream f(path);
+  if (!f) {
+    return false;
+  }
+  std::ostringstream oss;
+  oss << f.rdbuf();
+  out = oss.str();
+  return true;
 }
 
 }  // namespace
 
 int main(int argc, char** argv) {
-    std::string config_path;
-    std::string request_path;
-    std::string resources_path;
-    for (int i = 1; i < argc; ++i) {
-        std::string arg = argv[i];
-        if (arg == "-config" && i + 1 < argc) config_path = argv[++i];
-        else if (arg == "-request" && i + 1 < argc) request_path = argv[++i];
-        else if (arg == "-static-resources" && i + 1 < argc) resources_path = argv[++i];
+  std::string config_path;
+  std::string request_path;
+  std::string resources_path;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "-config" && i + 1 < argc) {
+      config_path = argv[++i];
+    } else if (arg == "-request" && i + 1 < argc) {
+      request_path = argv[++i];
+    } else if (arg == "-static-resources" && i + 1 < argc) {
+      resources_path = argv[++i];
     }
-    if (config_path.empty() || request_path.empty()) {
-        std::cerr << "Usage: pineapple-run -config <pipeline.json> -request <request.json> [-static-resources <resources.json>]\n";
-        return 1;
+  }
+  if (config_path.empty() || request_path.empty()) {
+    std::cerr << "Usage: pineapple-run -config <pipeline.json> -request <request.json> "
+                 "[-static-resources <resources.json>]\n";
+    return 1;
+  }
+
+  // Mirrors pine-go cmd/pineapple-run/main.go: per-phase stderr prefixes.
+  std::string config_data;
+  if (!read_file_to_string(config_path, config_data)) {
+    std::cerr << "error reading config: " << config_path << "\n";
+    return 1;
+  }
+
+  std::string request_data;
+  if (!read_file_to_string(request_path, request_data)) {
+    std::cerr << "error reading request: " << request_path << "\n";
+    return 1;
+  }
+
+  std::unique_ptr<pine::Engine> engine;
+  std::unique_ptr<pine::resource::Manager> resource_manager;
+  try {
+    auto config = pine::load_config_from_json(config_data);
+    engine = std::make_unique<pine::Engine>(config);
+
+    resource_manager = std::make_unique<pine::resource::Manager>();
+    resource_manager->load_from_config(config);
+    resource_manager->start();
+  } catch (const std::exception& err) {
+    std::cerr << "error creating engine: " << err.what() << "\n";
+    return 1;
+  }
+
+  pine::Request request;
+  try {
+    const auto root = pine::parse_json(request_data).as_object();
+    if (auto it = root.find("common"); it != root.end()) {
+      for (const auto& [key, value] : it->second.as_object()) {
+        request.common[key] = value;
+      }
     }
-
-    // Mirrors pine-go cmd/pineapple-run/main.go: per-phase stderr prefixes.
-    std::string config_data;
-    if (!read_file_to_string(config_path, config_data)) {
-        std::cerr << "error reading config: " << config_path << "\n";
-        return 1;
-    }
-
-    std::string request_data;
-    if (!read_file_to_string(request_path, request_data)) {
-        std::cerr << "error reading request: " << request_path << "\n";
-        return 1;
-    }
-
-    std::unique_ptr<pine::Engine> engine;
-    std::unique_ptr<pine::resource::Manager> resource_manager;
-    try {
-        auto config = pine::load_config_from_json(config_data);
-        engine = std::make_unique<pine::Engine>(config);
-
-        resource_manager = std::make_unique<pine::resource::Manager>();
-        resource_manager->load_from_config(config);
-        resource_manager->start();
-    } catch (const std::exception& err) {
-        std::cerr << "error creating engine: " << err.what() << "\n";
-        return 1;
-    }
-
-    pine::Request request;
-    try {
-        const auto root = pine::parse_json(request_data).as_object();
-        if (auto it = root.find("common"); it != root.end()) {
-            for (const auto& [key, value] : it->second.as_object()) request.common[key] = value;
+    if (auto it = root.find("items"); it != root.end()) {
+      for (const auto& item : it->second.as_array()) {
+        std::map<std::string, pine::JsonValue> row;
+        for (const auto& [key, value] : item.as_object()) {
+          row[key] = value;
         }
-        if (auto it = root.find("items"); it != root.end()) {
-            for (const auto& item : it->second.as_array()) {
-                std::map<std::string, pine::JsonValue> row;
-                for (const auto& [key, value] : item.as_object()) row[key] = value;
-                request.items.push_back(std::move(row));
-            }
-        }
-    } catch (const std::exception& err) {
-        std::cerr << "error parsing request: " << err.what() << "\n";
-        return 1;
+        request.items.push_back(std::move(row));
+      }
     }
+  } catch (const std::exception& err) {
+    std::cerr << "error parsing request: " << err.what() << "\n";
+    return 1;
+  }
 
-    std::map<std::string, pine::JsonValue> resources;
+  std::map<std::string, pine::JsonValue> resources;
+  if (resource_manager) {
+    resources = resource_manager->snapshot();
+  }
+
+  if (!resources_path.empty()) {
+    std::string res_data;
+    if (!read_file_to_string(resources_path, res_data)) {
+      std::cerr << "error reading static resources: " << resources_path << "\n";
+      if (resource_manager) {
+        resource_manager->stop();
+      }
+      return 1;
+    }
+    try {
+      auto resources_json = pine::parse_json(res_data);
+      for (const auto& [key, value] : resources_json.as_object()) {
+        resources[key] = value;
+      }
+    } catch (const std::exception& err) {
+      std::cerr << "error parsing static resources: " << err.what() << "\n";
+      if (resource_manager) {
+        resource_manager->stop();
+      }
+      return 1;
+    }
+  }
+
+  try {
+    std::cout << pine::result_to_json(engine->execute(request, resources));
     if (resource_manager) {
-        resources = resource_manager->snapshot();
+      resource_manager->stop();
     }
-
-    if (!resources_path.empty()) {
-        std::string res_data;
-        if (!read_file_to_string(resources_path, res_data)) {
-            std::cerr << "error reading static resources: " << resources_path << "\n";
-            if (resource_manager) resource_manager->stop();
-            return 1;
-        }
-        try {
-            auto resources_json = pine::parse_json(res_data);
-            for (const auto& [key, value] : resources_json.as_object()) resources[key] = value;
-        } catch (const std::exception& err) {
-            std::cerr << "error parsing static resources: " << err.what() << "\n";
-            if (resource_manager) resource_manager->stop();
-            return 1;
-        }
+    return 0;
+  } catch (const std::exception& err) {
+    std::cerr << "execution error: " << err.what() << "\n";
+    if (resource_manager) {
+      resource_manager->stop();
     }
-
-    try {
-        std::cout << pine::result_to_json(engine->execute(request, resources));
-        if (resource_manager) resource_manager->stop();
-        return 0;
-    } catch (const std::exception& err) {
-        std::cerr << "execution error: " << err.what() << "\n";
-        if (resource_manager) resource_manager->stop();
-        return 1;
-    }
+    return 1;
+  }
 }

--- a/pine-cpp/cmd/pineapple-server/main.cpp
+++ b/pine-cpp/cmd/pineapple-server/main.cpp
@@ -1,10 +1,10 @@
-#include "server/server.hpp"
-
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <string>
 #include <string_view>
+
+#include "server/server.hpp"
 
 namespace {
 
@@ -20,97 +20,112 @@ namespace {
 // "30m1h" is rejected. The previous implementation accepted any order
 // and produced silently-different totals from Go for shuffled inputs.
 int parse_duration_seconds(std::string_view s) {
-    if (s.empty()) return -1;
-    int total = 0;
-    int cur = 0;
-    bool has_digit = false;
-    // Encode unit priority: h > m > s; -1 = none seen yet.
-    int last_unit_priority = 4;  // higher than any actual unit
-    for (std::size_t i = 0; i < s.size(); ++i) {
-        char c = s[i];
-        if (c >= '0' && c <= '9') {
-            cur = cur * 10 + (c - '0');
-            has_digit = true;
-            continue;
-        }
-        if (!has_digit) return -1;
-        int priority;
-        int multiplier;
-        if (c == 'h') { priority = 3; multiplier = 3600; }
-        else if (c == 'm' && (i + 1 >= s.size() || s[i + 1] != 's')) {
-            priority = 2; multiplier = 60;
-        } else if (c == 's') { priority = 1; multiplier = 1; }
-        else return -1;
-        if (priority >= last_unit_priority) return -1;  // out-of-order unit
-        last_unit_priority = priority;
-        total += cur * multiplier;
-        cur = 0;
-        has_digit = false;
+  if (s.empty()) {
+    return -1;
+  }
+  int total = 0;
+  int cur = 0;
+  bool has_digit = false;
+  // Encode unit priority: h > m > s; -1 = none seen yet.
+  int last_unit_priority = 4;  // higher than any actual unit
+  for (std::size_t i = 0; i < s.size(); ++i) {
+    char c = s[i];
+    if (c >= '0' && c <= '9') {
+      cur = cur * 10 + (c - '0');
+      has_digit = true;
+      continue;
     }
-    if (has_digit) total += cur;  // trailing bare integer treated as seconds
-    return total;
+    if (!has_digit) {
+      return -1;
+    }
+    int priority;
+    int multiplier;
+    if (c == 'h') {
+      priority = 3;
+      multiplier = 3600;
+    } else if (c == 'm' && (i + 1 >= s.size() || s[i + 1] != 's')) {
+      priority = 2;
+      multiplier = 60;
+    } else if (c == 's') {
+      priority = 1;
+      multiplier = 1;
+    } else {
+      return -1;
+    }
+    if (priority >= last_unit_priority) {
+      return -1;  // out-of-order unit
+    }
+    last_unit_priority = priority;
+    total += cur * multiplier;
+    cur = 0;
+    has_digit = false;
+  }
+  if (has_digit) {
+    total += cur;  // trailing bare integer treated as seconds
+  }
+  return total;
 }
 
 }  // namespace
 
 int main(int argc, char** argv) {
-    pine::server::ServerConfig cfg;
+  pine::server::ServerConfig cfg;
 
-    auto take_value = [&](int& i, const char* name) -> const char* {
-        if (i + 1 >= argc) {
-            fprintf(stderr, "missing value for flag %s\n", name);
-            std::exit(2);
-        }
-        return argv[++i];
-    };
-    auto take_seconds = [&](int& i, const char* name) -> int {
-        const char* raw = take_value(i, name);
-        int s = parse_duration_seconds(raw);
-        if (s < 0) {
-            fprintf(stderr, "invalid duration for %s: %s\n", name, raw);
-            std::exit(2);
-        }
-        return s;
-    };
-
-    for (int i = 1; i < argc; ++i) {
-        std::string arg = argv[i];
-        if (arg == "-config") {
-            cfg.config_path = take_value(i, "-config");
-        } else if (arg == "-addr") {
-            cfg.addr = take_value(i, "-addr");
-        } else if (arg == "-read-header-timeout") {
-            cfg.read_header_timeout_seconds = take_seconds(i, "-read-header-timeout");
-        } else if (arg == "-read-timeout") {
-            cfg.read_timeout_seconds = take_seconds(i, "-read-timeout");
-        } else if (arg == "-write-timeout") {
-            cfg.write_timeout_seconds = take_seconds(i, "-write-timeout");
-        } else if (arg == "-idle-timeout") {
-            cfg.idle_timeout_seconds = take_seconds(i, "-idle-timeout");
-        } else if (arg == "-max-body-size") {
-            // Strict parse — strtoll returns 0 on garbage which
-            // would silently 413 every POST. Require the suffix to be
-            // fully consumed and the value to be positive.
-            const char* raw = take_value(i, "-max-body-size");
-            char* endp = nullptr;
-            long long v = std::strtoll(raw, &endp, 10);
-            if (endp == raw || *endp != '\0' || v <= 0) {
-                fprintf(stderr, "invalid -max-body-size value: %s\n", raw);
-                std::exit(2);
-            }
-            cfg.max_request_body_size = static_cast<int64_t>(v);
-        }
+  auto take_value = [&](int& i, const char* name) -> const char* {
+    if (i + 1 >= argc) {
+      fprintf(stderr, "missing value for flag %s\n", name);
+      std::exit(2);
     }
-
-    if (cfg.config_path.empty()) {
-        fprintf(stderr,
-                "usage: pineapple-server -config <path-to-config.json> "
-                "[-addr :8080] [-read-timeout 30s] [-read-header-timeout 5s] "
-                "[-write-timeout 60s] [-idle-timeout 120s] "
-                "[-max-body-size 10485760]\n");
-        return 1;
+    return argv[++i];
+  };
+  auto take_seconds = [&](int& i, const char* name) -> int {
+    const char* raw = take_value(i, name);
+    int s = parse_duration_seconds(raw);
+    if (s < 0) {
+      fprintf(stderr, "invalid duration for %s: %s\n", name, raw);
+      std::exit(2);
     }
+    return s;
+  };
 
-    pine::server::Server server;
-    return server.run(cfg);
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "-config") {
+      cfg.config_path = take_value(i, "-config");
+    } else if (arg == "-addr") {
+      cfg.addr = take_value(i, "-addr");
+    } else if (arg == "-read-header-timeout") {
+      cfg.read_header_timeout_seconds = take_seconds(i, "-read-header-timeout");
+    } else if (arg == "-read-timeout") {
+      cfg.read_timeout_seconds = take_seconds(i, "-read-timeout");
+    } else if (arg == "-write-timeout") {
+      cfg.write_timeout_seconds = take_seconds(i, "-write-timeout");
+    } else if (arg == "-idle-timeout") {
+      cfg.idle_timeout_seconds = take_seconds(i, "-idle-timeout");
+    } else if (arg == "-max-body-size") {
+      // Strict parse — strtoll returns 0 on garbage which
+      // would silently 413 every POST. Require the suffix to be
+      // fully consumed and the value to be positive.
+      const char* raw = take_value(i, "-max-body-size");
+      char* endp = nullptr;
+      long long v = std::strtoll(raw, &endp, 10);
+      if (endp == raw || *endp != '\0' || v <= 0) {
+        fprintf(stderr, "invalid -max-body-size value: %s\n", raw);
+        std::exit(2);
+      }
+      cfg.max_request_body_size = static_cast<int64_t>(v);
+    }
+  }
+
+  if (cfg.config_path.empty()) {
+    fprintf(stderr,
+            "usage: pineapple-server -config <path-to-config.json> "
+            "[-addr :8080] [-read-timeout 30s] [-read-header-timeout 5s] "
+            "[-write-timeout 60s] [-idle-timeout 120s] "
+            "[-max-body-size 10485760]\n");
+    return 1;
+  }
+
+  pine::server::Server server;
+  return server.run(cfg);
 }

--- a/pine-cpp/include/pine/column.hpp
+++ b/pine-cpp/include/pine/column.hpp
@@ -32,63 +32,74 @@ const char* column_type_name(ColumnType t);
 // write into a typed column) return false; the caller is expected to
 // promote the column to a JsonColumn first via to_json_column().
 class Column {
-public:
-    virtual ~Column() = default;
+ public:
+  virtual ~Column() = default;
 
-    virtual ColumnType type() const = 0;
-    virtual std::size_t size() const = 0;
-    // is_null is the user-facing "value at i is nil" predicate. Returns
-    // true when the slot is ABSENT or when the stored value is JsonValue
-    // null (only possible on JsonColumn).
-    virtual bool is_null(std::size_t i) const = 0;
-    // is_present reflects the raw presence bit: true iff the row
-    // explicitly wrote this field (the written value may itself be null
-    // for JsonColumn).
-    virtual bool is_present(std::size_t i) const = 0;
-    virtual JsonValue get(std::size_t i) const = 0;
+  virtual ColumnType type() const = 0;
+  virtual std::size_t size() const = 0;
+  // is_null is the user-facing "value at i is nil" predicate. Returns
+  // true when the slot is ABSENT or when the stored value is JsonValue
+  // null (only possible on JsonColumn).
+  virtual bool is_null(std::size_t i) const = 0;
+  // is_present reflects the raw presence bit: true iff the row
+  // explicitly wrote this field (the written value may itself be null
+  // for JsonColumn).
+  virtual bool is_present(std::size_t i) const = 0;
+  virtual JsonValue get(std::size_t i) const = 0;
 
-    virtual bool set(std::size_t i, const JsonValue& v) = 0;
-    virtual bool append(const JsonValue& v) = 0;
-    virtual void append_null() = 0;
-    virtual void remove(const std::set<int>& indices) = 0;
-    virtual void reorder(const std::vector<int>& order) = 0;
+  virtual bool set(std::size_t i, const JsonValue& v) = 0;
+  virtual bool append(const JsonValue& v) = 0;
+  virtual void append_null() = 0;
+  virtual void remove(const std::set<int>& indices) = 0;
+  virtual void reorder(const std::vector<int>& order) = 0;
 
-    virtual std::unique_ptr<Column> clone() const = 0;
-    // Materialize this column as an equivalent JsonColumn (used when a
-    // type-incompatible value or a present-null forces promotion).
-    virtual std::unique_ptr<Column> to_json_column() const = 0;
+  virtual std::unique_ptr<Column> clone() const = 0;
+  // Materialize this column as an equivalent JsonColumn (used when a
+  // type-incompatible value or a present-null forces promotion).
+  virtual std::unique_ptr<Column> to_json_column() const = 0;
 };
 
 // TypedColumn<T> stores fixed-width scalar data with a parallel validity
 // bitmap. Specialized for int64_t, double, std::string, bool.
 template <typename T>
 class TypedColumn final : public Column {
-public:
-    TypedColumn() = default;
-    explicit TypedColumn(std::size_t n) : data_(n), validity_(n, false) {}
+ public:
+  TypedColumn() = default;
+  explicit TypedColumn(std::size_t n) : data_(n), validity_(n, false) {
+  }
 
-    ColumnType type() const override;
-    std::size_t size() const override { return data_.size(); }
-    bool is_null(std::size_t i) const override { return i >= validity_.size() || !validity_[i]; }
-    bool is_present(std::size_t i) const override { return i < validity_.size() && validity_[i]; }
-    JsonValue get(std::size_t i) const override;
+  ColumnType type() const override;
+  std::size_t size() const override {
+    return data_.size();
+  }
+  bool is_null(std::size_t i) const override {
+    return i >= validity_.size() || !validity_[i];
+  }
+  bool is_present(std::size_t i) const override {
+    return i < validity_.size() && validity_[i];
+  }
+  JsonValue get(std::size_t i) const override;
 
-    bool set(std::size_t i, const JsonValue& v) override;
-    bool append(const JsonValue& v) override;
-    void append_null() override;
-    void remove(const std::set<int>& indices) override;
-    void reorder(const std::vector<int>& order) override;
+  bool set(std::size_t i, const JsonValue& v) override;
+  bool append(const JsonValue& v) override;
+  void append_null() override;
+  void remove(const std::set<int>& indices) override;
+  void reorder(const std::vector<int>& order) override;
 
-    std::unique_ptr<Column> clone() const override;
-    std::unique_ptr<Column> to_json_column() const override;
+  std::unique_ptr<Column> clone() const override;
+  std::unique_ptr<Column> to_json_column() const override;
 
-    // Direct access for testing / typed paths.
-    const std::vector<T>& data() const { return data_; }
-    const std::vector<bool>& validity() const { return validity_; }
+  // Direct access for testing / typed paths.
+  const std::vector<T>& data() const {
+    return data_;
+  }
+  const std::vector<bool>& validity() const {
+    return validity_;
+  }
 
-private:
-    std::vector<T> data_;
-    std::vector<bool> validity_;
+ private:
+  std::vector<T> data_;
+  std::vector<bool> validity_;
 };
 
 using Int64Column = TypedColumn<int64_t>;
@@ -107,37 +118,44 @@ using BoolColumn = TypedColumn<bool>;
 // natively, so the precision loss is symmetric across runtimes; this helper
 // is the pine-cpp-only seam for diagnosing the boundary.
 constexpr bool int64_lossy_as_double(int64_t v) {
-    constexpr int64_t k = static_cast<int64_t>(1) << 53;
-    return v > k || v < -k;
+  constexpr int64_t k = static_cast<int64_t>(1) << 53;
+  return v > k || v < -k;
 }
 
 // JsonColumn is the heterogeneous fallback: data stored as JsonValue.
 // All set/append operations succeed regardless of value type.
 class JsonColumn final : public Column {
-public:
-    JsonColumn() = default;
-    explicit JsonColumn(std::size_t n) : data_(n), validity_(n, false) {}
+ public:
+  JsonColumn() = default;
+  explicit JsonColumn(std::size_t n) : data_(n), validity_(n, false) {
+  }
 
-    ColumnType type() const override { return ColumnType::Json; }
-    std::size_t size() const override { return data_.size(); }
-    bool is_null(std::size_t i) const override {
-        return i >= validity_.size() || !validity_[i] || data_[i].is_null();
-    }
-    bool is_present(std::size_t i) const override { return i < validity_.size() && validity_[i]; }
-    JsonValue get(std::size_t i) const override;
+  ColumnType type() const override {
+    return ColumnType::Json;
+  }
+  std::size_t size() const override {
+    return data_.size();
+  }
+  bool is_null(std::size_t i) const override {
+    return i >= validity_.size() || !validity_[i] || data_[i].is_null();
+  }
+  bool is_present(std::size_t i) const override {
+    return i < validity_.size() && validity_[i];
+  }
+  JsonValue get(std::size_t i) const override;
 
-    bool set(std::size_t i, const JsonValue& v) override;
-    bool append(const JsonValue& v) override;
-    void append_null() override;
-    void remove(const std::set<int>& indices) override;
-    void reorder(const std::vector<int>& order) override;
+  bool set(std::size_t i, const JsonValue& v) override;
+  bool append(const JsonValue& v) override;
+  void append_null() override;
+  void remove(const std::set<int>& indices) override;
+  void reorder(const std::vector<int>& order) override;
 
-    std::unique_ptr<Column> clone() const override;
-    std::unique_ptr<Column> to_json_column() const override;
+  std::unique_ptr<Column> clone() const override;
+  std::unique_ptr<Column> to_json_column() const override;
 
-private:
-    std::vector<JsonValue> data_;
-    std::vector<bool> validity_;
+ private:
+  std::vector<JsonValue> data_;
+  std::vector<bool> validity_;
 };
 
 // make_column scans `values` and returns the best-fitting Column:

--- a/pine-cpp/include/pine/column_frame.hpp
+++ b/pine-cpp/include/pine/column_frame.hpp
@@ -27,77 +27,76 @@ namespace pine {
 // Implements the Frame interface — Engine selects ColumnFrame or
 // RowFrame based on Config.storage_mode.
 class ColumnFrame : public Frame {
-public:
-    ColumnFrame();
-    ColumnFrame(std::map<std::string, JsonValue> common,
-                std::vector<std::map<std::string, JsonValue>> items);
+ public:
+  ColumnFrame();
+  ColumnFrame(std::map<std::string, JsonValue> common, std::vector<std::map<std::string, JsonValue>> items);
 
-    // Static convenience constructor kept for callers that already know
-    // they want a ColumnFrame window view. parallel_execute uses the
-    // virtual Frame::make_window_view on the parent — this static form
-    // returns a ColumnFrame-typed unique_ptr for tests / legacy code.
-    //
-    // CONTRACT: the caller must keep `parent` alive AND must not mutate
-    // `parent` while any window view exists. parallel_execute satisfies
-    // both: shards execute synchronously between cv-waits on the parent
-    // node, and the parent frame is read-only during the shard window.
-    static std::unique_ptr<ColumnFrame> make_window_view(
-        const ColumnFrame& parent,
-        std::size_t row_offset,
-        std::size_t row_count);
+  // Static convenience constructor kept for callers that already know
+  // they want a ColumnFrame window view. parallel_execute uses the
+  // virtual Frame::make_window_view on the parent — this static form
+  // returns a ColumnFrame-typed unique_ptr for tests / legacy code.
+  //
+  // CONTRACT: the caller must keep `parent` alive AND must not mutate
+  // `parent` while any window view exists. parallel_execute satisfies
+  // both: shards execute synchronously between cv-waits on the parent
+  // node, and the parent frame is read-only during the shard window.
+  static std::unique_ptr<ColumnFrame> make_window_view(const ColumnFrame& parent, std::size_t row_offset,
+                                                       std::size_t row_count);
 
-    // ---- Frame interface ----
-    JsonValue common(const std::string& field) const override;
-    bool has_common(const std::string& field) const override;
-    void set_common(const std::string& field, JsonValue value) override;
-    std::vector<std::string> common_fields() const override;
+  // ---- Frame interface ----
+  JsonValue common(const std::string& field) const override;
+  bool has_common(const std::string& field) const override;
+  void set_common(const std::string& field, JsonValue value) override;
+  std::vector<std::string> common_fields() const override;
 
-    std::size_t item_count() const override;
-    JsonValue item(std::size_t index, const std::string& field) const override;
-    bool item_has(std::size_t index, const std::string& field) const override;
-    std::vector<std::string> item_fields() const override;
+  std::size_t item_count() const override;
+  JsonValue item(std::size_t index, const std::string& field) const override;
+  bool item_has(std::size_t index, const std::string& field) const override;
+  std::vector<std::string> item_fields() const override;
 
-    void set_resources(const std::map<std::string, JsonValue>* res) override { resources_ = res; }
-    const std::map<std::string, JsonValue>* resources() const override { return resources_; }
+  void set_resources(const std::map<std::string, JsonValue>* res) override {
+    resources_ = res;
+  }
+  const std::map<std::string, JsonValue>* resources() const override {
+    return resources_;
+  }
 
-    void push_warning(std::string msg) override;
-    std::vector<std::string> take_warnings() override;
-    const std::vector<std::string>& warnings_ref() const { return warnings_; }
+  void push_warning(std::string msg) override;
+  std::vector<std::string> take_warnings() override;
+  const std::vector<std::string>& warnings_ref() const {
+    return warnings_;
+  }
 
-    void apply_output(const OperatorOutput& out,
-                      const std::string& op_name,
-                      bool is_recall) override;
+  void apply_output(const OperatorOutput& out, const std::string& op_name, bool is_recall) override;
 
-    Result to_result(const std::vector<std::string>& common_out,
-                     const std::vector<std::string>& item_out) const override;
+  Result to_result(const std::vector<std::string>& common_out,
+                   const std::vector<std::string>& item_out) const override;
 
-    JsonValue::object_t item_object(std::size_t index) const override;
+  JsonValue::object_t item_object(std::size_t index) const override;
 
-    std::unique_ptr<Frame> make_window_view(std::size_t row_offset,
-                                             std::size_t row_count) const override;
+  std::unique_ptr<Frame> make_window_view(std::size_t row_offset, std::size_t row_count) const override;
 
-    std::pair<std::string, int> validate_strict_items(
-        const std::vector<std::string>& fields) const override;
+  std::pair<std::string, int> validate_strict_items(const std::vector<std::string>& fields) const override;
 
-private:
-    void write_item_field_locked(std::size_t idx,
-                                 const std::string& field,
-                                 const JsonValue& value);
+ private:
+  void write_item_field_locked(std::size_t idx, const std::string& field, const JsonValue& value);
 
-    mutable std::shared_mutex mu_;
-    std::map<std::string, JsonValue> common_;
-    std::unique_ptr<ColumnStore> items_;
-    std::vector<std::string> warnings_;
-    const std::map<std::string, JsonValue>* resources_ = nullptr;
+  mutable std::shared_mutex mu_;
+  std::map<std::string, JsonValue> common_;
+  std::unique_ptr<ColumnStore> items_;
+  std::vector<std::string> warnings_;
+  const std::map<std::string, JsonValue>* resources_ = nullptr;
 
-    // Window-view mode. When non-null, all reads delegate to
-    // the parent's storage with a (offset, count) translation, and all
-    // writes throw PanicError. Set only by make_window_view().
-    const ColumnStore* view_items_ = nullptr;
-    const std::map<std::string, JsonValue>* view_common_ = nullptr;
-    std::size_t view_offset_ = 0;
-    std::size_t view_count_ = 0;
-    bool is_window_view() const noexcept { return view_items_ != nullptr; }
+  // Window-view mode. When non-null, all reads delegate to
+  // the parent's storage with a (offset, count) translation, and all
+  // writes throw PanicError. Set only by make_window_view().
+  const ColumnStore* view_items_ = nullptr;
+  const std::map<std::string, JsonValue>* view_common_ = nullptr;
+  std::size_t view_offset_ = 0;
+  std::size_t view_count_ = 0;
+  bool is_window_view() const noexcept {
+    return view_items_ != nullptr;
+  }
 };
 
 }  // namespace pine

--- a/pine-cpp/include/pine/column_store.hpp
+++ b/pine-cpp/include/pine/column_store.hpp
@@ -18,60 +18,63 @@ namespace pine {
 // Adding a new column with set_column() must use a column whose size
 // matches row_count() (the caller is expected to back-fill).
 class ColumnStore {
-public:
-    virtual ~ColumnStore() = default;
+ public:
+  virtual ~ColumnStore() = default;
 
-    virtual std::size_t row_count() const = 0;
-    virtual std::vector<std::string> fields() const = 0;
-    virtual bool has_column(const std::string& field) const = 0;
-    virtual const Column* column(const std::string& field) const = 0;
+  virtual std::size_t row_count() const = 0;
+  virtual std::vector<std::string> fields() const = 0;
+  virtual bool has_column(const std::string& field) const = 0;
+  virtual const Column* column(const std::string& field) const = 0;
 
-    // Replace (or insert) `field`'s column. Column must have size ==
-    // row_count() unless this is the first column being inserted into
-    // an empty store, in which case its size sets row_count().
-    virtual void set_column(const std::string& field, std::unique_ptr<Column> col) = 0;
+  // Replace (or insert) `field`'s column. Column must have size ==
+  // row_count() unless this is the first column being inserted into
+  // an empty store, in which case its size sets row_count().
+  virtual void set_column(const std::string& field, std::unique_ptr<Column> col) = 0;
 
-    // Mutable access for in-place edits. The store guarantees a unique
-    // mutable column reference is returned (auto-cloning if needed in
-    // future COW variants). Returns nullptr if the field is absent.
-    virtual Column* mutate_column(const std::string& field) = 0;
+  // Mutable access for in-place edits. The store guarantees a unique
+  // mutable column reference is returned (auto-cloning if needed in
+  // future COW variants). Returns nullptr if the field is absent.
+  virtual Column* mutate_column(const std::string& field) = 0;
 
-    // remove_rows / reorder_rows apply to every column atomically so
-    // row_count() stays consistent. extend_rows(n, present=false)
-    // appends n null cells to every existing column (used when items
-    // are added).
-    virtual void remove_rows(const std::set<int>& indices) = 0;
-    virtual void reorder_rows(const std::vector<int>& order) = 0;
-    virtual void extend_rows(std::size_t n) = 0;
+  // remove_rows / reorder_rows apply to every column atomically so
+  // row_count() stays consistent. extend_rows(n, present=false)
+  // appends n null cells to every existing column (used when items
+  // are added).
+  virtual void remove_rows(const std::set<int>& indices) = 0;
+  virtual void reorder_rows(const std::vector<int>& order) = 0;
+  virtual void extend_rows(std::size_t n) = 0;
 
-    virtual std::unique_ptr<ColumnStore> clone() const = 0;
+  virtual std::unique_ptr<ColumnStore> clone() const = 0;
 };
 
 // TypedColumnStore is the default ColumnStore: an ordered map of
 // std::unique_ptr<Column>. Future Arrow / shared-snapshot variants
 // implement the same interface.
 class TypedColumnStore final : public ColumnStore {
-public:
-    TypedColumnStore() = default;
-    explicit TypedColumnStore(std::size_t row_count) : row_count_(row_count) {}
+ public:
+  TypedColumnStore() = default;
+  explicit TypedColumnStore(std::size_t row_count) : row_count_(row_count) {
+  }
 
-    std::size_t row_count() const override { return row_count_; }
-    std::vector<std::string> fields() const override;
-    bool has_column(const std::string& field) const override;
-    const Column* column(const std::string& field) const override;
+  std::size_t row_count() const override {
+    return row_count_;
+  }
+  std::vector<std::string> fields() const override;
+  bool has_column(const std::string& field) const override;
+  const Column* column(const std::string& field) const override;
 
-    void set_column(const std::string& field, std::unique_ptr<Column> col) override;
-    Column* mutate_column(const std::string& field) override;
+  void set_column(const std::string& field, std::unique_ptr<Column> col) override;
+  Column* mutate_column(const std::string& field) override;
 
-    void remove_rows(const std::set<int>& indices) override;
-    void reorder_rows(const std::vector<int>& order) override;
-    void extend_rows(std::size_t n) override;
+  void remove_rows(const std::set<int>& indices) override;
+  void reorder_rows(const std::vector<int>& order) override;
+  void extend_rows(std::size_t n) override;
 
-    std::unique_ptr<ColumnStore> clone() const override;
+  std::unique_ptr<ColumnStore> clone() const override;
 
-private:
-    std::map<std::string, std::unique_ptr<Column>> cols_;
-    std::size_t row_count_ = 0;
+ private:
+  std::map<std::string, std::unique_ptr<Column>> cols_;
+  std::size_t row_count_ = 0;
 };
 
 }  // namespace pine

--- a/pine-cpp/include/pine/error_chain.hpp
+++ b/pine-cpp/include/pine/error_chain.hpp
@@ -42,18 +42,22 @@ namespace detail {
 // leaving nested_ptr() null.
 template <typename Visitor>
 auto walk_nested(const std::exception& e, Visitor visitor) -> decltype(visitor(e)) {
-    const std::nested_exception* nested = dynamic_cast<const std::nested_exception*>(&e);
-    if (nested == nullptr) return nullptr;
-    if (nested->nested_ptr() == nullptr) return nullptr;
-    try {
-        nested->rethrow_nested();
-    } catch (const std::exception& inner) {
-        return visitor(inner);
-    } catch (...) {
-        // non-std::exception nested cause; we cannot type-match further
-        return nullptr;
-    }
+  const std::nested_exception* nested = dynamic_cast<const std::nested_exception*>(&e);
+  if (nested == nullptr) {
     return nullptr;
+  }
+  if (nested->nested_ptr() == nullptr) {
+    return nullptr;
+  }
+  try {
+    nested->rethrow_nested();
+  } catch (const std::exception& inner) {
+    return visitor(inner);
+  } catch (...) {
+    // non-std::exception nested cause; we cannot type-match further
+    return nullptr;
+  }
+  return nullptr;
 }
 
 }  // namespace detail
@@ -70,17 +74,17 @@ auto walk_nested(const std::exception& e, Visitor visitor) -> decltype(visitor(e
 // reviewer assertion of O(N²) was a misreading of the call structure).
 template <typename T>
 const T* error_as(const std::exception& err) {
-    if (auto self = dynamic_cast<const T*>(&err)) return self;
-    return detail::walk_nested(err, [](const std::exception& inner) -> const T* {
-        return error_as<T>(inner);
-    });
+  if (auto self = dynamic_cast<const T*>(&err)) {
+    return self;
+  }
+  return detail::walk_nested(err, [](const std::exception& inner) -> const T* { return error_as<T>(inner); });
 }
 
 // error_is returns true if any exception in the nested chain (including the
 // outermost) is dynamic_castable to T. Equivalent to Go's errors.Is(err, T{}).
 template <typename T>
 bool error_is(const std::exception& err) {
-    return error_as<T>(err) != nullptr;
+  return error_as<T>(err) != nullptr;
 }
 
 }  // namespace pine

--- a/pine-cpp/include/pine/frame.hpp
+++ b/pine-cpp/include/pine/frame.hpp
@@ -27,60 +27,55 @@ namespace pine {
 // pine-go's dual physical representation (decision-04 / decision-14
 // "MVP single impl" relaxed).
 class Frame {
-public:
-    virtual ~Frame() = default;
+ public:
+  virtual ~Frame() = default;
 
-    // ---- common ----
-    virtual JsonValue common(const std::string& field) const = 0;
-    virtual bool has_common(const std::string& field) const = 0;
-    virtual void set_common(const std::string& field, JsonValue value) = 0;
-    virtual std::vector<std::string> common_fields() const = 0;
+  // ---- common ----
+  virtual JsonValue common(const std::string& field) const = 0;
+  virtual bool has_common(const std::string& field) const = 0;
+  virtual void set_common(const std::string& field, JsonValue value) = 0;
+  virtual std::vector<std::string> common_fields() const = 0;
 
-    // ---- items ----
-    virtual std::size_t item_count() const = 0;
-    virtual JsonValue item(std::size_t index, const std::string& field) const = 0;
-    virtual bool item_has(std::size_t index, const std::string& field) const = 0;
-    virtual std::vector<std::string> item_fields() const = 0;
+  // ---- items ----
+  virtual std::size_t item_count() const = 0;
+  virtual JsonValue item(std::size_t index, const std::string& field) const = 0;
+  virtual bool item_has(std::size_t index, const std::string& field) const = 0;
+  virtual std::vector<std::string> item_fields() const = 0;
 
-    // ---- resources (read-only injected map) ----
-    virtual void set_resources(const std::map<std::string, JsonValue>* res) = 0;
-    virtual const std::map<std::string, JsonValue>* resources() const = 0;
+  // ---- resources (read-only injected map) ----
+  virtual void set_resources(const std::map<std::string, JsonValue>* res) = 0;
+  virtual const std::map<std::string, JsonValue>* resources() const = 0;
 
-    // ---- warnings ----
-    virtual void push_warning(std::string msg) = 0;
-    virtual std::vector<std::string> take_warnings() = 0;
+  // ---- warnings ----
+  virtual void push_warning(std::string msg) = 0;
+  virtual std::vector<std::string> take_warnings() = 0;
 
-    // ---- apply OperatorOutput (write log) ----
-    virtual void apply_output(const OperatorOutput& out,
-                              const std::string& op_name,
-                              bool is_recall) = 0;
+  // ---- apply OperatorOutput (write log) ----
+  virtual void apply_output(const OperatorOutput& out, const std::string& op_name, bool is_recall) = 0;
 
-    // Project the frame to a Result using the strict common/item field
-    // lists (skips fields whose validity is false on a given row).
-    virtual Result to_result(const std::vector<std::string>& common_out,
-                             const std::vector<std::string>& item_out) const = 0;
+  // Project the frame to a Result using the strict common/item field
+  // lists (skips fields whose validity is false on a given row).
+  virtual Result to_result(const std::vector<std::string>& common_out,
+                           const std::vector<std::string>& item_out) const = 0;
 
-    // ---- snapshots / read-only views ----
-    virtual JsonValue::object_t item_object(std::size_t index) const = 0;
+  // ---- snapshots / read-only views ----
+  virtual JsonValue::object_t item_object(std::size_t index) const = 0;
 
-    // Non-owning read-only window over a parent frame's items. Both
-    // implementations support this for parallel_execute. Reads
-    // delegate to the parent with an (offset, count) translation; writes
-    // throw.
-    virtual std::unique_ptr<Frame> make_window_view(std::size_t row_offset,
-                                                     std::size_t row_count) const = 0;
+  // Non-owning read-only window over a parent frame's items. Both
+  // implementations support this for parallel_execute. Reads
+  // delegate to the parent with an (offset, count) translation; writes
+  // throw.
+  virtual std::unique_ptr<Frame> make_window_view(std::size_t row_offset, std::size_t row_count) const = 0;
 
-    // Batch-validate strict item fields. Returns ("", -1) if all rows pass.
-    // On failure returns (field_name, row_index) of the first violation.
-    // ColumnFrame uses bitmap scans; RowFrame checks per-row maps.
-    virtual std::pair<std::string, int> validate_strict_items(
-        const std::vector<std::string>& fields) const = 0;
+  // Batch-validate strict item fields. Returns ("", -1) if all rows pass.
+  // On failure returns (field_name, row_index) of the first violation.
+  // ColumnFrame uses bitmap scans; RowFrame checks per-row maps.
+  virtual std::pair<std::string, int> validate_strict_items(const std::vector<std::string>& fields) const = 0;
 };
 
 // Factory: build the Frame implementation that matches storage_mode.
 // Unknown / empty storage_mode falls back to "column".
-std::unique_ptr<Frame> make_frame(const std::string& storage_mode,
-                                   std::map<std::string, JsonValue> common,
-                                   std::vector<std::map<std::string, JsonValue>> items);
+std::unique_ptr<Frame> make_frame(const std::string& storage_mode, std::map<std::string, JsonValue> common,
+                                  std::vector<std::map<std::string, JsonValue>> items);
 
 }  // namespace pine

--- a/pine-cpp/include/pine/metrics.hpp
+++ b/pine-cpp/include/pine/metrics.hpp
@@ -19,53 +19,53 @@ namespace pine {
 namespace metrics {
 
 class Counter {
-public:
-    virtual ~Counter() = default;
-    // Returns a counter narrowed to the given label values. Returned pointer
-    // is owned by the underlying Provider — do not delete.
-    virtual Counter* with(const std::vector<std::string>& label_values) = 0;
-    virtual void inc() = 0;
+ public:
+  virtual ~Counter() = default;
+  // Returns a counter narrowed to the given label values. Returned pointer
+  // is owned by the underlying Provider — do not delete.
+  virtual Counter* with(const std::vector<std::string>& label_values) = 0;
+  virtual void inc() = 0;
 };
 
 class Gauge {
-public:
-    virtual ~Gauge() = default;
-    virtual Gauge* with(const std::vector<std::string>& label_values) = 0;
-    virtual void set(double value) = 0;
-    virtual void add(double delta) = 0;
+ public:
+  virtual ~Gauge() = default;
+  virtual Gauge* with(const std::vector<std::string>& label_values) = 0;
+  virtual void set(double value) = 0;
+  virtual void add(double delta) = 0;
 };
 
 class Histogram {
-public:
-    virtual ~Histogram() = default;
-    virtual Histogram* with(const std::vector<std::string>& label_values) = 0;
-    virtual void observe(double value) = 0;
+ public:
+  virtual ~Histogram() = default;
+  virtual Histogram* with(const std::vector<std::string>& label_values) = 0;
+  virtual void observe(double value) = 0;
 };
 
 struct MetricOpts {
-    std::string name;
-    std::string help;
-    std::vector<std::string> label_names;
+  std::string name;
+  std::string help;
+  std::vector<std::string> label_names;
 };
 
 struct HistogramOpts {
-    MetricOpts opts;
-    std::vector<double> buckets;  // empty → implementation-chosen defaults
+  MetricOpts opts;
+  std::vector<double> buckets;  // empty → implementation-chosen defaults
 };
 
 class Provider {
-public:
-    virtual ~Provider() = default;
-    virtual Counter* new_counter(const MetricOpts& opts) = 0;
-    virtual Gauge* new_gauge(const MetricOpts& opts) = 0;
-    virtual Histogram* new_histogram(const HistogramOpts& opts) = 0;
+ public:
+  virtual ~Provider() = default;
+  virtual Counter* new_counter(const MetricOpts& opts) = 0;
+  virtual Gauge* new_gauge(const MetricOpts& opts) = 0;
+  virtual Histogram* new_histogram(const HistogramOpts& opts) = 0;
 };
 
 // Returns a singleton no-op Provider. Discards every observation at zero cost.
 Provider* nop_provider();
 
 inline double duration_seconds(std::chrono::nanoseconds d) {
-    return static_cast<double>(d.count()) / 1e9;
+  return static_cast<double>(d.count()) / 1e9;
 }
 
 }  // namespace metrics

--- a/pine-cpp/include/pine/operator.hpp
+++ b/pine-cpp/include/pine/operator.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include "pine/pine.hpp"
 #include "pine/column_frame.hpp"
 #include "pine/frame.hpp"
 #include "pine/metrics.hpp"
+#include "pine/pine.hpp"
+
 #include <functional>
 #include <map>
 #include <memory>
@@ -31,18 +32,18 @@ struct ConcurrentSafe {};
 // Engine injects the configured metrics::Provider after init() but before
 // the first execute() call (matches pine-go pine.go:170 ordering).
 class MetricsAware {
-public:
-    virtual ~MetricsAware() = default;
-    virtual void set_metrics_provider(metrics::Provider* provider) = 0;
+ public:
+  virtual ~MetricsAware() = default;
+  virtual void set_metrics_provider(metrics::Provider* provider) = 0;
 };
 
 // StatsProvider mirrors pine-go's types.StatsProvider optional interface.
 // Operators that expose internal counters/gauges for the /stats endpoint
 // implement this. The Engine polls OperatorStats() during stats collection.
 class StatsProvider {
-public:
-    virtual ~StatsProvider() = default;
-    virtual std::map<std::string, int64_t> operator_stats() const = 0;
+ public:
+  virtual ~StatsProvider() = default;
+  virtual std::map<std::string, int64_t> operator_stats() const = 0;
 };
 
 // Note: Operator base class is declared in pine/pine.hpp (as class Operator)
@@ -51,10 +52,10 @@ public:
 
 // --- OperatorSchema ---
 struct OperatorSchema {
-    std::string name;
-    OpType type;
-    std::string description;
-    std::map<std::string, ParamSchema> params;
+  std::string name;
+  OpType type;
+  std::string description;
+  std::map<std::string, ParamSchema> params;
 };
 
 using OperatorFactory = std::function<std::unique_ptr<Operator>()>;
@@ -64,19 +65,19 @@ using OperatorFactory = std::function<std::unique_ptr<Operator>()>;
 // Engine instantiation.
 template <typename T>
 struct OperatorTraits {
-    static constexpr bool consumes_row_set         = std::is_base_of_v<ConsumesRowSet, T>;
-    static constexpr bool mutates_row_set          = std::is_base_of_v<MutatesRowSet, T>;
-    static constexpr bool additive_writes_row_set  = std::is_base_of_v<AdditiveWritesRowSet, T>;
-    static constexpr bool concurrent_safe          = std::is_base_of_v<ConcurrentSafe, T>;
+  static constexpr bool consumes_row_set = std::is_base_of_v<ConsumesRowSet, T>;
+  static constexpr bool mutates_row_set = std::is_base_of_v<MutatesRowSet, T>;
+  static constexpr bool additive_writes_row_set = std::is_base_of_v<AdditiveWritesRowSet, T>;
+  static constexpr bool concurrent_safe = std::is_base_of_v<ConcurrentSafe, T>;
 };
 
 struct OperatorEntry {
-    OperatorSchema schema;
-    OperatorFactory factory;
-    bool consumes_row_set = false;
-    bool mutates_row_set = false;
-    bool additive_writes_row_set = false;
-    bool concurrent_safe = false;
+  OperatorSchema schema;
+  OperatorFactory factory;
+  bool consumes_row_set = false;
+  bool mutates_row_set = false;
+  bool additive_writes_row_set = false;
+  bool concurrent_safe = false;
 };
 
 // Register an operator with pre-computed marker bits. Used by
@@ -85,26 +86,19 @@ struct OperatorEntry {
 //
 // Throws RegistryError on: empty name, empty description, null factory,
 // duplicate name.
-void register_operator_with_traits(OperatorSchema schema,
-                                   OperatorFactory factory,
-                                   bool consumes_row_set,
-                                   bool mutates_row_set,
-                                   bool additive_writes_row_set,
-                                   bool concurrent_safe);
+void register_operator_with_traits(OperatorSchema schema, OperatorFactory factory, bool consumes_row_set,
+                                   bool mutates_row_set, bool additive_writes_row_set, bool concurrent_safe);
 
 // Templated entry: derives marker bits from OperatorTraits<T> at compile
 // time, so the registry never needs a dynamic_cast probe.
 template <typename T>
 void register_operator_typed(OperatorSchema schema) {
-    static_assert(std::is_base_of_v<Operator, T>,
-                  "register_operator_typed<T>: T must derive from pine::Operator");
-    register_operator_with_traits(
-        std::move(schema),
-        [] { return std::make_unique<T>(); },
-        OperatorTraits<T>::consumes_row_set,
-        OperatorTraits<T>::mutates_row_set,
-        OperatorTraits<T>::additive_writes_row_set,
-        OperatorTraits<T>::concurrent_safe);
+  static_assert(std::is_base_of_v<Operator, T>,
+                "register_operator_typed<T>: T must derive from pine::Operator");
+  register_operator_with_traits(
+      std::move(schema), [] { return std::make_unique<T>(); }, OperatorTraits<T>::consumes_row_set,
+      OperatorTraits<T>::mutates_row_set, OperatorTraits<T>::additive_writes_row_set,
+      OperatorTraits<T>::concurrent_safe);
 }
 
 // Lookup an operator entry by type name; returns nullptr if not registered.
@@ -115,7 +109,7 @@ std::vector<std::string> registered_operator_names();
 
 // --- Macro helpers ---
 #define PINE_DETAIL_CONCAT_INNER(a, b) a##b
-#define PINE_DETAIL_CONCAT(a, b) PINE_DETAIL_CONCAT_INNER(a, b)
+#define PINE_DETAIL_CONCAT(a, b)       PINE_DETAIL_CONCAT_INNER(a, b)
 
 // PINE_REGISTER_OPERATOR_T registers an operator at static initialization
 // time. It accepts the operator type directly so marker bits resolve at
@@ -124,13 +118,12 @@ std::vector<std::string> registered_operator_names();
 // Example:
 //   static const pine::OperatorSchema k_my_op_schema{ ... };
 //   PINE_REGISTER_OPERATOR_T(MyOp, k_my_op_schema)
-#define PINE_REGISTER_OPERATOR_T(T, SCHEMA)                                  \
-    namespace {                                                              \
-        const bool PINE_DETAIL_CONCAT(_pine_reg_t_, __COUNTER__) = [] {      \
-            ::pine::register_operator_typed<T>((SCHEMA));                    \
-            return true;                                                     \
-        }();                                                                 \
-    }
-
+#define PINE_REGISTER_OPERATOR_T(T, SCHEMA)                       \
+  namespace {                                                     \
+  const bool PINE_DETAIL_CONCAT(_pine_reg_t_, __COUNTER__) = [] { \
+    ::pine::register_operator_typed<T>((SCHEMA));                 \
+    return true;                                                  \
+  }();                                                            \
+  }
 
 }  // namespace pine

--- a/pine-cpp/include/pine/operator_input.hpp
+++ b/pine-cpp/include/pine/operator_input.hpp
@@ -21,38 +21,37 @@ class Frame;
 // Strict field validation is done once by build_operator_input before
 // constructing the proxy (PERF-1a).
 class OperatorInput {
-public:
-    OperatorInput(const Frame& frame, const InputFieldSpec& spec);
+ public:
+  OperatorInput(const Frame& frame, const InputFieldSpec& spec);
 
-    // common returns the value for the given field, or null if absent.
-    // Substitutes defaults for nil values.
-    JsonValue common(const std::string& field) const;
+  // common returns the value for the given field, or null if absent.
+  // Substitutes defaults for nil values.
+  JsonValue common(const std::string& field) const;
 
-    // item_count returns the number of items.
-    std::size_t item_count() const;
+  // item_count returns the number of items.
+  std::size_t item_count() const;
 
-    // item returns the value for (index, field), or null if absent.
-    // Substitutes defaults for nil values.
-    JsonValue item(std::size_t index, const std::string& field) const;
+  // item returns the value for (index, field), or null if absent.
+  // Substitutes defaults for nil values.
+  JsonValue item(std::size_t index, const std::string& field) const;
 
-    // common_keys returns all common field names present in the spec.
-    std::vector<std::string> common_keys() const;
+  // common_keys returns all common field names present in the spec.
+  std::vector<std::string> common_keys() const;
 
-    // item_keys returns all item field names present in the spec.
-    std::vector<std::string> item_keys(std::size_t index) const;
+  // item_keys returns all item field names present in the spec.
+  std::vector<std::string> item_keys(std::size_t index) const;
 
-    // resources returns the injected resource map (may be nullptr).
-    const std::map<std::string, JsonValue>* resources() const;
+  // resources returns the injected resource map (may be nullptr).
+  const std::map<std::string, JsonValue>* resources() const;
 
-private:
-    const Frame* frame_;
-    const InputFieldSpec* spec_;
+ private:
+  const Frame* frame_;
+  const InputFieldSpec* spec_;
 };
 
 // build_operator_input constructs an OperatorInput from a Frame and the
 // operator's InputFieldSpec. Throws ExecutionError for strict field violations.
-OperatorInput build_operator_input(const Frame& frame,
-                                   const std::string& op_name,
+OperatorInput build_operator_input(const Frame& frame, const std::string& op_name,
                                    const InputFieldSpec& spec);
 
 }  // namespace pine

--- a/pine-cpp/include/pine/pine.hpp
+++ b/pine-cpp/include/pine/pine.hpp
@@ -15,7 +15,6 @@
 #include <variant>
 #include <vector>
 
-
 namespace pine {
 
 // Pineapple engine version. Single source of truth for all C++ code —
@@ -25,8 +24,8 @@ namespace pine {
 inline constexpr const char* kVersion = "0.9.1";
 
 class Error : public std::runtime_error {
-public:
-    using std::runtime_error::runtime_error;
+ public:
+  using std::runtime_error::runtime_error;
 };
 
 // ConfigError, ValidationError, RegistryError auto-prefix their what() output
@@ -34,15 +33,19 @@ public:
 // (types/errors.go ConfigError/ValidationError/RegistryError). Throw sites
 // should pass the bare message body; the prefix is added once at construction.
 class ConfigError : public Error {
-public:
-    explicit ConfigError(const std::string& msg) : Error("pine: config error: " + msg) {}
-    explicit ConfigError(const char* msg) : Error(std::string("pine: config error: ") + msg) {}
+ public:
+  explicit ConfigError(const std::string& msg) : Error("pine: config error: " + msg) {
+  }
+  explicit ConfigError(const char* msg) : Error(std::string("pine: config error: ") + msg) {
+  }
 };
 
 class ValidationError : public Error {
-public:
-    explicit ValidationError(const std::string& msg) : Error("pine: validation error: " + msg) {}
-    explicit ValidationError(const char* msg) : Error(std::string("pine: validation error: ") + msg) {}
+ public:
+  explicit ValidationError(const std::string& msg) : Error("pine: validation error: " + msg) {
+  }
+  explicit ValidationError(const char* msg) : Error(std::string("pine: validation error: ") + msg) {
+  }
 };
 
 // RegistryError supports both `pine: registry error: <msg>` (legacy 1-arg
@@ -50,11 +53,14 @@ public:
 // and `pine: registry error [<op>]: <msg>` (matches pine-go RegistryError
 // with explicit Operator field).
 class RegistryError : public Error {
-public:
-    explicit RegistryError(const std::string& msg) : Error("pine: registry error: " + msg) {}
-    explicit RegistryError(const char* msg) : Error(std::string("pine: registry error: ") + msg) {}
-    RegistryError(const std::string& operator_name, const std::string& msg)
-        : Error("pine: registry error [" + operator_name + "]: " + msg) {}
+ public:
+  explicit RegistryError(const std::string& msg) : Error("pine: registry error: " + msg) {
+  }
+  explicit RegistryError(const char* msg) : Error(std::string("pine: registry error: ") + msg) {
+  }
+  RegistryError(const std::string& operator_name, const std::string& msg)
+      : Error("pine: registry error [" + operator_name + "]: " + msg) {
+  }
 };
 
 // ExecutionError carries the operator name and an inner error message and
@@ -81,20 +87,27 @@ public:
 // nested cause. Use pine::error_as<T>() (include/pine/error_chain.hpp) to
 // walk the cause chain, mirroring Go's errors.As / Java's Throwable.getCause().
 class ExecutionError : public Error, public std::nested_exception {
-public:
-    explicit ExecutionError(std::string msg) : Error(msg), inner_(std::move(msg)) {}
-    ExecutionError(std::string operator_name, std::string inner)
-        : Error(format_msg(operator_name, inner)),
-          operator_(std::move(operator_name)),
-          inner_(std::move(inner)) {}
-    const std::string& operator_name() const { return operator_; }
-    const std::string& inner() const { return inner_; }
-private:
-    static std::string format_msg(const std::string& op, const std::string& inner) {
-        return "pine: execution error in operator \"" + op + "\": " + inner;
-    }
-    std::string operator_;
-    std::string inner_;
+ public:
+  explicit ExecutionError(std::string msg) : Error(msg), inner_(std::move(msg)) {
+  }
+  ExecutionError(std::string operator_name, std::string inner)
+      : Error(format_msg(operator_name, inner)),
+        operator_(std::move(operator_name)),
+        inner_(std::move(inner)) {
+  }
+  const std::string& operator_name() const {
+    return operator_;
+  }
+  const std::string& inner() const {
+    return inner_;
+  }
+
+ private:
+  static std::string format_msg(const std::string& op, const std::string& inner) {
+    return "pine: execution error in operator \"" + op + "\": " + inner;
+  }
+  std::string operator_;
+  std::string inner_;
 };
 
 // PanicError wraps an unexpected (non-pine::Error) exception thrown from an
@@ -108,118 +121,125 @@ private:
 // C++ has no goroutine concept, so the trace is the constructing thread's
 // frames only (use std::stacktrace::current via std::stacktrace_entry).
 class PanicError : public Error, public std::nested_exception {
-public:
-    PanicError(std::string operator_name, std::string value);
-    const std::string& operator_name() const { return operator_; }
-    const std::string& value() const { return value_; }
-    const std::string& stack() const { return stack_; }
-    std::string detailed_error() const;
-private:
-    static std::string format_msg(const std::string& op, const std::string& v) {
-        return "pine: panic in operator \"" + op + "\": " + v;
-    }
-    std::string operator_;
-    std::string value_;
-    std::string stack_;  // empty when std::stacktrace unavailable at link time
+ public:
+  PanicError(std::string operator_name, std::string value);
+  const std::string& operator_name() const {
+    return operator_;
+  }
+  const std::string& value() const {
+    return value_;
+  }
+  const std::string& stack() const {
+    return stack_;
+  }
+  std::string detailed_error() const;
+
+ private:
+  static std::string format_msg(const std::string& op, const std::string& v) {
+    return "pine: panic in operator \"" + op + "\": " + v;
+  }
+  std::string operator_;
+  std::string value_;
+  std::string stack_;  // empty when std::stacktrace unavailable at link time
 };
 
 class JsonValue {
-public:
-    using object_t = std::map<std::string, JsonValue>;
-    using array_t = std::vector<JsonValue>;
-    using value_t = std::variant<std::nullptr_t, bool, double, std::string, array_t, object_t>;
+ public:
+  using object_t = std::map<std::string, JsonValue>;
+  using array_t = std::vector<JsonValue>;
+  using value_t = std::variant<std::nullptr_t, bool, double, std::string, array_t, object_t>;
 
-    JsonValue();
-    JsonValue(std::nullptr_t);
-    JsonValue(bool value);
-    JsonValue(double value);
-    JsonValue(int value);
-    JsonValue(std::string value);
-    JsonValue(const char* value);
-    JsonValue(array_t value);
-    JsonValue(object_t value);
+  JsonValue();
+  JsonValue(std::nullptr_t);
+  JsonValue(bool value);
+  JsonValue(double value);
+  JsonValue(int value);
+  JsonValue(std::string value);
+  JsonValue(const char* value);
+  JsonValue(array_t value);
+  JsonValue(object_t value);
 
-    bool is_null() const;
-    bool is_bool() const;
-    bool is_number() const;
-    bool is_string() const;
-    bool is_array() const;
-    bool is_object() const;
+  bool is_null() const;
+  bool is_bool() const;
+  bool is_number() const;
+  bool is_string() const;
+  bool is_array() const;
+  bool is_object() const;
 
-    bool as_bool() const;
-    double as_number() const;
-    const std::string& as_string() const;
-    const array_t& as_array() const;
-    const object_t& as_object() const;
-    array_t& as_array();
-    object_t& as_object();
+  bool as_bool() const;
+  double as_number() const;
+  const std::string& as_string() const;
+  const array_t& as_array() const;
+  const object_t& as_object() const;
+  array_t& as_array();
+  object_t& as_object();
 
-    bool truthy() const;
+  bool truthy() const;
 
-    const JsonValue* find(const std::string& key) const;
-    JsonValue* find(const std::string& key);
+  const JsonValue* find(const std::string& key) const;
+  JsonValue* find(const std::string& key);
 
-private:
-    value_t value_;
+ private:
+  value_t value_;
 };
 
 JsonValue parse_json(const std::string& text);
 std::string dump_json(const JsonValue& value, int indent = 2);
 
 struct Metadata {
-    std::vector<std::string> common_input;
-    std::vector<std::string> common_output;
-    std::vector<std::string> item_input;
-    std::vector<std::string> item_output;
+  std::vector<std::string> common_input;
+  std::vector<std::string> common_output;
+  std::vector<std::string> item_input;
+  std::vector<std::string> item_output;
 };
 
 struct OperatorConfig {
-    std::string name;
-    std::string type_name;
-    Metadata metadata;
-    std::vector<std::string> skip;
-    bool recall = false;
-    bool consumes_row_set = false;
-    bool mutates_row_set = false;
-    bool additive_writes_row_set = false;
-    bool concurrent_safe = false;
-    std::optional<bool> debug;
-    bool for_branch_control = false;
-    std::map<std::string, JsonValue> common_defaults;
-    std::map<std::string, JsonValue> item_defaults;
-    std::vector<std::string> strict_common;
-    std::vector<std::string> strict_item;
-    std::vector<std::string> sources;
-    JsonValue params;
-    std::string operator_type;
-    int data_parallel = 0;
+  std::string name;
+  std::string type_name;
+  Metadata metadata;
+  std::vector<std::string> skip;
+  bool recall = false;
+  bool consumes_row_set = false;
+  bool mutates_row_set = false;
+  bool additive_writes_row_set = false;
+  bool concurrent_safe = false;
+  std::optional<bool> debug;
+  bool for_branch_control = false;
+  std::map<std::string, JsonValue> common_defaults;
+  std::map<std::string, JsonValue> item_defaults;
+  std::vector<std::string> strict_common;
+  std::vector<std::string> strict_item;
+  std::vector<std::string> sources;
+  JsonValue params;
+  std::string operator_type;
+  int data_parallel = 0;
 };
 
 // InputFieldSpec describes which fields are strict (must be non-nil) vs
 // defaulted (nil → use default) for an operator. Computed once at config
 // load time from metadata + defaults maps.
 struct DefaultedField {
-    std::string name;
-    JsonValue default_value;
+  std::string name;
+  JsonValue default_value;
 };
 
 struct InputFieldSpec {
-    std::vector<std::string> strict_common;
-    std::vector<DefaultedField> defaulted_common;
-    std::vector<std::string> nullable_common;
-    std::vector<std::string> strict_item;
-    std::vector<DefaultedField> defaulted_item;
-    std::vector<std::string> nullable_item;
+  std::vector<std::string> strict_common;
+  std::vector<DefaultedField> defaulted_common;
+  std::vector<std::string> nullable_common;
+  std::vector<std::string> strict_item;
+  std::vector<DefaultedField> defaulted_item;
+  std::vector<std::string> nullable_item;
 };
 
 // compute_input_field_spec derives the InputFieldSpec from an OperatorConfig.
 InputFieldSpec compute_input_field_spec(const OperatorConfig& config);
 
 struct FlowContract {
-    std::vector<std::string> common_input;
-    std::vector<std::string> item_input;
-    std::vector<std::string> common_output;
-    std::vector<std::string> item_output;
+  std::vector<std::string> common_input;
+  std::vector<std::string> item_input;
+  std::vector<std::string> common_output;
+  std::vector<std::string> item_output;
 };
 
 // ResourceEntry mirrors pine-go's resource.resourceConfig: a single entry in
@@ -228,32 +248,32 @@ struct FlowContract {
 // these fields are parsed and stored for downstream tooling / future wiring
 // without producing fetchers at config-load time.
 struct ResourceEntry {
-    std::string type;
-    int interval = 0;  // seconds
-    JsonValue params;  // arbitrary object passed to the fetcher factory
+  std::string type;
+  int interval = 0;  // seconds
+  JsonValue params;  // arbitrary object passed to the fetcher factory
 };
 
 struct Config {
-    std::map<std::string, OperatorConfig> operators;
-    std::map<std::string, std::vector<std::string>> pipeline_map;
-    std::map<std::string, std::vector<std::string>> pipeline_group;
-    FlowContract flow_contract;
-    std::string storage_mode = "row";
-    bool debug = false;
-    std::string log_prefix;
-    // Metadata fields written by codegen at config-build time. Surfaced
-    // verbatim so downstream tooling can read them; the engine itself does
-    // not act on them. Mirrors pine-go RootConfig._PINEAPPLE_VERSION /
-    // _PINEAPPLE_CREATE_TIME.
-    std::string pineapple_version;
-    std::string pineapple_create_time;
-    // Optional resource_config block. Empty when omitted.
-    std::map<std::string, ResourceEntry> resource_config;
+  std::map<std::string, OperatorConfig> operators;
+  std::map<std::string, std::vector<std::string>> pipeline_map;
+  std::map<std::string, std::vector<std::string>> pipeline_group;
+  FlowContract flow_contract;
+  std::string storage_mode = "row";
+  bool debug = false;
+  std::string log_prefix;
+  // Metadata fields written by codegen at config-build time. Surfaced
+  // verbatim so downstream tooling can read them; the engine itself does
+  // not act on them. Mirrors pine-go RootConfig._PINEAPPLE_VERSION /
+  // _PINEAPPLE_CREATE_TIME.
+  std::string pineapple_version;
+  std::string pineapple_create_time;
+  // Optional resource_config block. Empty when omitted.
+  std::map<std::string, ResourceEntry> resource_config;
 };
 
 struct ExpandedSequence {
-    std::vector<std::string> sequence;
-    std::map<std::string, std::string> op_to_subflow;
+  std::vector<std::string> sequence;
+  std::map<std::string, std::string> op_to_subflow;
 };
 
 Config load_config_from_file(const std::string& path);
@@ -263,26 +283,26 @@ ExpandedSequence expand_operator_sequence_with_subflows(const Config& config);
 // --- Operator Registry (equivalent to Go's pine.Register + marker interfaces) ---
 
 struct ParamSchema {
-    std::string type;
-    bool required = false;
-    JsonValue default_value;            // null means no default
-    std::string description;
+  std::string type;
+  bool required = false;
+  JsonValue default_value;  // null means no default
+  std::string description;
 };
 
 void apply_registry_traits(Config& config);
 std::string export_schema_json();
 
 struct Node {
-    std::string name;
-    std::string subflow;
-    std::vector<int> preds;
-    std::vector<int> succs;
-    const OperatorConfig* config = nullptr;
+  std::string name;
+  std::string subflow;
+  std::vector<int> preds;
+  std::vector<int> succs;
+  const OperatorConfig* config = nullptr;
 };
 
 struct Graph {
-    std::vector<Node> nodes;
-    std::map<std::string, int> name_to_index;
+  std::vector<Node> nodes;
+  std::map<std::string, int> name_to_index;
 };
 
 Graph build_dag(const Config& config, const ExpandedSequence& expanded);
@@ -292,13 +312,13 @@ std::string render_collapsed_dot(const Graph& graph, int level);
 std::string render_collapsed_mermaid(const Graph& graph, int level);
 
 struct Request {
-    std::map<std::string, JsonValue> common;
-    std::vector<std::map<std::string, JsonValue>> items;
+  std::map<std::string, JsonValue> common;
+  std::vector<std::map<std::string, JsonValue>> items;
 };
 
 struct Result {
-    std::map<std::string, JsonValue> common;
-    std::vector<std::map<std::string, JsonValue>> items;
+  std::map<std::string, JsonValue> common;
+  std::vector<std::map<std::string, JsonValue>> items;
 };
 
 // OperatorOutput collects writes from an operator, applied to the DataFrame by
@@ -307,73 +327,89 @@ struct Result {
 // Sequence enforced by Frame::apply_output: common writes → item writes →
 // removals → reorder → additions.
 class OperatorOutput {
-public:
-    OperatorOutput() = default;
+ public:
+  OperatorOutput() = default;
 
-    // ItemWrite is a single (index, field, value) log entry. set_item()
-    // appends; apply_output replays in order (last write wins per cell).
-    // Replaces the old nested map<int, map<string, JsonValue>> which paid
-    // two tree-node allocations per write.
-    struct ItemWrite {
-        int index;
-        std::string field;
-        JsonValue value;
-    };
+  // ItemWrite is a single (index, field, value) log entry. set_item()
+  // appends; apply_output replays in order (last write wins per cell).
+  // Replaces the old nested map<int, map<string, JsonValue>> which paid
+  // two tree-node allocations per write.
+  struct ItemWrite {
+    int index;
+    std::string field;
+    JsonValue value;
+  };
 
-    void set_common(const std::string& field, JsonValue value);
-    void set_item(int index, const std::string& field, JsonValue value);
-    void add_item(std::map<std::string, JsonValue> fields);
-    void remove_item(int index);
-    void set_item_order(std::vector<int> order);
-    void set_warning(std::string msg);  // first warning wins
+  void set_common(const std::string& field, JsonValue value);
+  void set_item(int index, const std::string& field, JsonValue value);
+  void add_item(std::map<std::string, JsonValue> fields);
+  void remove_item(int index);
+  void set_item_order(std::vector<int> order);
+  void set_warning(std::string msg);  // first warning wins
 
-    const std::map<std::string, JsonValue>& common_writes() const { return common_writes_; }
-    const std::vector<ItemWrite>& item_writes() const { return item_writes_; }
-    const std::vector<std::map<std::string, JsonValue>>& added_items() const { return added_items_; }
-    const std::set<int>& removed_items() const { return removed_items_; }
-    const std::vector<int>& item_order() const { return item_order_; }
-    bool has_item_order() const { return has_item_order_; }
-    const std::string& warning() const { return warning_; }
-    bool has_warning() const { return has_warning_; }
+  const std::map<std::string, JsonValue>& common_writes() const {
+    return common_writes_;
+  }
+  const std::vector<ItemWrite>& item_writes() const {
+    return item_writes_;
+  }
+  const std::vector<std::map<std::string, JsonValue>>& added_items() const {
+    return added_items_;
+  }
+  const std::set<int>& removed_items() const {
+    return removed_items_;
+  }
+  const std::vector<int>& item_order() const {
+    return item_order_;
+  }
+  bool has_item_order() const {
+    return has_item_order_;
+  }
+  const std::string& warning() const {
+    return warning_;
+  }
+  bool has_warning() const {
+    return has_warning_;
+  }
 
-private:
-    std::map<std::string, JsonValue> common_writes_;
-    std::vector<ItemWrite> item_writes_;
-    std::vector<std::map<std::string, JsonValue>> added_items_;
-    std::set<int> removed_items_;
-    std::vector<int> item_order_;
-    bool has_item_order_ = false;
-    std::string warning_;
-    bool has_warning_ = false;
+ private:
+  std::map<std::string, JsonValue> common_writes_;
+  std::vector<ItemWrite> item_writes_;
+  std::vector<std::map<std::string, JsonValue>> added_items_;
+  std::set<int> removed_items_;
+  std::vector<int> item_order_;
+  bool has_item_order_ = false;
+  std::string warning_;
+  bool has_warning_ = false;
 };
 
 struct OpTrace {
-    std::string name;
-    int64_t start_time_us = 0;   // microseconds since unix epoch (system_clock)
-    int64_t duration_us = 0;
-    bool skipped = false;
-    bool has_input_snapshot = false;
-    JsonValue input_snapshot;    // object {common?, items?}
-    bool has_output_snapshot = false;
-    JsonValue output_snapshot;   // object {common_writes?, item_writes?, added_items?, removed_items?}
+  std::string name;
+  int64_t start_time_us = 0;  // microseconds since unix epoch (system_clock)
+  int64_t duration_us = 0;
+  bool skipped = false;
+  bool has_input_snapshot = false;
+  JsonValue input_snapshot;  // object {common?, items?}
+  bool has_output_snapshot = false;
+  JsonValue output_snapshot;  // object {common_writes?, item_writes?, added_items?, removed_items?}
 };
 
 struct TracedResult {
-    Result result;
-    std::vector<OpTrace> trace;
-    std::vector<std::string> warnings;
+  Result result;
+  std::vector<OpTrace> trace;
+  std::vector<std::string> warnings;
 };
 
 struct EngineOptions {
-    // When set, forces debug snapshot collection on/off, overriding Config.debug
-    // and any per-operator debug flag in JSON. Mirrors Go's pine.WithDebug.
-    std::optional<bool> debug;
-    // When set, overrides root-level log_prefix from JSON config. Mirrors Go's
-    // pine.WithLogPrefix. When both are empty/unset, no prefix is applied.
-    std::optional<std::string> log_prefix;
-    // Optional metrics provider. Defaults to metrics::nop_provider().
-    // Mirrors Go's pine.WithMetrics.
-    metrics::Provider* metrics_provider = nullptr;
+  // When set, forces debug snapshot collection on/off, overriding Config.debug
+  // and any per-operator debug flag in JSON. Mirrors Go's pine.WithDebug.
+  std::optional<bool> debug;
+  // When set, overrides root-level log_prefix from JSON config. Mirrors Go's
+  // pine.WithLogPrefix. When both are empty/unset, no prefix is applied.
+  std::optional<std::string> log_prefix;
+  // Optional metrics provider. Defaults to metrics::nop_provider().
+  // Mirrors Go's pine.WithMetrics.
+  metrics::Provider* metrics_provider = nullptr;
 };
 
 // Forward declaration: ColumnFrame is defined in pine/column_frame.hpp.
@@ -391,77 +427,82 @@ class OperatorInput;
 // unique_ptr<Operator> member has a complete type in all TUs that
 // include pine.hpp.
 class Operator {
-public:
-    virtual ~Operator() = default;
-    virtual void init(const OperatorConfig& config) { (void)config; }
-    virtual void execute(const OperatorInput& input, OperatorOutput& out) = 0;
+ public:
+  virtual ~Operator() = default;
+  virtual void init(const OperatorConfig& config) {
+    (void)config;
+  }
+  virtual void execute(const OperatorInput& input, OperatorOutput& out) = 0;
 };
 
 class Engine {
-public:
-    explicit Engine(Config config);
-    Engine(Config config, EngineOptions options);
-    ~Engine();
-    Engine(Engine&&) noexcept;
-    Engine& operator=(Engine&&) noexcept;
-    Engine(const Engine&) = delete;
-    Engine& operator=(const Engine&) = delete;
-    static Engine from_file(const std::string& path);
-    static Engine from_file(const std::string& path, EngineOptions options);
+ public:
+  explicit Engine(Config config);
+  Engine(Config config, EngineOptions options);
+  ~Engine();
+  Engine(Engine&&) noexcept;
+  Engine& operator=(Engine&&) noexcept;
+  Engine(const Engine&) = delete;
+  Engine& operator=(const Engine&) = delete;
+  static Engine from_file(const std::string& path);
+  static Engine from_file(const std::string& path, EngineOptions options);
 
-    Result execute(const Request& request) const;
-    Result execute(const Request& request, const std::map<std::string, JsonValue>& resources) const;
-    // Cancellable variant: external_cancel.request_stop() (typically called
-    // from a different thread when the client disconnects) interrupts any
-    // cv.wait inside the DAG scheduler and aborts the run. Mirrors pine-go
-    // Execute(ctx, req) where ctx.Done() is watched at every wait.
-    Result execute(const Request& request,
-                   const std::map<std::string, JsonValue>& resources,
-                   std::stop_token external_cancel) const;
-    TracedResult execute_traced(const Request& request, const std::map<std::string, JsonValue>& resources) const;
-    // Variant of execute_traced that writes the partial result/trace/warnings
-    // into *out before re-throwing any execution error. Mirrors pine-go's
-    // (*Result, error) return contract where partial results survive errors.
-    void execute_traced_into(const Request& request,
-                              const std::map<std::string, JsonValue>& resources,
-                              TracedResult* out) const;
-    void execute_traced_into(const Request& request,
-                              const std::map<std::string, JsonValue>& resources,
-                              TracedResult* out,
-                              std::stop_token external_cancel) const;
-    std::string render_dag(const std::string& format, int collapse = 0) const;
+  Result execute(const Request& request) const;
+  Result execute(const Request& request, const std::map<std::string, JsonValue>& resources) const;
+  // Cancellable variant: external_cancel.request_stop() (typically called
+  // from a different thread when the client disconnects) interrupts any
+  // cv.wait inside the DAG scheduler and aborts the run. Mirrors pine-go
+  // Execute(ctx, req) where ctx.Done() is watched at every wait.
+  Result execute(const Request& request, const std::map<std::string, JsonValue>& resources,
+                 std::stop_token external_cancel) const;
+  TracedResult execute_traced(const Request& request,
+                              const std::map<std::string, JsonValue>& resources) const;
+  // Variant of execute_traced that writes the partial result/trace/warnings
+  // into *out before re-throwing any execution error. Mirrors pine-go's
+  // (*Result, error) return contract where partial results survive errors.
+  void execute_traced_into(const Request& request, const std::map<std::string, JsonValue>& resources,
+                           TracedResult* out) const;
+  void execute_traced_into(const Request& request, const std::map<std::string, JsonValue>& resources,
+                           TracedResult* out, std::stop_token external_cancel) const;
+  std::string render_dag(const std::string& format, int collapse = 0) const;
 
-    const ExpandedSequence& expanded() const { return expanded_; }
-    const std::string& log_prefix() const { return log_prefix_; }
-    // Cumulative peak DAG-node concurrency observed across all execute calls.
-    // Mirrors pine-go internal/runtime/stats.go peakConcurrency.
-    int64_t peak_concurrency() const;
-    // Returns the configured metrics provider (never nullptr; nop by default).
-    metrics::Provider* metrics_provider() const { return metrics_provider_; }
+  const ExpandedSequence& expanded() const {
+    return expanded_;
+  }
+  const std::string& log_prefix() const {
+    return log_prefix_;
+  }
+  // Cumulative peak DAG-node concurrency observed across all execute calls.
+  // Mirrors pine-go internal/runtime/stats.go peakConcurrency.
+  int64_t peak_concurrency() const;
+  // Returns the configured metrics provider (never nullptr; nop by default).
+  metrics::Provider* metrics_provider() const {
+    return metrics_provider_;
+  }
 
-    // OperatorCustomStats collects custom statistics from operators that implement
-    // StatsProvider. Returns an empty map when no operator reports custom stats.
-    std::map<std::string, std::map<std::string, int64_t>> operator_custom_stats() const;
+  // OperatorCustomStats collects custom statistics from operators that implement
+  // StatsProvider. Returns an empty map when no operator reports custom stats.
+  std::map<std::string, std::map<std::string, int64_t>> operator_custom_stats() const;
 
-    // Pre-created scheduler/operator metrics. Public so the scheduler in
-    // engine.cpp can record observations; not part of the stable public API.
-    struct EngineMetrics;
+  // Pre-created scheduler/operator metrics. Public so the scheduler in
+  // engine.cpp can record observations; not part of the stable public API.
+  struct EngineMetrics;
 
-private:
-    Config config_;
-    ExpandedSequence expanded_;
-    Graph graph_;
-    std::map<std::string, std::unique_ptr<Operator>> operators_;
-    std::map<std::string, InputFieldSpec> input_specs_;
-    std::string log_prefix_;
-    std::unique_ptr<std::atomic<int64_t>> peak_concurrency_;
-    metrics::Provider* metrics_provider_ = nullptr;
-    std::unique_ptr<EngineMetrics> engine_metrics_;
-    // Shared worker pool for data-parallel shards. Constructed in Engine
-    // ctor body (engine.cpp) so this header stays free of the pool
-    // implementation.
-    struct PoolHolder;
-    std::unique_ptr<PoolHolder> shard_pool_;
+ private:
+  Config config_;
+  ExpandedSequence expanded_;
+  Graph graph_;
+  std::map<std::string, std::unique_ptr<Operator>> operators_;
+  std::map<std::string, InputFieldSpec> input_specs_;
+  std::string log_prefix_;
+  std::unique_ptr<std::atomic<int64_t>> peak_concurrency_;
+  metrics::Provider* metrics_provider_ = nullptr;
+  std::unique_ptr<EngineMetrics> engine_metrics_;
+  // Shared worker pool for data-parallel shards. Constructed in Engine
+  // ctor body (engine.cpp) so this header stays free of the pool
+  // implementation.
+  struct PoolHolder;
+  std::unique_ptr<PoolHolder> shard_pool_;
 };
 
 Request load_request_from_file(const std::string& path);

--- a/pine-cpp/include/pine/resource.hpp
+++ b/pine-cpp/include/pine/resource.hpp
@@ -48,59 +48,58 @@ void reset_fetcher_registry();
 
 // Manager owns a set of named resources with background refresh.
 class Manager {
-public:
-    Manager();
-    ~Manager();
-    Manager(const Manager&) = delete;
-    Manager& operator=(const Manager&) = delete;
+ public:
+  Manager();
+  ~Manager();
+  Manager(const Manager&) = delete;
+  Manager& operator=(const Manager&) = delete;
 
-    // Register a fetcher under a name with a refresh interval (must be > 0).
-    // Throws on duplicate name or if start() already ran.
-    void register_resource(const std::string& name, Fetcher fetcher,
-                           std::chrono::seconds interval);
+  // Register a fetcher under a name with a refresh interval (must be > 0).
+  // Throws on duplicate name or if start() already ran.
+  void register_resource(const std::string& name, Fetcher fetcher, std::chrono::seconds interval);
 
-    // Load resources from a parsed Config. Each `resource_config` entry is
-    // resolved against the global FetcherFactory registry. Returns silently
-    // when no resources are configured.
-    void load_from_config(const Config& config);
+  // Load resources from a parsed Config. Each `resource_config` entry is
+  // resolved against the global FetcherFactory registry. Returns silently
+  // when no resources are configured.
+  void load_from_config(const Config& config);
 
-    // Synchronous initial load for all registered resources, then launches
-    // background refresh threads. Throws on initial-load failure.
-    void start();
+  // Synchronous initial load for all registered resources, then launches
+  // background refresh threads. Throws on initial-load failure.
+  void start();
 
-    // Cancel refresh threads and wait for them to exit. Safe to call from any
-    // state; safe to call multiple times.
-    void stop();
+  // Cancel refresh threads and wait for them to exit. Safe to call from any
+  // state; safe to call multiple times.
+  void stop();
 
-    // Returns a snapshot of all currently-loaded resources. Pass to
-    // `Engine::execute(request, snapshot)`.
-    std::map<std::string, JsonValue> snapshot() const;
+  // Returns a snapshot of all currently-loaded resources. Pass to
+  // `Engine::execute(request, snapshot)`.
+  std::map<std::string, JsonValue> snapshot() const;
 
-    // Returns the registered resource names, sorted.
-    std::vector<std::string> names() const;
+  // Returns the registered resource names, sorted.
+  std::vector<std::string> names() const;
 
-    // ValidateResourceDeps checks that every resource_name referenced in the
-    // Config's operators is registered in the Manager. Throws on missing.
-    void validate_resource_deps(const Config& config) const;
+  // ValidateResourceDeps checks that every resource_name referenced in the
+  // Config's operators is registered in the Manager. Throws on missing.
+  void validate_resource_deps(const Config& config) const;
 
-private:
-    struct Managed {
-        std::string name;
-        Fetcher fetcher;
-        std::chrono::seconds interval{0};
-        JsonValue value;
-        bool loaded = false;
-    };
+ private:
+  struct Managed {
+    std::string name;
+    Fetcher fetcher;
+    std::chrono::seconds interval{0};
+    JsonValue value;
+    bool loaded = false;
+  };
 
-    void refresh_loop(Managed* r);
+  void refresh_loop(Managed* r);
 
-    mutable std::shared_mutex mu_;
-    std::map<std::string, std::unique_ptr<Managed>> resources_;
-    std::vector<std::thread> refresh_threads_;
-    std::mutex stop_mu_;
-    std::condition_variable stop_cv_;
-    std::atomic<bool> stopping_{false};
-    bool started_ = false;
+  mutable std::shared_mutex mu_;
+  std::map<std::string, std::unique_ptr<Managed>> resources_;
+  std::vector<std::thread> refresh_threads_;
+  std::mutex stop_mu_;
+  std::condition_variable stop_cv_;
+  std::atomic<bool> stopping_{false};
+  bool started_ = false;
 };
 
 }  // namespace resource

--- a/pine-cpp/include/pine/row_frame.hpp
+++ b/pine-cpp/include/pine/row_frame.hpp
@@ -24,58 +24,59 @@ namespace pine {
 // Added when pine-cpp grew dual physical representation to match
 // pine-go's Frame interface. Selected via Config.storage_mode = "row".
 class RowFrame : public Frame {
-public:
-    RowFrame();
-    RowFrame(std::map<std::string, JsonValue> common,
-             std::vector<std::map<std::string, JsonValue>> items);
+ public:
+  RowFrame();
+  RowFrame(std::map<std::string, JsonValue> common, std::vector<std::map<std::string, JsonValue>> items);
 
-    // ---- Frame interface ----
-    JsonValue common(const std::string& field) const override;
-    bool has_common(const std::string& field) const override;
-    void set_common(const std::string& field, JsonValue value) override;
-    std::vector<std::string> common_fields() const override;
+  // ---- Frame interface ----
+  JsonValue common(const std::string& field) const override;
+  bool has_common(const std::string& field) const override;
+  void set_common(const std::string& field, JsonValue value) override;
+  std::vector<std::string> common_fields() const override;
 
-    std::size_t item_count() const override;
-    JsonValue item(std::size_t index, const std::string& field) const override;
-    bool item_has(std::size_t index, const std::string& field) const override;
-    std::vector<std::string> item_fields() const override;
+  std::size_t item_count() const override;
+  JsonValue item(std::size_t index, const std::string& field) const override;
+  bool item_has(std::size_t index, const std::string& field) const override;
+  std::vector<std::string> item_fields() const override;
 
-    void set_resources(const std::map<std::string, JsonValue>* res) override { resources_ = res; }
-    const std::map<std::string, JsonValue>* resources() const override { return resources_; }
+  void set_resources(const std::map<std::string, JsonValue>* res) override {
+    resources_ = res;
+  }
+  const std::map<std::string, JsonValue>* resources() const override {
+    return resources_;
+  }
 
-    void push_warning(std::string msg) override;
-    std::vector<std::string> take_warnings() override;
+  void push_warning(std::string msg) override;
+  std::vector<std::string> take_warnings() override;
 
-    void apply_output(const OperatorOutput& out,
-                      const std::string& op_name,
-                      bool is_recall) override;
+  void apply_output(const OperatorOutput& out, const std::string& op_name, bool is_recall) override;
 
-    Result to_result(const std::vector<std::string>& common_out,
-                     const std::vector<std::string>& item_out) const override;
+  Result to_result(const std::vector<std::string>& common_out,
+                   const std::vector<std::string>& item_out) const override;
 
-    JsonValue::object_t item_object(std::size_t index) const override;
+  JsonValue::object_t item_object(std::size_t index) const override;
 
-    std::unique_ptr<Frame> make_window_view(std::size_t row_offset,
-                                             std::size_t row_count) const override;
+  std::unique_ptr<Frame> make_window_view(std::size_t row_offset, std::size_t row_count) const override;
 
-    std::pair<std::string, int> validate_strict_items(
-        const std::vector<std::string>& fields) const override;
+  std::pair<std::string, int> validate_strict_items(const std::vector<std::string>& fields) const override;
 
-private:
-    mutable std::shared_mutex mu_;
-    std::map<std::string, JsonValue> common_;
-    std::vector<std::map<std::string, JsonValue>> items_;
-    std::vector<std::string> warnings_;
-    const std::map<std::string, JsonValue>* resources_ = nullptr;
+ private:
+  mutable std::shared_mutex mu_;
+  std::map<std::string, JsonValue> common_;
+  std::vector<std::map<std::string, JsonValue>> items_;
+  std::vector<std::string> warnings_;
+  const std::map<std::string, JsonValue>* resources_ = nullptr;
 
-    // Window-view mode: when set, reads delegate to parent storage with
-    // an (offset, count) translation; writes throw. Set only by
-    // make_window_view.
-    const std::map<std::string, JsonValue>* view_common_ = nullptr;
-    const std::vector<std::map<std::string, JsonValue>>* view_items_ = nullptr;
-    std::size_t view_offset_ = 0;
-    std::size_t view_count_ = 0;
-    bool is_window_view() const noexcept { return view_items_ != nullptr; }
+  // Window-view mode: when set, reads delegate to parent storage with
+  // an (offset, count) translation; writes throw. Set only by
+  // make_window_view.
+  const std::map<std::string, JsonValue>* view_common_ = nullptr;
+  const std::vector<std::map<std::string, JsonValue>>* view_items_ = nullptr;
+  std::size_t view_offset_ = 0;
+  std::size_t view_count_ = 0;
+  bool is_window_view() const noexcept {
+    return view_items_ != nullptr;
+  }
 };
 
 }  // namespace pine

--- a/pine-cpp/operators/_helpers.cpp
+++ b/pine-cpp/operators/_helpers.cpp
@@ -1,4 +1,5 @@
 #include "operators/_helpers.hpp"
+
 #include "pine/operator_input.hpp"
 
 #include <algorithm>
@@ -11,233 +12,338 @@ namespace pine {
 namespace operators {
 
 double to_double(const JsonValue& value) {
-    if (value.is_bool()) throw OperatorError("cannot convert bool to float64");
-    if (value.is_number()) return value.as_number();
-    if (value.is_null()) throw OperatorError("cannot convert <nil> to float64");
-    if (value.is_string()) throw OperatorError("cannot convert string to float64");
-    if (value.is_array()) throw OperatorError("cannot convert []interface {} to float64");
-    throw OperatorError("cannot convert map[string]interface {} to float64");
+  if (value.is_bool()) {
+    throw OperatorError("cannot convert bool to float64");
+  }
+  if (value.is_number()) {
+    return value.as_number();
+  }
+  if (value.is_null()) {
+    throw OperatorError("cannot convert <nil> to float64");
+  }
+  if (value.is_string()) {
+    throw OperatorError("cannot convert string to float64");
+  }
+  if (value.is_array()) {
+    throw OperatorError("cannot convert []interface {} to float64");
+  }
+  throw OperatorError("cannot convert map[string]interface {} to float64");
 }
 
 std::string json_type_name(const JsonValue& value) {
-    if (value.is_null()) return "<nil>";
-    if (value.is_bool()) return "bool";
-    if (value.is_number()) return "float64";
-    if (value.is_string()) return "string";
-    if (value.is_array()) return "[]interface {}";
-    if (value.is_object()) return "map[string]interface {}";
-    return "unknown";
+  if (value.is_null()) {
+    return "<nil>";
+  }
+  if (value.is_bool()) {
+    return "bool";
+  }
+  if (value.is_number()) {
+    return "float64";
+  }
+  if (value.is_string()) {
+    return "string";
+  }
+  if (value.is_array()) {
+    return "[]interface {}";
+  }
+  if (value.is_object()) {
+    return "map[string]interface {}";
+  }
+  return "unknown";
 }
 
 JsonValue require_common(const Frame& frame, const OperatorConfig& op, const std::string& field) {
-    JsonValue v = frame.common(field);
-    if (!v.is_null()) return v;
-    if (auto def = op.common_defaults.find(field); def != op.common_defaults.end()) return def->second;
-    throw ExecutionError("required field \"" + field + "\" is nil in common");
+  JsonValue v = frame.common(field);
+  if (!v.is_null()) {
+    return v;
+  }
+  if (auto def = op.common_defaults.find(field); def != op.common_defaults.end()) {
+    return def->second;
+  }
+  throw ExecutionError("required field \"" + field + "\" is nil in common");
 }
 
-JsonValue require_item(const Frame& frame, const OperatorConfig& op, std::size_t index, const std::string& field) {
-    JsonValue v = frame.item(index, field);
-    if (!v.is_null()) return v;
-    if (auto def = op.item_defaults.find(field); def != op.item_defaults.end()) return def->second;
-    throw ExecutionError("required field \"" + field + "\" is nil on item[" + std::to_string(index) + "]");
+JsonValue require_item(const Frame& frame, const OperatorConfig& op, std::size_t index,
+                       const std::string& field) {
+  JsonValue v = frame.item(index, field);
+  if (!v.is_null()) {
+    return v;
+  }
+  if (auto def = op.item_defaults.find(field); def != op.item_defaults.end()) {
+    return def->second;
+  }
+  throw ExecutionError("required field \"" + field + "\" is nil on item[" + std::to_string(index) + "]");
 }
 
-JsonValue require_common_by_name(const Frame& frame,
-                                  const std::map<std::string, JsonValue>& defaults,
-                                  const std::string& field) {
-    JsonValue v = frame.common(field);
-    if (!v.is_null()) return v;
-    if (auto def = defaults.find(field); def != defaults.end()) return def->second;
-    throw ExecutionError("required field \"" + field + "\" is nil in common");
+JsonValue require_common_by_name(const Frame& frame, const std::map<std::string, JsonValue>& defaults,
+                                 const std::string& field) {
+  JsonValue v = frame.common(field);
+  if (!v.is_null()) {
+    return v;
+  }
+  if (auto def = defaults.find(field); def != defaults.end()) {
+    return def->second;
+  }
+  throw ExecutionError("required field \"" + field + "\" is nil in common");
 }
 
 JsonValue require_item_by_name(const Frame& frame, std::size_t index,
-                                const std::map<std::string, JsonValue>& defaults,
-                                const std::string& field) {
-    JsonValue v = frame.item(index, field);
-    if (!v.is_null()) return v;
-    if (auto def = defaults.find(field); def != defaults.end()) return def->second;
-    throw ExecutionError("required field \"" + field + "\" is nil on item[" + std::to_string(index) + "]");
+                               const std::map<std::string, JsonValue>& defaults, const std::string& field) {
+  JsonValue v = frame.item(index, field);
+  if (!v.is_null()) {
+    return v;
+  }
+  if (auto def = defaults.find(field); def != defaults.end()) {
+    return def->second;
+  }
+  throw ExecutionError("required field \"" + field + "\" is nil on item[" + std::to_string(index) + "]");
 }
 
 std::string go_format_g(double d) {
-    if (std::isnan(d)) return "NaN";
-    if (std::isinf(d)) return d < 0 ? "-Inf" : "+Inf";
-    if (d == 0.0) return std::signbit(d) ? "-0" : "0";
+  if (std::isnan(d)) {
+    return "NaN";
+  }
+  if (std::isinf(d)) {
+    return d < 0 ? "-Inf" : "+Inf";
+  }
+  if (d == 0.0) {
+    return std::signbit(d) ? "-0" : "0";
+  }
 
-    char buf[64];
-    auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), d, std::chars_format::scientific);
-    std::string s(buf, ptr);
+  char buf[64];
+  auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), d, std::chars_format::scientific);
+  std::string s(buf, ptr);
 
-    std::size_t i = 0;
-    bool neg = false;
-    if (s[i] == '-') { neg = true; ++i; }
-    std::string mantissa;
-    while (i < s.size() && s[i] != 'e' && s[i] != 'E') {
-        if (s[i] != '.') mantissa.push_back(s[i]);
-        ++i;
+  std::size_t i = 0;
+  bool neg = false;
+  if (s[i] == '-') {
+    neg = true;
+    ++i;
+  }
+  std::string mantissa;
+  while (i < s.size() && s[i] != 'e' && s[i] != 'E') {
+    if (s[i] != '.') {
+      mantissa.push_back(s[i]);
     }
-    ++i;  // skip 'e'
-    bool exp_neg = false;
-    if (i < s.size() && (s[i] == '+' || s[i] == '-')) {
-        exp_neg = (s[i] == '-');
-        ++i;
+    ++i;
+  }
+  ++i;  // skip 'e'
+  bool exp_neg = false;
+  if (i < s.size() && (s[i] == '+' || s[i] == '-')) {
+    exp_neg = (s[i] == '-');
+    ++i;
+  }
+  int exp_val = 0;
+  while (i < s.size()) {
+    exp_val = exp_val * 10 + (s[i] - '0');
+    ++i;
+  }
+  if (exp_neg) {
+    exp_val = -exp_val;
+  }
+
+  int nd = static_cast<int>(mantissa.size());
+  std::string result;
+  if (neg) {
+    result += '-';
+  }
+
+  if (exp_val < -4 || exp_val >= 6) {
+    result += mantissa[0];
+    if (nd > 1) {
+      result += '.';
+      result.append(mantissa, 1, std::string::npos);
     }
-    int exp_val = 0;
-    while (i < s.size()) { exp_val = exp_val * 10 + (s[i] - '0'); ++i; }
-    if (exp_neg) exp_val = -exp_val;
-
-    int nd = static_cast<int>(mantissa.size());
-    std::string result;
-    if (neg) result += '-';
-
-    if (exp_val < -4 || exp_val >= 6) {
-        result += mantissa[0];
-        if (nd > 1) {
-            result += '.';
-            result.append(mantissa, 1, std::string::npos);
-        }
-        result += 'e';
-        int e = exp_val;
-        if (e >= 0) result += '+';
-        else { result += '-'; e = -e; }
-        if (e < 10) result += '0';
-        result += std::to_string(e);
+    result += 'e';
+    int e = exp_val;
+    if (e >= 0) {
+      result += '+';
     } else {
-        int dp_pos = exp_val + 1;
-        if (dp_pos <= 0) {
-            result += "0.";
-            for (int k = 0; k < -dp_pos; ++k) result += '0';
-            result += mantissa;
-        } else if (dp_pos >= nd) {
-            result += mantissa;
-            for (int k = 0; k < dp_pos - nd; ++k) result += '0';
-        } else {
-            result.append(mantissa, 0, dp_pos);
-            result += '.';
-            result.append(mantissa, dp_pos, std::string::npos);
-        }
+      result += '-';
+      e = -e;
     }
-    return result;
+    if (e < 10) {
+      result += '0';
+    }
+    result += std::to_string(e);
+  } else {
+    int dp_pos = exp_val + 1;
+    if (dp_pos <= 0) {
+      result += "0.";
+      for (int k = 0; k < -dp_pos; ++k) {
+        result += '0';
+      }
+      result += mantissa;
+    } else if (dp_pos >= nd) {
+      result += mantissa;
+      for (int k = 0; k < dp_pos - nd; ++k) {
+        result += '0';
+      }
+    } else {
+      result.append(mantissa, 0, dp_pos);
+      result += '.';
+      result.append(mantissa, dp_pos, std::string::npos);
+    }
+  }
+  return result;
 }
 
 // go_format_lookup_key mirrors pine-go transform/resource_lookup.go:91-96.
 // Note: distinct from go_format_g — never emits scientific notation, so
 // `1e-5` becomes `"0.00001"` not `"1e-05"`.
 std::string go_format_lookup_key(double d) {
-    if (std::isnan(d) || std::isinf(d)) {
-        // Match strconv.FormatFloat for these edge cases via go_format_g —
-        // they will not normally hit a lookup table anyway.
-        return go_format_g(d);
-    }
-    // Integer-valued floats: strconv.FormatInt produces the decimal
-    // representation with no decimal point.
-    if (d == static_cast<double>(static_cast<int64_t>(d)) &&
-        d >= static_cast<double>(std::numeric_limits<int64_t>::min()) &&
-        d <= static_cast<double>(std::numeric_limits<int64_t>::max())) {
-        return std::to_string(static_cast<int64_t>(d));
-    }
-    // FormatFloat(d, 'f', -1, 64): shortest non-scientific representation
-    // that round-trips. std::to_chars(d, chars_format::fixed) is the
-    // closest C++ analog and produces identical output for finite
-    // doubles in the cases that matter here.
-    char buf[64];
-    auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), d, std::chars_format::fixed);
-    if (ec != std::errc{}) {
-        return go_format_g(d);  // fallback
-    }
-    return std::string(buf, ptr);
+  if (std::isnan(d) || std::isinf(d)) {
+    // Match strconv.FormatFloat for these edge cases via go_format_g —
+    // they will not normally hit a lookup table anyway.
+    return go_format_g(d);
+  }
+  // Integer-valued floats: strconv.FormatInt produces the decimal
+  // representation with no decimal point.
+  if (d == static_cast<double>(static_cast<int64_t>(d)) &&
+      d >= static_cast<double>(std::numeric_limits<int64_t>::min()) &&
+      d <= static_cast<double>(std::numeric_limits<int64_t>::max())) {
+    return std::to_string(static_cast<int64_t>(d));
+  }
+  // FormatFloat(d, 'f', -1, 64): shortest non-scientific representation
+  // that round-trips. std::to_chars(d, chars_format::fixed) is the
+  // closest C++ analog and produces identical output for finite
+  // doubles in the cases that matter here.
+  char buf[64];
+  auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), d, std::chars_format::fixed);
+  if (ec != std::errc{}) {
+    return go_format_g(d);  // fallback
+  }
+  return std::string(buf, ptr);
 }
 
 std::string sprint_value(const JsonValue& v) {
-    if (v.is_null()) return "<nil>";
-    if (v.is_bool()) return v.as_bool() ? "true" : "false";
-    if (v.is_number()) return go_format_g(v.as_number());
-    if (v.is_string()) return v.as_string();
-    return "<complex>";
+  if (v.is_null()) {
+    return "<nil>";
+  }
+  if (v.is_bool()) {
+    return v.as_bool() ? "true" : "false";
+  }
+  if (v.is_number()) {
+    return go_format_g(v.as_number());
+  }
+  if (v.is_string()) {
+    return v.as_string();
+  }
+  return "<complex>";
 }
 
 std::string any_to_string(const JsonValue& v) {
-    if (v.is_null()) return "";
-    if (v.is_string()) return v.as_string();
-    if (v.is_number()) return go_format_g(v.as_number());
-    if (v.is_bool()) return v.as_bool() ? "true" : "false";
-    return dump_json(v, 0);
+  if (v.is_null()) {
+    return "";
+  }
+  if (v.is_string()) {
+    return v.as_string();
+  }
+  if (v.is_number()) {
+    return go_format_g(v.as_number());
+  }
+  if (v.is_bool()) {
+    return v.as_bool() ? "true" : "false";
+  }
+  return dump_json(v, 0);
 }
 
 std::string dedup_key(const JsonValue& v) {
-    if (v.is_null()) return "N:";
-    if (v.is_bool()) return v.as_bool() ? "B:1" : "B:0";
-    if (v.is_number()) {
-        double d = v.as_number();
-        // Canonicalize -0.0 to +0.0 (IEEE 754: -0 == +0).
-        if (d == 0.0) d = 0.0;
-        return "F:" + go_format_g(d);
+  if (v.is_null()) {
+    return "N:";
+  }
+  if (v.is_bool()) {
+    return v.as_bool() ? "B:1" : "B:0";
+  }
+  if (v.is_number()) {
+    double d = v.as_number();
+    // Canonicalize -0.0 to +0.0 (IEEE 754: -0 == +0).
+    if (d == 0.0) {
+      d = 0.0;
     }
-    if (v.is_string()) return "S:" + v.as_string();
-    // Composite types (array/object) must produce distinct keys.
-    // Previously returned "O:<complex>" for both → all composites collided.
-    // Use compact JSON serialization (deterministic, distinguishes types).
-    return "O:" + dump_json(v, 0);
+    return "F:" + go_format_g(d);
+  }
+  if (v.is_string()) {
+    return "S:" + v.as_string();
+  }
+  // Composite types (array/object) must produce distinct keys.
+  // Previously returned "O:<complex>" for both → all composites collided.
+  // Use compact JSON serialization (deterministic, distinguishes types).
+  return "O:" + dump_json(v, 0);
 }
 
 std::string build_key_suffix(const Frame& frame, const std::vector<std::string>& fields) {
-    if (fields.empty()) return "";
-    std::string result;
-    for (std::size_t i = 0; i < fields.size(); ++i) {
-        if (i > 0) result += ':';
-        result += sprint_value(frame.common(fields[i]));
+  if (fields.empty()) {
+    return "";
+  }
+  std::string result;
+  for (std::size_t i = 0; i < fields.size(); ++i) {
+    if (i > 0) {
+      result += ':';
     }
-    return result;
+    result += sprint_value(frame.common(fields[i]));
+  }
+  return result;
 }
 
 std::string build_key_suffix(const OperatorInput& input, const std::vector<std::string>& fields) {
-    if (fields.empty()) return "";
-    std::string result;
-    for (std::size_t i = 0; i < fields.size(); ++i) {
-        if (i > 0) result += ':';
-        result += sprint_value(input.common(fields[i]));
+  if (fields.empty()) {
+    return "";
+  }
+  std::string result;
+  for (std::size_t i = 0; i < fields.size(); ++i) {
+    if (i > 0) {
+      result += ':';
     }
-    return result;
+    result += sprint_value(input.common(fields[i]));
+  }
+  return result;
 }
 
 std::vector<std::string> json_to_string_slice(const JsonValue& v) {
-    std::vector<std::string> out;
-    if (!v.is_array()) return out;
-    for (const auto& item : v.as_array()) {
-        out.push_back(sprint_value(item));
-    }
+  std::vector<std::string> out;
+  if (!v.is_array()) {
     return out;
+  }
+  for (const auto& item : v.as_array()) {
+    out.push_back(sprint_value(item));
+  }
+  return out;
 }
 
 RedisParams parse_redis_params(const OperatorConfig& op) {
-    RedisParams rp;
-    const auto& params = op.params.as_object();
-    auto addr_it = params.find("redis_addr");
-    if (addr_it != params.end() && addr_it->second.is_string()) {
-        const auto& addr = addr_it->second.as_string();
-        auto colon = addr.rfind(':');
-        if (colon != std::string::npos) {
-            rp.host = addr.substr(0, colon);
-            rp.port = std::stoi(addr.substr(colon + 1));
-        } else {
-            rp.host = addr;
-        }
+  RedisParams rp;
+  const auto& params = op.params.as_object();
+  auto addr_it = params.find("redis_addr");
+  if (addr_it != params.end() && addr_it->second.is_string()) {
+    const auto& addr = addr_it->second.as_string();
+    auto colon = addr.rfind(':');
+    if (colon != std::string::npos) {
+      rp.host = addr.substr(0, colon);
+      rp.port = std::stoi(addr.substr(colon + 1));
+    } else {
+      rp.host = addr;
     }
-    if (auto it = params.find("redis_password"); it != params.end() && it->second.is_string())
-        rp.password = it->second.as_string();
-    if (auto it = params.find("redis_db"); it != params.end() && it->second.is_number())
-        rp.db = static_cast<int>(it->second.as_number());
-    if (auto it = params.find("key_prefix"); it != params.end() && it->second.is_string())
-        rp.key_prefix = it->second.as_string();
-    if (auto it = params.find("data_type"); it != params.end() && it->second.is_string())
-        rp.data_type = it->second.as_string();
-    if (auto it = params.find("ttl"); it != params.end() && it->second.is_number())
-        rp.ttl = static_cast<int>(it->second.as_number());
-    if (auto it = params.find("fail_on_error"); it != params.end() && it->second.is_bool())
-        rp.fail_on_error = it->second.as_bool();
-    return rp;
+  }
+  if (auto it = params.find("redis_password"); it != params.end() && it->second.is_string()) {
+    rp.password = it->second.as_string();
+  }
+  if (auto it = params.find("redis_db"); it != params.end() && it->second.is_number()) {
+    rp.db = static_cast<int>(it->second.as_number());
+  }
+  if (auto it = params.find("key_prefix"); it != params.end() && it->second.is_string()) {
+    rp.key_prefix = it->second.as_string();
+  }
+  if (auto it = params.find("data_type"); it != params.end() && it->second.is_string()) {
+    rp.data_type = it->second.as_string();
+  }
+  if (auto it = params.find("ttl"); it != params.end() && it->second.is_number()) {
+    rp.ttl = static_cast<int>(it->second.as_number());
+  }
+  if (auto it = params.find("fail_on_error"); it != params.end() && it->second.is_bool()) {
+    rp.fail_on_error = it->second.as_bool();
+  }
+  return rp;
 }
 
 }  // namespace operators

--- a/pine-cpp/operators/_helpers.hpp
+++ b/pine-cpp/operators/_helpers.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include "pine/pine.hpp"
-#include "pine/operator_input.hpp"
 #include "pine/column_frame.hpp"
+#include "pine/operator_input.hpp"
+#include "pine/pine.hpp"
 
 #include <cstdint>
 #include <string>
@@ -14,8 +14,8 @@ using Frame = pine::Frame;
 
 // Exception type for operator-internal errors (converted to ExecutionError by caller).
 class OperatorError : public std::runtime_error {
-public:
-    using std::runtime_error::runtime_error;
+ public:
+  using std::runtime_error::runtime_error;
 };
 
 double to_double(const JsonValue& value);
@@ -29,19 +29,18 @@ double to_double(const JsonValue& value);
 std::string json_type_name(const JsonValue& value);
 
 JsonValue require_common(const Frame& frame, const OperatorConfig& op, const std::string& field);
-JsonValue require_item(const Frame& frame, const OperatorConfig& op, std::size_t index, const std::string& field);
+JsonValue require_item(const Frame& frame, const OperatorConfig& op, std::size_t index,
+                       const std::string& field);
 
 // Variants that take the operator name + defaults map directly. Operators
 // that cached `op_name_` / `common_defaults_` / `item_defaults_` on `init`
 // (transform_copy, transform_normalize, reorder_sort, ...) used to keep a
 // per-class copy of these helpers; consolidated to one place so future
 // error-message tweaks land once.
-JsonValue require_common_by_name(const Frame& frame,
-                                  const std::map<std::string, JsonValue>& defaults,
-                                  const std::string& field);
+JsonValue require_common_by_name(const Frame& frame, const std::map<std::string, JsonValue>& defaults,
+                                 const std::string& field);
 JsonValue require_item_by_name(const Frame& frame, std::size_t index,
-                                const std::map<std::string, JsonValue>& defaults,
-                                const std::string& field);
+                               const std::map<std::string, JsonValue>& defaults, const std::string& field);
 
 std::string go_format_g(double d);
 // go_format_lookup_key mirrors pine-go transform/resource_lookup.go:91-96:
@@ -58,14 +57,14 @@ std::string build_key_suffix(const OperatorInput& input, const std::vector<std::
 std::vector<std::string> json_to_string_slice(const JsonValue& v);
 
 struct RedisParams {
-    std::string host;
-    int port = 6379;
-    std::string password;
-    int db = 0;
-    std::string key_prefix;
-    std::string data_type = "string";
-    int ttl = 0;
-    bool fail_on_error = false;
+  std::string host;
+  int port = 6379;
+  std::string password;
+  int db = 0;
+  std::string key_prefix;
+  std::string data_type = "string";
+  int ttl = 0;
+  bool fail_on_error = false;
 };
 
 RedisParams parse_redis_params(const OperatorConfig& op);

--- a/pine-cpp/operators/filter/filter_condition.cpp
+++ b/pine-cpp/operators/filter/filter_condition.cpp
@@ -1,39 +1,48 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
+
+#include "operators/_helpers.hpp"
 
 namespace pine {
 
 class FilterConditionOp : public Operator, public ConsumesRowSet, public MutatesRowSet {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        const auto& params = cfg.params.as_object();
-        auto val_it = params.find("value");
-        if (val_it == params.end())
-            throw ExecutionError("filter_condition: missing required param 'value'");
-        target_ = operators::sprint_value(val_it->second);
-        field_ = cfg.metadata.item_input.at(0);
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    const auto& params = cfg.params.as_object();
+    auto val_it = params.find("value");
+    if (val_it == params.end()) {
+      throw ExecutionError("filter_condition: missing required param 'value'");
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        for (std::size_t i = 0; i < input.item_count(); ++i) {
-            JsonValue fv = input.item(i, field_);
-            if (operators::sprint_value(fv) == target_) out.remove_item(static_cast<int>(i));
-        }
+    target_ = operators::sprint_value(val_it->second);
+    field_ = cfg.metadata.item_input.at(0);
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    for (std::size_t i = 0; i < input.item_count(); ++i) {
+      JsonValue fv = input.item(i, field_);
+      if (operators::sprint_value(fv) == target_) {
+        out.remove_item(static_cast<int>(i));
+      }
     }
-private:
-    std::string op_name_;
-    std::string target_;
-    std::string field_;
+  }
+
+ private:
+  std::string op_name_;
+  std::string target_;
+  std::string field_;
 };
 
 static const OperatorSchema k_filter_condition_schema{
     .name = "filter_condition",
     .type = OpType::Filter,
     .description = "Removes items where a specified field equals a given value.",
-    .params = {
-        {"value", {.type = "any", .required = true, .default_value = JsonValue(nullptr),
-                   .description = "Items where field == value are removed."}},
-    },
+    .params =
+        {
+            {"value",
+             {.type = "any",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Items where field == value are removed."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(FilterConditionOp, k_filter_condition_schema)
 

--- a/pine-cpp/operators/filter/filter_paginate.cpp
+++ b/pine-cpp/operators/filter/filter_paginate.cpp
@@ -1,37 +1,51 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
+
+#include "operators/_helpers.hpp"
 
 namespace pine {
 
 class FilterPaginateOp : public Operator, public ConsumesRowSet, public MutatesRowSet {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        page_field_ = cfg.metadata.common_input.at(0);
-        size_field_ = cfg.metadata.common_input.at(1);
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    page_field_ = cfg.metadata.common_input.at(0);
+    size_field_ = cfg.metadata.common_input.at(1);
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    int n = static_cast<int>(input.item_count());
+    if (n == 0) {
+      return;
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        int n = static_cast<int>(input.item_count());
-        if (n == 0) return;
-        auto to_int = [](const JsonValue& v) -> int {
-            if (v.is_number()) return static_cast<int>(v.as_number());
-            return 0;
-        };
-        int page = to_int(input.common(page_field_));
-        int size = to_int(input.common(size_field_));
-        if (size <= 0) size = 10;
-        if (page < 0) page = 0;
-        int start = page * size;
-        int end = start + size;
-        if (end > n) end = n;
-        for (int i = 0; i < n; ++i) {
-            if (i < start || i >= end) out.remove_item(i);
-        }
+    auto to_int = [](const JsonValue& v) -> int {
+      if (v.is_number()) {
+        return static_cast<int>(v.as_number());
+      }
+      return 0;
+    };
+    int page = to_int(input.common(page_field_));
+    int size = to_int(input.common(size_field_));
+    if (size <= 0) {
+      size = 10;
     }
-private:
-    std::string op_name_;
-    std::string page_field_;
-    std::string size_field_;
+    if (page < 0) {
+      page = 0;
+    }
+    int start = page * size;
+    int end = start + size;
+    if (end > n) {
+      end = n;
+    }
+    for (int i = 0; i < n; ++i) {
+      if (i < start || i >= end) {
+        out.remove_item(i);
+      }
+    }
+  }
+
+ private:
+  std::string op_name_;
+  std::string page_field_;
+  std::string size_field_;
 };
 
 static const OperatorSchema k_filter_paginate_schema{

--- a/pine-cpp/operators/filter/filter_truncate.cpp
+++ b/pine-cpp/operators/filter/filter_truncate.cpp
@@ -1,33 +1,42 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
+
+#include "operators/_helpers.hpp"
 
 namespace pine {
 
 class FilterTruncateOp : public Operator, public ConsumesRowSet, public MutatesRowSet {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        top_n_ = static_cast<int>(cfg.params.as_object().at("top_n").as_number());
-        if (top_n_ < 0)
-            throw ExecutionError("filter_truncate: top_n must be non-negative, got " + std::to_string(top_n_));
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    top_n_ = static_cast<int>(cfg.params.as_object().at("top_n").as_number());
+    if (top_n_ < 0) {
+      throw ExecutionError("filter_truncate: top_n must be non-negative, got " + std::to_string(top_n_));
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        int n = static_cast<int>(input.item_count());
-        for (int i = top_n_; i < n; ++i) out.remove_item(i);
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    int n = static_cast<int>(input.item_count());
+    for (int i = top_n_; i < n; ++i) {
+      out.remove_item(i);
     }
-private:
-    std::string op_name_;
-    int top_n_ = 0;
+  }
+
+ private:
+  std::string op_name_;
+  int top_n_ = 0;
 };
 
 static const OperatorSchema k_filter_truncate_schema{
     .name = "filter_truncate",
     .type = OpType::Filter,
     .description = "Keeps only the first N items, removing the rest.",
-    .params = {
-        {"top_n", {.type = "int64", .required = true, .default_value = JsonValue(nullptr),
-                   .description = "Number of items to keep."}},
-    },
+    .params =
+        {
+            {"top_n",
+             {.type = "int64",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Number of items to keep."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(FilterTruncateOp, k_filter_truncate_schema)
 

--- a/pine-cpp/operators/merge/merge_dedup.cpp
+++ b/pine-cpp/operators/merge/merge_dedup.cpp
@@ -1,41 +1,52 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
+
+#include "operators/_helpers.hpp"
 
 namespace pine {
 
 class MergeDedupOp : public Operator, public ConsumesRowSet, public MutatesRowSet {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        field_ = cfg.metadata.item_input.at(0);
-    }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        std::vector<std::string> seen;
-        for (std::size_t i = 0; i < input.item_count(); ++i) {
-            JsonValue fv = input.item(i, field_);
-            std::string key = operators::dedup_key(fv);
-            bool dup = false;
-            for (const auto& s : seen) { if (s == key) { dup = true; break; } }
-            if (dup) {
-                out.remove_item(static_cast<int>(i));
-            } else {
-                seen.push_back(key);
-            }
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    field_ = cfg.metadata.item_input.at(0);
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    std::vector<std::string> seen;
+    for (std::size_t i = 0; i < input.item_count(); ++i) {
+      JsonValue fv = input.item(i, field_);
+      std::string key = operators::dedup_key(fv);
+      bool dup = false;
+      for (const auto& s : seen) {
+        if (s == key) {
+          dup = true;
+          break;
         }
+      }
+      if (dup) {
+        out.remove_item(static_cast<int>(i));
+      } else {
+        seen.push_back(key);
+      }
     }
-private:
-    std::string op_name_;
-    std::string field_;
+  }
+
+ private:
+  std::string op_name_;
+  std::string field_;
 };
 
 static const OperatorSchema k_merge_dedup_schema{
     .name = "merge_dedup",
     .type = OpType::Merge,
     .description = "Deduplicates items by a key field, keeping the first occurrence.",
-    .params = {
-        {"strategy", {.type = "string", .required = false, .default_value = JsonValue("first"),
-                      .description = "Dedup strategy \xe2\x80\x94 \"first\" keeps first occurrence."}},
-    },
+    .params =
+        {
+            {"strategy",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue("first"),
+              .description = "Dedup strategy \xe2\x80\x94 \"first\" keeps first occurrence."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(MergeDedupOp, k_merge_dedup_schema)
 

--- a/pine-cpp/operators/observe/observe_log.cpp
+++ b/pine-cpp/operators/observe/observe_log.cpp
@@ -1,68 +1,77 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
 
 #include <iostream>
 
+#include "operators/_helpers.hpp"
+
 namespace pine {
 
 class ObserveLogOp : public Operator {
-public:
-    void init(const OperatorConfig& cfg) override {
-        common_input_ = cfg.metadata.common_input;
-        item_input_ = cfg.metadata.item_input;
-        const auto& params = cfg.params.as_object();
-        auto it = params.find("log_prefix");
-        if (it != params.end() && !it->second.is_null()) {
-            prefix_ = it->second.as_string();
+ public:
+  void init(const OperatorConfig& cfg) override {
+    common_input_ = cfg.metadata.common_input;
+    item_input_ = cfg.metadata.item_input;
+    const auto& params = cfg.params.as_object();
+    auto it = params.find("log_prefix");
+    if (it != params.end() && !it->second.is_null()) {
+      prefix_ = it->second.as_string();
+    }
+  }
+
+  void execute(const OperatorInput& input, OperatorOutput& /*out*/) override {
+    JsonValue::object_t snapshot;
+    if (!common_input_.empty()) {
+      JsonValue::object_t common;
+      for (const auto& k : common_input_) {
+        common[k] = input.common(k);
+      }
+      snapshot["common"] = JsonValue(std::move(common));
+    }
+    if (!item_input_.empty() && input.item_count() > 0) {
+      JsonValue::array_t items;
+      items.reserve(input.item_count());
+      for (std::size_t i = 0; i < input.item_count(); ++i) {
+        JsonValue::object_t row;
+        for (const auto& k : item_input_) {
+          row[k] = input.item(i, k);
         }
+        items.push_back(JsonValue(std::move(row)));
+      }
+      snapshot["items"] = JsonValue(std::move(items));
     }
 
-    void execute(const OperatorInput& input, OperatorOutput& /*out*/) override {
-        JsonValue::object_t snapshot;
-        if (!common_input_.empty()) {
-            JsonValue::object_t common;
-            for (const auto& k : common_input_) {
-                common[k] = input.common(k);
-            }
-            snapshot["common"] = JsonValue(std::move(common));
-        }
-        if (!item_input_.empty() && input.item_count() > 0) {
-            JsonValue::array_t items;
-            items.reserve(input.item_count());
-            for (std::size_t i = 0; i < input.item_count(); ++i) {
-                JsonValue::object_t row;
-                for (const auto& k : item_input_) {
-                    row[k] = input.item(i, k);
-                }
-                items.push_back(JsonValue(std::move(row)));
-            }
-            snapshot["items"] = JsonValue(std::move(items));
-        }
-
-        std::string data = dump_json(JsonValue(snapshot), 0);
-        while (!data.empty() && data.back() == '\n') data.pop_back();
-
-        if (!prefix_.empty()) {
-            std::cerr << "[observe_log] " << prefix_ << " " << data << "\n";
-        } else {
-            std::cerr << "[observe_log] " << data << "\n";
-        }
+    std::string data = dump_json(JsonValue(snapshot), 0);
+    while (!data.empty() && data.back() == '\n') {
+      data.pop_back();
     }
 
-private:
-    std::string prefix_;
-    std::vector<std::string> common_input_;
-    std::vector<std::string> item_input_;
+    if (!prefix_.empty()) {
+      std::cerr << "[observe_log] " << prefix_ << " " << data << "\n";
+    } else {
+      std::cerr << "[observe_log] " << data << "\n";
+    }
+  }
+
+ private:
+  std::string prefix_;
+  std::vector<std::string> common_input_;
+  std::vector<std::string> item_input_;
 };
 
 static const OperatorSchema k_observe_log_schema{
     .name = "observe_log",
     .type = OpType::Observe,
-    .description = "Reads declared input fields and writes them to Go standard log. This is a read-only operator: it produces no output fields and does not modify the DataFrame. It is exempt from dead-code detection.",
-    .params = {
-        {"log_prefix", {.type = "string", .required = false, .default_value = JsonValue(""),
-                        .description = "Prefix prepended to each log line."}},
-    },
+    .description =
+        "Reads declared input fields and writes them to Go standard log. This is a read-only operator: it "
+        "produces no output fields and does not modify the DataFrame. It is exempt from dead-code detection.",
+    .params =
+        {
+            {"log_prefix",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue(""),
+              .description = "Prefix prepended to each log line."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(ObserveLogOp, k_observe_log_schema)
 

--- a/pine-cpp/operators/recall/recall_resource.cpp
+++ b/pine-cpp/operators/recall/recall_resource.cpp
@@ -1,51 +1,66 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
 
 #include <map>
 
+#include "operators/_helpers.hpp"
+
 namespace pine {
 
 class RecallResourceOp : public Operator, public AdditiveWritesRowSet {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        const auto& params = cfg.params.as_object();
-        auto rn_it = params.find("resource_name");
-        if (rn_it == params.end() || !rn_it->second.is_string())
-            throw ExecutionError("recall_resource: missing resource_name");
-        resource_name_ = rn_it->second.as_string();
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    const auto& params = cfg.params.as_object();
+    auto rn_it = params.find("resource_name");
+    if (rn_it == params.end() || !rn_it->second.is_string()) {
+      throw ExecutionError("recall_resource: missing resource_name");
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        if (!input.resources())
-            throw ExecutionError("recall_resource: no resource provider in context");
-        auto res_it = input.resources()->find(resource_name_);
-        if (res_it == input.resources()->end())
-            throw ExecutionError("recall_resource: resource \"" + resource_name_ + "\" not found");
-        const auto& resource = res_it->second;
-        if (!resource.is_array())
-            throw ExecutionError("recall_resource: resource \"" + resource_name_ + "\" is " + pine::operators::json_type_name(resource) + ", want []map[string]any");
-        for (std::size_t i = 0; i < resource.as_array().size(); ++i) {
-            const auto& elem = resource.as_array()[i];
-            if (!elem.is_object())
-                throw ExecutionError("recall_resource: items[" + std::to_string(i) + "] is " + pine::operators::json_type_name(elem) + ", want map[string]any");
-            std::map<std::string, JsonValue> row;
-            for (const auto& [key, value] : elem.as_object()) row[key] = value;
-            out.add_item(std::move(row));
-        }
+    resource_name_ = rn_it->second.as_string();
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    if (!input.resources()) {
+      throw ExecutionError("recall_resource: no resource provider in context");
     }
-private:
-    std::string op_name_;
-    std::string resource_name_;
+    auto res_it = input.resources()->find(resource_name_);
+    if (res_it == input.resources()->end()) {
+      throw ExecutionError("recall_resource: resource \"" + resource_name_ + "\" not found");
+    }
+    const auto& resource = res_it->second;
+    if (!resource.is_array()) {
+      throw ExecutionError("recall_resource: resource \"" + resource_name_ + "\" is " +
+                           pine::operators::json_type_name(resource) + ", want []map[string]any");
+    }
+    for (std::size_t i = 0; i < resource.as_array().size(); ++i) {
+      const auto& elem = resource.as_array()[i];
+      if (!elem.is_object()) {
+        throw ExecutionError("recall_resource: items[" + std::to_string(i) + "] is " +
+                             pine::operators::json_type_name(elem) + ", want map[string]any");
+      }
+      std::map<std::string, JsonValue> row;
+      for (const auto& [key, value] : elem.as_object()) {
+        row[key] = value;
+      }
+      out.add_item(std::move(row));
+    }
+  }
+
+ private:
+  std::string op_name_;
+  std::string resource_name_;
 };
 
 static const OperatorSchema k_recall_resource_schema{
     .name = "recall_resource",
     .type = OpType::Recall,
     .description = "Recalls items from a named resource.",
-    .params = {
-        {"resource_name", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                           .description = "Name of the resource to read."}},
-    },
+    .params =
+        {
+            {"resource_name",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Name of the resource to read."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(RecallResourceOp, k_recall_resource_schema)
 

--- a/pine-cpp/operators/recall/recall_static.cpp
+++ b/pine-cpp/operators/recall/recall_static.cpp
@@ -1,38 +1,46 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
 
 #include <map>
 
+#include "operators/_helpers.hpp"
+
 namespace pine {
 
 class RecallStaticOp : public Operator, public AdditiveWritesRowSet {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        for (const auto& item : cfg.params.as_object().at("items").as_array()) {
-            std::map<std::string, JsonValue> row;
-            for (const auto& [key, value] : item.as_object()) row[key] = value;
-            items_.push_back(std::move(row));
-        }
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    for (const auto& item : cfg.params.as_object().at("items").as_array()) {
+      std::map<std::string, JsonValue> row;
+      for (const auto& [key, value] : item.as_object()) {
+        row[key] = value;
+      }
+      items_.push_back(std::move(row));
     }
-    void execute(const OperatorInput& /*input*/, OperatorOutput& out) override {
-        for (const auto& row : items_) {
-            out.add_item(row);
-        }
+  }
+  void execute(const OperatorInput& /*input*/, OperatorOutput& out) override {
+    for (const auto& row : items_) {
+      out.add_item(row);
     }
-private:
-    std::string op_name_;
-    std::vector<std::map<std::string, JsonValue>> items_;
+  }
+
+ private:
+  std::string op_name_;
+  std::vector<std::map<std::string, JsonValue>> items_;
 };
 
 static const OperatorSchema k_recall_static_schema{
     .name = "recall_static",
     .type = OpType::Recall,
     .description = "Emits a configurable static set of items for testing and validation.",
-    .params = {
-        {"items", {.type = "any", .required = true, .default_value = JsonValue(nullptr),
-                   .description = "JSON array of item maps to emit as candidates."}},
-    },
+    .params =
+        {
+            {"items",
+             {.type = "any",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "JSON array of item maps to emit as candidates."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(RecallStaticOp, k_recall_static_schema)
 

--- a/pine-cpp/operators/reorder/reorder_shuffle_by_salt.cpp
+++ b/pine-cpp/operators/reorder/reorder_shuffle_by_salt.cpp
@@ -1,74 +1,90 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
 
 #include <algorithm>
 #include <charconv>
 #include <cstdint>
 
+#include "operators/_helpers.hpp"
+
 namespace pine {
 
 namespace {
 
 uint64_t fnv64a(const std::string& s) {
-    uint64_t hash = 14695981039346656037ULL;
-    for (unsigned char c : s) {
-        hash ^= c;
-        hash *= 1099511628211ULL;
-    }
-    return hash;
+  uint64_t hash = 14695981039346656037ULL;
+  for (unsigned char c : s) {
+    hash ^= c;
+    hash *= 1099511628211ULL;
+  }
+  return hash;
 }
 
 uint64_t parse_uint64(const std::string& s) {
-    uint64_t result = 0;
-    std::from_chars(s.data(), s.data() + s.size(), result);
-    return result;
+  uint64_t result = 0;
+  std::from_chars(s.data(), s.data() + s.size(), result);
+  return result;
 }
 
 }  // namespace
 
 class ReorderShuffleBySaltOp : public Operator, public ConsumesRowSet, public MutatesRowSet {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        common_inputs_ = cfg.metadata.common_input;
-        item_field_ = cfg.metadata.item_input.at(0);
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    common_inputs_ = cfg.metadata.common_input;
+    item_field_ = cfg.metadata.item_input.at(0);
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    if (input.item_count() == 0) {
+      return;
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        if (input.item_count() == 0) return;
-        std::string salt;
-        for (std::size_t i = 0; i < common_inputs_.size(); ++i) {
-            if (i > 0) salt += '|';
-            salt += operators::any_to_string(input.common(common_inputs_[i]));
-        }
+    std::string salt;
+    for (std::size_t i = 0; i < common_inputs_.size(); ++i) {
+      if (i > 0) {
         salt += '|';
-        struct Ranked { std::size_t idx; double r; uint64_t id; };
-        std::vector<Ranked> ranked;
-        ranked.reserve(input.item_count());
-        for (std::size_t i = 0; i < input.item_count(); ++i) {
-            std::string item_val = operators::any_to_string(input.item(i, item_field_));
-            uint64_t h = fnv64a(salt + item_val);
-            double r = static_cast<double>(h) / (static_cast<double>(UINT64_MAX) + 1.0);
-            ranked.push_back({i, r, parse_uint64(item_val)});
-        }
-        // pine-go shuffle.go:81 uses sort.Slice (non-stable). The (r, id)
-        // composite key is unique in practice (FNV-64a collisions are
-        // astronomically rare and the id tiebreak resolves them), so the
-        // outputs match — but using std::sort keeps the algorithmic
-        // contract aligned with Go for any future divergence.
-        std::sort(ranked.begin(), ranked.end(), [](const Ranked& a, const Ranked& b) {
-            if (a.r != b.r) return a.r < b.r;
-            if (a.id != b.id) return a.id < b.id;
-            return a.idx < b.idx;
-        });
-        std::vector<int> order;
-        order.reserve(ranked.size());
-        for (const auto& r : ranked) order.push_back(static_cast<int>(r.idx));
-        out.set_item_order(std::move(order));
+      }
+      salt += operators::any_to_string(input.common(common_inputs_[i]));
     }
-private:
-    std::string op_name_;
-    std::vector<std::string> common_inputs_;
-    std::string item_field_;
+    salt += '|';
+    struct Ranked {
+      std::size_t idx;
+      double r;
+      uint64_t id;
+    };
+    std::vector<Ranked> ranked;
+    ranked.reserve(input.item_count());
+    for (std::size_t i = 0; i < input.item_count(); ++i) {
+      std::string item_val = operators::any_to_string(input.item(i, item_field_));
+      uint64_t h = fnv64a(salt + item_val);
+      double r = static_cast<double>(h) / (static_cast<double>(UINT64_MAX) + 1.0);
+      ranked.push_back({i, r, parse_uint64(item_val)});
+    }
+    // pine-go shuffle.go:81 uses sort.Slice (non-stable). The (r, id)
+    // composite key is unique in practice (FNV-64a collisions are
+    // astronomically rare and the id tiebreak resolves them), so the
+    // outputs match — but using std::sort keeps the algorithmic
+    // contract aligned with Go for any future divergence.
+    std::sort(ranked.begin(), ranked.end(), [](const Ranked& a, const Ranked& b) {
+      if (a.r != b.r) {
+        return a.r < b.r;
+      }
+      if (a.id != b.id) {
+        return a.id < b.id;
+      }
+      return a.idx < b.idx;
+    });
+    std::vector<int> order;
+    order.reserve(ranked.size());
+    for (const auto& r : ranked) {
+      order.push_back(static_cast<int>(r.idx));
+    }
+    out.set_item_order(std::move(order));
+  }
+
+ private:
+  std::string op_name_;
+  std::vector<std::string> common_inputs_;
+  std::string item_field_;
 };
 
 static const OperatorSchema k_reorder_shuffle_by_salt_schema{

--- a/pine-cpp/operators/reorder/reorder_sort.cpp
+++ b/pine-cpp/operators/reorder/reorder_sort.cpp
@@ -1,63 +1,78 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
 
 #include <algorithm>
 
+#include "operators/_helpers.hpp"
+
 namespace pine {
 
 class ReorderSortOp : public Operator, public ConsumesRowSet, public MutatesRowSet {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        if (cfg.metadata.item_input.empty())
-            throw ExecutionError("reorder_sort requires item_input field");
-        field_ = cfg.metadata.item_input.front();
-        const auto& obj = cfg.params.as_object();
-        auto it = obj.find("order");
-        order_ = (it == obj.end()) ? std::string("desc") : it->second.as_string();
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    if (cfg.metadata.item_input.empty()) {
+      throw ExecutionError("reorder_sort requires item_input field");
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        if (input.item_count() == 0) return;
-        struct Keyed { double v; std::size_t idx; };
-        std::vector<Keyed> keyed;
-        keyed.reserve(input.item_count());
-        for (std::size_t i = 0; i < input.item_count(); ++i) {
-            try {
-                JsonValue v = input.item(i, field_);
-                if (v.is_null()) {
-                    throw operators::OperatorError("required field \"" + field_ + "\" is nil on item[" + std::to_string(i) + "]");
-                }
-                keyed.push_back({operators::to_double(v), i});
-            } catch (const operators::OperatorError& err) {
-                throw ExecutionError("reorder_sort: item[" + std::to_string(i) + "]." + field_ + ": " + err.what());
-            }
-        }
-        if (order_ == "asc") {
-            std::stable_sort(keyed.begin(), keyed.end(), [](const Keyed& a, const Keyed& b) { return a.v < b.v; });
-        } else if (order_ == "desc") {
-            std::stable_sort(keyed.begin(), keyed.end(), [](const Keyed& a, const Keyed& b) { return a.v > b.v; });
-        } else {
-            throw ExecutionError("reorder_sort: unsupported order \"" + order_ + "\"");
-        }
-        std::vector<int> order_vec;
-        order_vec.reserve(keyed.size());
-        for (const auto& k : keyed) order_vec.push_back(static_cast<int>(k.idx));
-        out.set_item_order(std::move(order_vec));
+    field_ = cfg.metadata.item_input.front();
+    const auto& obj = cfg.params.as_object();
+    auto it = obj.find("order");
+    order_ = (it == obj.end()) ? std::string("desc") : it->second.as_string();
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    if (input.item_count() == 0) {
+      return;
     }
-private:
-    std::string op_name_;
-    std::string field_;
-    std::string order_;
+    struct Keyed {
+      double v;
+      std::size_t idx;
+    };
+    std::vector<Keyed> keyed;
+    keyed.reserve(input.item_count());
+    for (std::size_t i = 0; i < input.item_count(); ++i) {
+      try {
+        JsonValue v = input.item(i, field_);
+        if (v.is_null()) {
+          throw operators::OperatorError("required field \"" + field_ + "\" is nil on item[" +
+                                         std::to_string(i) + "]");
+        }
+        keyed.push_back({operators::to_double(v), i});
+      } catch (const operators::OperatorError& err) {
+        throw ExecutionError("reorder_sort: item[" + std::to_string(i) + "]." + field_ + ": " + err.what());
+      }
+    }
+    if (order_ == "asc") {
+      std::stable_sort(keyed.begin(), keyed.end(), [](const Keyed& a, const Keyed& b) { return a.v < b.v; });
+    } else if (order_ == "desc") {
+      std::stable_sort(keyed.begin(), keyed.end(), [](const Keyed& a, const Keyed& b) { return a.v > b.v; });
+    } else {
+      throw ExecutionError("reorder_sort: unsupported order \"" + order_ + "\"");
+    }
+    std::vector<int> order_vec;
+    order_vec.reserve(keyed.size());
+    for (const auto& k : keyed) {
+      order_vec.push_back(static_cast<int>(k.idx));
+    }
+    out.set_item_order(std::move(order_vec));
+  }
+
+ private:
+  std::string op_name_;
+  std::string field_;
+  std::string order_;
 };
 
 static const OperatorSchema k_reorder_sort_schema{
     .name = "reorder_sort",
     .type = OpType::Reorder,
     .description = "Sorts items by a numeric field in ascending or descending order.",
-    .params = {
-        {"order", {.type = "string", .required = false, .default_value = JsonValue("desc"),
-                   .description = "Sort direction \xe2\x80\x94 \"asc\" or \"desc\"."}},
-    },
+    .params =
+        {
+            {"order",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue("desc"),
+              .description = "Sort direction \xe2\x80\x94 \"asc\" or \"desc\"."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(ReorderSortOp, k_reorder_sort_schema)
 

--- a/pine-cpp/operators/transform/transform_by_lua.cpp
+++ b/pine-cpp/operators/transform/transform_by_lua.cpp
@@ -1,102 +1,130 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
+
 #include "lua/lua_bridge.hpp"
 #include "lua/lua_pool.hpp"
+#include "operators/_helpers.hpp"
 
 namespace pine {
 
 class TransformByLuaOp : public Operator, public ConcurrentSafe, public StatsProvider, public MetricsAware {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        const auto& params = cfg.params.as_object();
-        auto script_it = params.find("lua_script");
-        if (script_it == params.end() || !script_it->second.is_string())
-            throw RegistryError(op_name_, "lua: exactly one of function_for_item or function_for_common must be set");
-        lua_script_ = script_it->second.as_string();
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    const auto& params = cfg.params.as_object();
+    auto script_it = params.find("lua_script");
+    if (script_it == params.end() || !script_it->second.is_string()) {
+      throw RegistryError(op_name_,
+                          "lua: exactly one of function_for_item or function_for_common must be set");
+    }
+    lua_script_ = script_it->second.as_string();
 
-        auto fi_it = params.find("function_for_item");
-        auto fc_it = params.find("function_for_common");
-        func_for_item_ = (fi_it != params.end() && fi_it->second.is_string()) ? fi_it->second.as_string() : "";
-        func_for_common_ = (fc_it != params.end() && fc_it->second.is_string()) ? fc_it->second.as_string() : "";
+    auto fi_it = params.find("function_for_item");
+    auto fc_it = params.find("function_for_common");
+    func_for_item_ = (fi_it != params.end() && fi_it->second.is_string()) ? fi_it->second.as_string() : "";
+    func_for_common_ = (fc_it != params.end() && fc_it->second.is_string()) ? fc_it->second.as_string() : "";
 
-        if (func_for_item_.empty() && func_for_common_.empty())
-            throw RegistryError(op_name_, "lua: exactly one of function_for_item or function_for_common must be set");
-        if (!func_for_item_.empty() && !func_for_common_.empty())
-            throw RegistryError(op_name_, "lua: cannot set both function_for_item and function_for_common");
-
-        common_input_ = cfg.metadata.common_input;
-        item_input_ = cfg.metadata.item_input;
-        item_output_ = cfg.metadata.item_output;
-        common_output_ = cfg.metadata.common_output;
-
-        pool_ = std::make_unique<lua::StatePool>(lua_script_, op_name_);
+    if (func_for_item_.empty() && func_for_common_.empty()) {
+      throw RegistryError(op_name_,
+                          "lua: exactly one of function_for_item or function_for_common must be set");
+    }
+    if (!func_for_item_.empty() && !func_for_common_.empty()) {
+      throw RegistryError(op_name_, "lua: cannot set both function_for_item and function_for_common");
     }
 
-    void set_metrics_provider(metrics::Provider* provider) override {
-        if (pool_) pool_->set_metrics(provider, op_name_);
+    common_input_ = cfg.metadata.common_input;
+    item_input_ = cfg.metadata.item_input;
+    item_output_ = cfg.metadata.item_output;
+    common_output_ = cfg.metadata.common_output;
+
+    pool_ = std::make_unique<lua::StatePool>(lua_script_, op_name_);
+  }
+
+  void set_metrics_provider(metrics::Provider* provider) override {
+    if (pool_) {
+      pool_->set_metrics(provider, op_name_);
     }
+  }
 
-    std::map<std::string, int64_t> operator_stats() const override {
-        if (pool_) return pool_->stats_snapshot();
-        return {};
+  std::map<std::string, int64_t> operator_stats() const override {
+    if (pool_) {
+      return pool_->stats_snapshot();
     }
+    return {};
+  }
 
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        auto borrowed = pool_->borrow();
-        lua::LuaVM& vm = *borrowed;
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    auto borrowed = pool_->borrow();
+    lua::LuaVM& vm = *borrowed;
 
-        if (!func_for_item_.empty()) {
-            int nret = static_cast<int>(item_output_.size());
-            for (const auto& field : common_input_)
-                vm.set_global(field, input.common(field));
-            for (std::size_t i = 0; i < input.item_count(); ++i) {
-                for (const auto& field : item_input_)
-                    vm.set_global(field, input.item(i, field));
-                auto results = vm.call_function(func_for_item_, nret, op_name_);
-                for (int j = 0; j < nret; ++j)
-                    out.set_item(static_cast<int>(i), item_output_[static_cast<std::size_t>(j)], results[static_cast<std::size_t>(j)]);
-            }
-        } else {
-            int nret = static_cast<int>(common_output_.size());
-            for (const auto& field : common_input_)
-                vm.set_global(field, input.common(field));
-            for (const auto& field : item_input_) {
-                std::vector<JsonValue> column;
-                column.reserve(input.item_count());
-                for (std::size_t i = 0; i < input.item_count(); ++i)
-                    column.push_back(input.item(i, field));
-                vm.set_global_table(field, column);
-            }
-            auto results = vm.call_function(func_for_common_, nret, op_name_);
-            for (int j = 0; j < nret; ++j)
-                out.set_common(common_output_[static_cast<std::size_t>(j)], results[static_cast<std::size_t>(j)]);
+    if (!func_for_item_.empty()) {
+      int nret = static_cast<int>(item_output_.size());
+      for (const auto& field : common_input_) {
+        vm.set_global(field, input.common(field));
+      }
+      for (std::size_t i = 0; i < input.item_count(); ++i) {
+        for (const auto& field : item_input_) {
+          vm.set_global(field, input.item(i, field));
         }
+        auto results = vm.call_function(func_for_item_, nret, op_name_);
+        for (int j = 0; j < nret; ++j) {
+          out.set_item(static_cast<int>(i), item_output_[static_cast<std::size_t>(j)],
+                       results[static_cast<std::size_t>(j)]);
+        }
+      }
+    } else {
+      int nret = static_cast<int>(common_output_.size());
+      for (const auto& field : common_input_) {
+        vm.set_global(field, input.common(field));
+      }
+      for (const auto& field : item_input_) {
+        std::vector<JsonValue> column;
+        column.reserve(input.item_count());
+        for (std::size_t i = 0; i < input.item_count(); ++i) {
+          column.push_back(input.item(i, field));
+        }
+        vm.set_global_table(field, column);
+      }
+      auto results = vm.call_function(func_for_common_, nret, op_name_);
+      for (int j = 0; j < nret; ++j) {
+        out.set_common(common_output_[static_cast<std::size_t>(j)], results[static_cast<std::size_t>(j)]);
+      }
     }
-private:
-    std::string op_name_;
-    std::string lua_script_;
-    std::string func_for_item_;
-    std::string func_for_common_;
-    std::vector<std::string> common_input_;
-    std::vector<std::string> item_input_;
-    std::vector<std::string> item_output_;
-    std::vector<std::string> common_output_;
-    std::unique_ptr<lua::StatePool> pool_;
+  }
+
+ private:
+  std::string op_name_;
+  std::string lua_script_;
+  std::string func_for_item_;
+  std::string func_for_common_;
+  std::vector<std::string> common_input_;
+  std::vector<std::string> item_input_;
+  std::vector<std::string> item_output_;
+  std::vector<std::string> common_output_;
+  std::unique_ptr<lua::StatePool> pool_;
 };
 
 static const OperatorSchema k_transform_by_lua_schema{
     .name = "transform_by_lua",
     .type = OpType::Transform,
     .description = "Executes a Lua script for per-item or per-common computation.",
-    .params = {
-        {"function_for_common", {.type = "string", .required = false, .default_value = JsonValue(""),
-                                 .description = "Function name to call once for all items."}},
-        {"function_for_item", {.type = "string", .required = false, .default_value = JsonValue(""),
-                               .description = "Function name to call per item."}},
-        {"lua_script", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                        .description = "Lua source code defining the function to call."}},
-    },
+    .params =
+        {
+            {"function_for_common",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue(""),
+              .description = "Function name to call once for all items."}},
+            {"function_for_item",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue(""),
+              .description = "Function name to call per item."}},
+            {"lua_script",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Lua source code defining the function to call."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(TransformByLuaOp, k_transform_by_lua_schema)
 

--- a/pine-cpp/operators/transform/transform_copy.cpp
+++ b/pine-cpp/operators/transform/transform_copy.cpp
@@ -1,89 +1,97 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
 
 #include <set>
 
+#include "operators/_helpers.hpp"
+
 namespace pine {
 
 class TransformCopyOp : public Operator, public ConcurrentSafe {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        direction_ = cfg.params.as_object().at("direction").as_string();
-        skip_ = cfg.skip;
-        common_input_ = cfg.metadata.common_input;
-        common_output_ = cfg.metadata.common_output;
-        item_input_ = cfg.metadata.item_input;
-        item_output_ = cfg.metadata.item_output;
-    }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        std::set<std::string> skip_set(skip_.begin(), skip_.end());
-        const auto active_inputs = [&](const std::vector<std::string>& src_list) {
-            std::vector<std::string> out_list;
-            out_list.reserve(src_list.size());
-            for (const auto& f : src_list) {
-                if (!skip_set.count(f)) out_list.push_back(f);
-            }
-            return out_list;
-        };
-
-        if (direction_ == "common_to_item") {
-            const auto inputs = active_inputs(common_input_);
-            for (std::size_t i = 0; i < inputs.size(); ++i) {
-                JsonValue value = input.common(inputs[i]);
-                const auto& dst = item_output_.at(i);
-                for (std::size_t j = 0; j < input.item_count(); ++j) {
-                    out.set_item(static_cast<int>(j), dst, value);
-                }
-            }
-        } else if (direction_ == "common_to_common") {
-            const auto inputs = active_inputs(common_input_);
-            for (std::size_t i = 0; i < inputs.size(); ++i) {
-                JsonValue value = input.common(inputs[i]);
-                out.set_common(common_output_.at(i), value);
-            }
-        } else if (direction_ == "item_to_item") {
-            const auto inputs = active_inputs(item_input_);
-            for (std::size_t i = 0; i < inputs.size(); ++i) {
-                const auto& src = inputs[i];
-                const auto& dst = item_output_.at(i);
-                for (std::size_t j = 0; j < input.item_count(); ++j) {
-                    out.set_item(static_cast<int>(j), dst, input.item(j, src));
-                }
-            }
-        } else if (direction_ == "item_to_common") {
-            const auto inputs = active_inputs(item_input_);
-            for (std::size_t i = 0; i < inputs.size(); ++i) {
-                const auto& src = inputs[i];
-                JsonValue::array_t vals;
-                for (std::size_t j = 0; j < input.item_count(); ++j) {
-                    vals.push_back(input.item(j, src));
-                }
-                out.set_common(common_output_.at(i), JsonValue(vals));
-            }
-        } else {
-            throw ExecutionError("transform_copy: unsupported direction \"" + direction_ + "\"");
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    direction_ = cfg.params.as_object().at("direction").as_string();
+    skip_ = cfg.skip;
+    common_input_ = cfg.metadata.common_input;
+    common_output_ = cfg.metadata.common_output;
+    item_input_ = cfg.metadata.item_input;
+    item_output_ = cfg.metadata.item_output;
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    std::set<std::string> skip_set(skip_.begin(), skip_.end());
+    const auto active_inputs = [&](const std::vector<std::string>& src_list) {
+      std::vector<std::string> out_list;
+      out_list.reserve(src_list.size());
+      for (const auto& f : src_list) {
+        if (!skip_set.count(f)) {
+          out_list.push_back(f);
         }
-    }
+      }
+      return out_list;
+    };
 
-private:
-    std::string op_name_;
-    std::string direction_;
-    std::vector<std::string> skip_;
-    std::vector<std::string> common_input_;
-    std::vector<std::string> common_output_;
-    std::vector<std::string> item_input_;
-    std::vector<std::string> item_output_;
+    if (direction_ == "common_to_item") {
+      const auto inputs = active_inputs(common_input_);
+      for (std::size_t i = 0; i < inputs.size(); ++i) {
+        JsonValue value = input.common(inputs[i]);
+        const auto& dst = item_output_.at(i);
+        for (std::size_t j = 0; j < input.item_count(); ++j) {
+          out.set_item(static_cast<int>(j), dst, value);
+        }
+      }
+    } else if (direction_ == "common_to_common") {
+      const auto inputs = active_inputs(common_input_);
+      for (std::size_t i = 0; i < inputs.size(); ++i) {
+        JsonValue value = input.common(inputs[i]);
+        out.set_common(common_output_.at(i), value);
+      }
+    } else if (direction_ == "item_to_item") {
+      const auto inputs = active_inputs(item_input_);
+      for (std::size_t i = 0; i < inputs.size(); ++i) {
+        const auto& src = inputs[i];
+        const auto& dst = item_output_.at(i);
+        for (std::size_t j = 0; j < input.item_count(); ++j) {
+          out.set_item(static_cast<int>(j), dst, input.item(j, src));
+        }
+      }
+    } else if (direction_ == "item_to_common") {
+      const auto inputs = active_inputs(item_input_);
+      for (std::size_t i = 0; i < inputs.size(); ++i) {
+        const auto& src = inputs[i];
+        JsonValue::array_t vals;
+        for (std::size_t j = 0; j < input.item_count(); ++j) {
+          vals.push_back(input.item(j, src));
+        }
+        out.set_common(common_output_.at(i), JsonValue(vals));
+      }
+    } else {
+      throw ExecutionError("transform_copy: unsupported direction \"" + direction_ + "\"");
+    }
+  }
+
+ private:
+  std::string op_name_;
+  std::string direction_;
+  std::vector<std::string> skip_;
+  std::vector<std::string> common_input_;
+  std::vector<std::string> common_output_;
+  std::vector<std::string> item_input_;
+  std::vector<std::string> item_output_;
 };
 
 static const OperatorSchema k_transform_copy_schema{
     .name = "transform_copy",
     .type = OpType::Transform,
     .description = "Copies field values between common and item dimensions.",
-    .params = {
-        {"direction", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                       .description = "Copy direction: \"common_to_item\", \"item_to_common\", \"common_to_common\", or \"item_to_item\"."}},
-    },
+    .params =
+        {
+            {"direction",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Copy direction: \"common_to_item\", \"item_to_common\", \"common_to_common\", "
+                             "or \"item_to_item\"."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(TransformCopyOp, k_transform_copy_schema)
 

--- a/pine-cpp/operators/transform/transform_dispatch.cpp
+++ b/pine-cpp/operators/transform/transform_dispatch.cpp
@@ -1,25 +1,27 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
+
+#include "operators/_helpers.hpp"
 
 namespace pine {
 
 class TransformDispatchOp : public Operator, public ConcurrentSafe {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        src_ = cfg.metadata.common_input.at(0);
-        dst_ = cfg.metadata.item_output.at(0);
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    src_ = cfg.metadata.common_input.at(0);
+    dst_ = cfg.metadata.item_output.at(0);
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    JsonValue v = input.common(src_);
+    for (std::size_t j = 0; j < input.item_count(); ++j) {
+      out.set_item(static_cast<int>(j), dst_, v);
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        JsonValue v = input.common(src_);
-        for (std::size_t j = 0; j < input.item_count(); ++j) {
-            out.set_item(static_cast<int>(j), dst_, v);
-        }
-    }
-private:
-    std::string op_name_;
-    std::string src_;
-    std::string dst_;
+  }
+
+ private:
+  std::string op_name_;
+  std::string src_;
+  std::string dst_;
 };
 
 static const OperatorSchema k_transform_dispatch_schema{

--- a/pine-cpp/operators/transform/transform_normalize.cpp
+++ b/pine-cpp/operators/transform/transform_normalize.cpp
@@ -1,71 +1,81 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
 
 #include <algorithm>
 
+#include "operators/_helpers.hpp"
+
 namespace pine {
 
 class TransformNormalizeOp : public Operator {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        item_input_ = cfg.metadata.item_input;
-        item_output_ = cfg.metadata.item_output;
-        std::string method = "min_max";
-        const auto& params = cfg.params.as_object();
-        auto it = params.find("method");
-        if (it != params.end() && !it->second.is_null()) {
-            method = it->second.as_string();
-        }
-        if (method != "min_max") {
-            throw RegistryError(op_name_, "unsupported method \"" + method + "\"");
-        }
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    item_input_ = cfg.metadata.item_input;
+    item_output_ = cfg.metadata.item_output;
+    std::string method = "min_max";
+    const auto& params = cfg.params.as_object();
+    auto it = params.find("method");
+    if (it != params.end() && !it->second.is_null()) {
+      method = it->second.as_string();
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        if (input.item_count() == 0) return;
-        if (item_input_.empty()) {
-            throw ExecutionError(op_name_, "transform_normalize: item_input is empty");
-        }
-        if (item_output_.empty()) {
-            throw ExecutionError(op_name_, "transform_normalize: item_output is empty");
-        }
-        const std::string& field_ = item_input_[0];
-        const std::string& out_field_ = item_output_[0];
-        std::vector<double> vals;
-        vals.reserve(input.item_count());
-        for (std::size_t i = 0; i < input.item_count(); ++i) {
-            try {
-                JsonValue v = input.item(i, field_);
-                if (v.is_null()) {
-                    throw operators::OperatorError("required field \"" + field_ + "\" is nil on item[" + std::to_string(i) + "]");
-                }
-                vals.push_back(operators::to_double(v));
-            } catch (const operators::OperatorError& err) {
-                throw ExecutionError("transform_normalize: item[" + std::to_string(i) + "]." + field_ + ": " + err.what());
-            }
-        }
-        double minv = *std::min_element(vals.begin(), vals.end());
-        double maxv = *std::max_element(vals.begin(), vals.end());
-        double rng = maxv - minv;
-        for (std::size_t i = 0; i < vals.size(); ++i) {
-            double norm = (rng == 0.0) ? 0.0 : (vals[i] - minv) / rng;
-            out.set_item(static_cast<int>(i), out_field_, JsonValue(norm));
-        }
+    if (method != "min_max") {
+      throw RegistryError(op_name_, "unsupported method \"" + method + "\"");
     }
-private:
-    std::string op_name_;
-    std::vector<std::string> item_input_;
-    std::vector<std::string> item_output_;
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    if (input.item_count() == 0) {
+      return;
+    }
+    if (item_input_.empty()) {
+      throw ExecutionError(op_name_, "transform_normalize: item_input is empty");
+    }
+    if (item_output_.empty()) {
+      throw ExecutionError(op_name_, "transform_normalize: item_output is empty");
+    }
+    const std::string& field_ = item_input_[0];
+    const std::string& out_field_ = item_output_[0];
+    std::vector<double> vals;
+    vals.reserve(input.item_count());
+    for (std::size_t i = 0; i < input.item_count(); ++i) {
+      try {
+        JsonValue v = input.item(i, field_);
+        if (v.is_null()) {
+          throw operators::OperatorError("required field \"" + field_ + "\" is nil on item[" +
+                                         std::to_string(i) + "]");
+        }
+        vals.push_back(operators::to_double(v));
+      } catch (const operators::OperatorError& err) {
+        throw ExecutionError("transform_normalize: item[" + std::to_string(i) + "]." + field_ + ": " +
+                             err.what());
+      }
+    }
+    double minv = *std::min_element(vals.begin(), vals.end());
+    double maxv = *std::max_element(vals.begin(), vals.end());
+    double rng = maxv - minv;
+    for (std::size_t i = 0; i < vals.size(); ++i) {
+      double norm = (rng == 0.0) ? 0.0 : (vals[i] - minv) / rng;
+      out.set_item(static_cast<int>(i), out_field_, JsonValue(norm));
+    }
+  }
+
+ private:
+  std::string op_name_;
+  std::vector<std::string> item_input_;
+  std::vector<std::string> item_output_;
 };
 
 static const OperatorSchema k_transform_normalize_schema{
     .name = "transform_normalize",
     .type = OpType::Transform,
     .description = "Normalizes a numeric item field using min-max scaling to [0, 1].",
-    .params = {
-        {"method", {.type = "string", .required = false, .default_value = JsonValue("min_max"),
-                    .description = "Normalization method."}},
-    },
+    .params =
+        {
+            {"method",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue("min_max"),
+              .description = "Normalization method."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(TransformNormalizeOp, k_transform_normalize_schema)
 

--- a/pine-cpp/operators/transform/transform_redis_get.cpp
+++ b/pine-cpp/operators/transform/transform_redis_get.cpp
@@ -1,119 +1,151 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
-#include "redis/connection_pool.hpp"
-#include "redis/redis_client.hpp"
 
 #include <memory>
+
+#include "operators/_helpers.hpp"
+#include "redis/connection_pool.hpp"
+#include "redis/redis_client.hpp"
 
 namespace pine {
 
 class TransformRedisGetOp : public Operator, public ConcurrentSafe {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        rp_ = operators::parse_redis_params(cfg);
-        result_field_ = cfg.metadata.common_output.at(0);
-        cache_hit_field_ = cfg.metadata.common_output.at(1);
-        common_input_ = cfg.metadata.common_input;
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    rp_ = operators::parse_redis_params(cfg);
+    result_field_ = cfg.metadata.common_output.at(0);
+    cache_hit_field_ = cfg.metadata.common_output.at(1);
+    common_input_ = cfg.metadata.common_input;
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    if (rp_.host.empty()) {
+      out.set_common(cache_hit_field_, JsonValue(false));
+      return;
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        if (rp_.host.empty()) {
-            out.set_common(cache_hit_field_, JsonValue(false));
-            return;
-        }
 
-        std::string key = rp_.key_prefix + operators::build_key_suffix(input, common_input_);
+    std::string key = rp_.key_prefix + operators::build_key_suffix(input, common_input_);
 
-        // Borrow a connection from the shared pool to avoid the full
-        // getaddrinfo + connect + AUTH + SELECT round-trip on every
-        // dispatch.
-        redis::ConnectionPool::ScopedClient client;
-        try {
-            client = redis::shared_pool().acquire_scoped(rp_.host, rp_.port, rp_.password, rp_.db);
-        } catch (const std::exception& e) {
-            if (rp_.fail_on_error)
-                throw ExecutionError("transform_redis_get: " + std::string(e.what()));
-            out.set_warning("transform_redis_get: Get(" + key + "): " + std::string(e.what()));
-            out.set_common(cache_hit_field_, JsonValue(false));
-            return;
-        }
-        if (!client || !client->connected()) {
-            if (rp_.fail_on_error)
-                throw ExecutionError("transform_redis_get: connection failed");
-            out.set_warning("transform_redis_get: Get(" + key + "): connection failed");
-            out.set_common(cache_hit_field_, JsonValue(false));
-            return;
-        }
-        redis::Client* cli = client.get();
-
-        try {
-            if (rp_.data_type == "string") {
-                auto val = cli->get(key);
-                if (val && !val->empty()) {
-                    out.set_common(result_field_, JsonValue(*val));
-                    out.set_common(cache_hit_field_, JsonValue(true));
-                } else {
-                    out.set_common(cache_hit_field_, JsonValue(false));
-                }
-            } else if (rp_.data_type == "set") {
-                auto members = cli->smembers(key);
-                if (!members.empty()) {
-                    JsonValue::array_t arr;
-                    for (auto& m : members) arr.push_back(JsonValue(std::move(m)));
-                    out.set_common(result_field_, JsonValue(std::move(arr)));
-                    out.set_common(cache_hit_field_, JsonValue(true));
-                } else {
-                    out.set_common(cache_hit_field_, JsonValue(false));
-                }
-            } else if (rp_.data_type == "list") {
-                auto vals = cli->lrange(key, 0, -1);
-                if (!vals.empty()) {
-                    JsonValue::array_t arr;
-                    for (auto& v : vals) arr.push_back(JsonValue(std::move(v)));
-                    out.set_common(result_field_, JsonValue(std::move(arr)));
-                    out.set_common(cache_hit_field_, JsonValue(true));
-                } else {
-                    out.set_common(cache_hit_field_, JsonValue(false));
-                }
-            } else {
-                throw ExecutionError("transform_redis_get: unsupported data_type \"" + rp_.data_type + "\"");
-            }
-        } catch (const ExecutionError&) {
-            throw;
-        } catch (const std::exception& e) {
-            if (rp_.fail_on_error)
-                throw ExecutionError("transform_redis_get: " + std::string(e.what()));
-            std::string cmd_name = (rp_.data_type == "set") ? "SMembers" : (rp_.data_type == "list") ? "LRange" : "Get";
-            out.set_warning("transform_redis_get: " + cmd_name + "(" + key + "): " + std::string(e.what()));
-            out.set_common(cache_hit_field_, JsonValue(false));
-        }
+    // Borrow a connection from the shared pool to avoid the full
+    // getaddrinfo + connect + AUTH + SELECT round-trip on every
+    // dispatch.
+    redis::ConnectionPool::ScopedClient client;
+    try {
+      client = redis::shared_pool().acquire_scoped(rp_.host, rp_.port, rp_.password, rp_.db);
+    } catch (const std::exception& e) {
+      if (rp_.fail_on_error) {
+        throw ExecutionError("transform_redis_get: " + std::string(e.what()));
+      }
+      out.set_warning("transform_redis_get: Get(" + key + "): " + std::string(e.what()));
+      out.set_common(cache_hit_field_, JsonValue(false));
+      return;
     }
-private:
-    std::string op_name_;
-    operators::RedisParams rp_;
-    std::string result_field_;
-    std::string cache_hit_field_;
-    std::vector<std::string> common_input_;
+    if (!client || !client->connected()) {
+      if (rp_.fail_on_error) {
+        throw ExecutionError("transform_redis_get: connection failed");
+      }
+      out.set_warning("transform_redis_get: Get(" + key + "): connection failed");
+      out.set_common(cache_hit_field_, JsonValue(false));
+      return;
+    }
+    redis::Client* cli = client.get();
+
+    try {
+      if (rp_.data_type == "string") {
+        auto val = cli->get(key);
+        if (val && !val->empty()) {
+          out.set_common(result_field_, JsonValue(*val));
+          out.set_common(cache_hit_field_, JsonValue(true));
+        } else {
+          out.set_common(cache_hit_field_, JsonValue(false));
+        }
+      } else if (rp_.data_type == "set") {
+        auto members = cli->smembers(key);
+        if (!members.empty()) {
+          JsonValue::array_t arr;
+          for (auto& m : members) {
+            arr.push_back(JsonValue(std::move(m)));
+          }
+          out.set_common(result_field_, JsonValue(std::move(arr)));
+          out.set_common(cache_hit_field_, JsonValue(true));
+        } else {
+          out.set_common(cache_hit_field_, JsonValue(false));
+        }
+      } else if (rp_.data_type == "list") {
+        auto vals = cli->lrange(key, 0, -1);
+        if (!vals.empty()) {
+          JsonValue::array_t arr;
+          for (auto& v : vals) {
+            arr.push_back(JsonValue(std::move(v)));
+          }
+          out.set_common(result_field_, JsonValue(std::move(arr)));
+          out.set_common(cache_hit_field_, JsonValue(true));
+        } else {
+          out.set_common(cache_hit_field_, JsonValue(false));
+        }
+      } else {
+        throw ExecutionError("transform_redis_get: unsupported data_type \"" + rp_.data_type + "\"");
+      }
+    } catch (const ExecutionError&) {
+      throw;
+    } catch (const std::exception& e) {
+      if (rp_.fail_on_error) {
+        throw ExecutionError("transform_redis_get: " + std::string(e.what()));
+      }
+      std::string cmd_name = (rp_.data_type == "set")    ? "SMembers"
+                             : (rp_.data_type == "list") ? "LRange"
+                                                         : "Get";
+      out.set_warning("transform_redis_get: " + cmd_name + "(" + key + "): " + std::string(e.what()));
+      out.set_common(cache_hit_field_, JsonValue(false));
+    }
+  }
+
+ private:
+  std::string op_name_;
+  operators::RedisParams rp_;
+  std::string result_field_;
+  std::string cache_hit_field_;
+  std::vector<std::string> common_input_;
 };
 
 static const OperatorSchema k_transform_redis_get_schema{
     .name = "transform_redis_get",
     .type = OpType::Transform,
-    .description = "Generic Redis read operator. Reads a value by key and outputs the result and a cache-hit flag.",
-    .params = {
-        {"data_type", {.type = "string", .required = false, .default_value = JsonValue("string"),
-                       .description = "Redis data type: \"set\", \"string\", or \"list\"."}},
-        {"fail_on_error", {.type = "bool", .required = false, .default_value = JsonValue(false),
-                           .description = "Return fatal error on Redis infrastructure failure instead of treating as cache miss."}},
-        {"key_prefix", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                        .description = "Key prefix prepended to the suffix built from common_input fields."}},
-        {"redis_addr", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                        .description = "Redis server address (host:port)."}},
-        {"redis_db", {.type = "int", .required = false, .default_value = JsonValue(0.0),
-                      .description = "Redis DB number."}},
-        {"redis_password", {.type = "string", .required = false, .default_value = JsonValue(""),
-                            .description = "Redis password."}},
-    },
+    .description =
+        "Generic Redis read operator. Reads a value by key and outputs the result and a cache-hit flag.",
+    .params =
+        {
+            {"data_type",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue("string"),
+              .description = "Redis data type: \"set\", \"string\", or \"list\"."}},
+            {"fail_on_error",
+             {.type = "bool",
+              .required = false,
+              .default_value = JsonValue(false),
+              .description =
+                  "Return fatal error on Redis infrastructure failure instead of treating as cache miss."}},
+            {"key_prefix",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Key prefix prepended to the suffix built from common_input fields."}},
+            {"redis_addr",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Redis server address (host:port)."}},
+            {"redis_db",
+             {.type = "int",
+              .required = false,
+              .default_value = JsonValue(0.0),
+              .description = "Redis DB number."}},
+            {"redis_password",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue(""),
+              .description = "Redis password."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(TransformRedisGetOp, k_transform_redis_get_schema)
 

--- a/pine-cpp/operators/transform/transform_redis_set.cpp
+++ b/pine-cpp/operators/transform/transform_redis_set.cpp
@@ -1,114 +1,157 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
-#include "redis/connection_pool.hpp"
-#include "redis/redis_client.hpp"
 
 #include <memory>
+
+#include "operators/_helpers.hpp"
+#include "redis/connection_pool.hpp"
+#include "redis/redis_client.hpp"
 
 namespace pine {
 
 class TransformRedisSetOp : public Operator, public ConcurrentSafe {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        rp_ = operators::parse_redis_params(cfg);
-        int n = static_cast<int>(cfg.metadata.common_input.size());
-        if (n < 2)
-            throw ExecutionError("transform_redis_set: common_input must have at least 2 fields (key fields + value field)");
-        common_input_ = cfg.metadata.common_input;
-        key_fields_ = std::vector<std::string>(cfg.metadata.common_input.begin(), cfg.metadata.common_input.begin() + (n - 1));
-        value_field_ = cfg.metadata.common_input.back();
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    rp_ = operators::parse_redis_params(cfg);
+    int n = static_cast<int>(cfg.metadata.common_input.size());
+    if (n < 2) {
+      throw ExecutionError(
+          "transform_redis_set: common_input must have at least 2 fields (key fields + value field)");
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        if (rp_.host.empty()) return;
-
-        std::string key = rp_.key_prefix + operators::build_key_suffix(input, key_fields_);
-        JsonValue value = input.common(value_field_);
-
-        // Borrow from the shared pool. See transform_redis_get for
-        // pool semantics; same RAII guard pattern.
-        redis::ConnectionPool::ScopedClient client;
-        try {
-            client = redis::shared_pool().acquire_scoped(rp_.host, rp_.port, rp_.password, rp_.db);
-        } catch (const std::exception& e) {
-            if (rp_.fail_on_error)
-                throw ExecutionError("transform_redis_set: write key " + key + ": " + e.what());
-            out.set_warning("transform_redis_set: write key " + key + ": " + std::string(e.what()));
-            return;
-        }
-        if (!client || !client->connected()) {
-            if (rp_.fail_on_error)
-                throw ExecutionError("transform_redis_set: write key " + key + ": connection failed");
-            out.set_warning("transform_redis_set: write key " + key + ": connection failed");
-            return;
-        }
-        redis::Client* cli = client.get();
-
-        try {
-            if (rp_.data_type == "string") {
-                if (!value.is_string()) return;
-                cli->set(key, value.as_string(), rp_.ttl);
-            } else if (rp_.data_type == "set") {
-                auto members = operators::json_to_string_slice(value);
-                if (members.empty()) return;
-                std::vector<std::vector<std::string>> commands = {{"DEL", key}};
-                std::vector<std::string> sadd_cmd = {"SADD", key};
-                for (const auto& m : members) sadd_cmd.push_back(m);
-                commands.push_back(std::move(sadd_cmd));
-                if (rp_.ttl > 0) {
-                    commands.push_back({"EXPIRE", key, std::to_string(rp_.ttl)});
-                }
-                cli->write_multiexec(commands);
-            } else if (rp_.data_type == "list") {
-                auto members = operators::json_to_string_slice(value);
-                if (members.empty()) return;
-                std::vector<std::vector<std::string>> commands = {{"DEL", key}};
-                std::vector<std::string> rpush_cmd = {"RPUSH", key};
-                for (const auto& m : members) rpush_cmd.push_back(m);
-                commands.push_back(std::move(rpush_cmd));
-                if (rp_.ttl > 0) {
-                    commands.push_back({"EXPIRE", key, std::to_string(rp_.ttl)});
-                }
-                cli->write_multiexec(commands);
-            } else {
-                throw ExecutionError("transform_redis_set: unsupported data_type \"" + rp_.data_type + "\"");
-            }
-        } catch (const ExecutionError&) {
-            throw;
-        } catch (const std::exception& e) {
-            if (rp_.fail_on_error)
-                throw ExecutionError("transform_redis_set: write key " + key + ": " + e.what());
-            out.set_warning("transform_redis_set: write key " + key + ": " + std::string(e.what()));
-        }
+    common_input_ = cfg.metadata.common_input;
+    key_fields_ = std::vector<std::string>(cfg.metadata.common_input.begin(),
+                                           cfg.metadata.common_input.begin() + (n - 1));
+    value_field_ = cfg.metadata.common_input.back();
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    if (rp_.host.empty()) {
+      return;
     }
-private:
-    std::string op_name_;
-    operators::RedisParams rp_;
-    std::vector<std::string> common_input_;
-    std::vector<std::string> key_fields_;
-    std::string value_field_;
+
+    std::string key = rp_.key_prefix + operators::build_key_suffix(input, key_fields_);
+    JsonValue value = input.common(value_field_);
+
+    // Borrow from the shared pool. See transform_redis_get for
+    // pool semantics; same RAII guard pattern.
+    redis::ConnectionPool::ScopedClient client;
+    try {
+      client = redis::shared_pool().acquire_scoped(rp_.host, rp_.port, rp_.password, rp_.db);
+    } catch (const std::exception& e) {
+      if (rp_.fail_on_error) {
+        throw ExecutionError("transform_redis_set: write key " + key + ": " + e.what());
+      }
+      out.set_warning("transform_redis_set: write key " + key + ": " + std::string(e.what()));
+      return;
+    }
+    if (!client || !client->connected()) {
+      if (rp_.fail_on_error) {
+        throw ExecutionError("transform_redis_set: write key " + key + ": connection failed");
+      }
+      out.set_warning("transform_redis_set: write key " + key + ": connection failed");
+      return;
+    }
+    redis::Client* cli = client.get();
+
+    try {
+      if (rp_.data_type == "string") {
+        if (!value.is_string()) {
+          return;
+        }
+        cli->set(key, value.as_string(), rp_.ttl);
+      } else if (rp_.data_type == "set") {
+        auto members = operators::json_to_string_slice(value);
+        if (members.empty()) {
+          return;
+        }
+        std::vector<std::vector<std::string>> commands = {{"DEL", key}};
+        std::vector<std::string> sadd_cmd = {"SADD", key};
+        for (const auto& m : members) {
+          sadd_cmd.push_back(m);
+        }
+        commands.push_back(std::move(sadd_cmd));
+        if (rp_.ttl > 0) {
+          commands.push_back({"EXPIRE", key, std::to_string(rp_.ttl)});
+        }
+        cli->write_multiexec(commands);
+      } else if (rp_.data_type == "list") {
+        auto members = operators::json_to_string_slice(value);
+        if (members.empty()) {
+          return;
+        }
+        std::vector<std::vector<std::string>> commands = {{"DEL", key}};
+        std::vector<std::string> rpush_cmd = {"RPUSH", key};
+        for (const auto& m : members) {
+          rpush_cmd.push_back(m);
+        }
+        commands.push_back(std::move(rpush_cmd));
+        if (rp_.ttl > 0) {
+          commands.push_back({"EXPIRE", key, std::to_string(rp_.ttl)});
+        }
+        cli->write_multiexec(commands);
+      } else {
+        throw ExecutionError("transform_redis_set: unsupported data_type \"" + rp_.data_type + "\"");
+      }
+    } catch (const ExecutionError&) {
+      throw;
+    } catch (const std::exception& e) {
+      if (rp_.fail_on_error) {
+        throw ExecutionError("transform_redis_set: write key " + key + ": " + e.what());
+      }
+      out.set_warning("transform_redis_set: write key " + key + ": " + std::string(e.what()));
+    }
+  }
+
+ private:
+  std::string op_name_;
+  operators::RedisParams rp_;
+  std::vector<std::string> common_input_;
+  std::vector<std::string> key_fields_;
+  std::string value_field_;
 };
 
 static const OperatorSchema k_transform_redis_set_schema{
     .name = "transform_redis_set",
     .type = OpType::Transform,
     .description = "Generic Redis write operator. Writes a value by key with optional TTL.",
-    .params = {
-        {"data_type", {.type = "string", .required = false, .default_value = JsonValue("string"),
-                       .description = "Redis data type: \"set\", \"string\", or \"list\"."}},
-        {"fail_on_error", {.type = "bool", .required = false, .default_value = JsonValue(false),
-                           .description = "Return fatal error on Redis infrastructure failure instead of logging and continuing."}},
-        {"key_prefix", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                        .description = "Key prefix prepended to the suffix built from common_input fields."}},
-        {"redis_addr", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                        .description = "Redis server address (host:port)."}},
-        {"redis_db", {.type = "int", .required = false, .default_value = JsonValue(0.0),
-                      .description = "Redis DB number."}},
-        {"redis_password", {.type = "string", .required = false, .default_value = JsonValue(""),
-                            .description = "Redis password."}},
-        {"ttl", {.type = "int", .required = false, .default_value = JsonValue(0.0),
-                 .description = "TTL in seconds. 0 means no expiry."}},
-    },
+    .params =
+        {
+            {"data_type",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue("string"),
+              .description = "Redis data type: \"set\", \"string\", or \"list\"."}},
+            {"fail_on_error",
+             {.type = "bool",
+              .required = false,
+              .default_value = JsonValue(false),
+              .description =
+                  "Return fatal error on Redis infrastructure failure instead of logging and continuing."}},
+            {"key_prefix",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Key prefix prepended to the suffix built from common_input fields."}},
+            {"redis_addr",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Redis server address (host:port)."}},
+            {"redis_db",
+             {.type = "int",
+              .required = false,
+              .default_value = JsonValue(0.0),
+              .description = "Redis DB number."}},
+            {"redis_password",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue(""),
+              .description = "Redis password."}},
+            {"ttl",
+             {.type = "int",
+              .required = false,
+              .default_value = JsonValue(0.0),
+              .description = "TTL in seconds. 0 means no expiry."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(TransformRedisSetOp, k_transform_redis_set_schema)
 

--- a/pine-cpp/operators/transform/transform_remote_pineapple.cpp
+++ b/pine-cpp/operators/transform/transform_remote_pineapple.cpp
@@ -1,11 +1,12 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
-#include "http/http_client.hpp"
-#include "http/ssrf.hpp"
 
 #include <chrono>
 #include <cstdint>
 #include <memory>
+
+#include "http/http_client.hpp"
+#include "http/ssrf.hpp"
+#include "operators/_helpers.hpp"
 
 namespace pine {
 
@@ -14,255 +15,323 @@ namespace {
 // Best-effort coercion of a JSON value to int64. Mirrors pine-go's
 // toInt64Param: accepts number, string-encoded integer, or bool→0/1.
 int64_t to_int64_param(const JsonValue& v) {
-    if (v.is_number()) return static_cast<int64_t>(v.as_number());
-    if (v.is_bool()) return v.as_bool() ? 1 : 0;
-    if (v.is_string()) {
-        try {
-            return std::stoll(v.as_string());
-        } catch (...) {
-            return 0;
-        }
+  if (v.is_number()) {
+    return static_cast<int64_t>(v.as_number());
+  }
+  if (v.is_bool()) {
+    return v.as_bool() ? 1 : 0;
+  }
+  if (v.is_string()) {
+    try {
+      return std::stoll(v.as_string());
+    } catch (...) {
+      return 0;
     }
-    return 0;
+  }
+  return 0;
 }
 
 std::vector<std::string> to_string_slice(const JsonValue& v) {
-    std::vector<std::string> out;
-    if (!v.is_array()) return out;
-    for (const auto& e : v.as_array()) {
-        if (e.is_string()) out.push_back(e.as_string());
-    }
+  std::vector<std::string> out;
+  if (!v.is_array()) {
     return out;
+  }
+  for (const auto& e : v.as_array()) {
+    if (e.is_string()) {
+      out.push_back(e.as_string());
+    }
+  }
+  return out;
 }
 
 }  // namespace
 
-class TransformByRemotePineappleOp : public Operator,
-                                     public ConcurrentSafe,
-                                     public ConsumesRowSet {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        if (!cfg.params.is_object())
-            throw ExecutionError("transform_by_remote_pineapple: params must be an object");
-        const auto& params = cfg.params.as_object();
+class TransformByRemotePineappleOp : public Operator, public ConcurrentSafe, public ConsumesRowSet {
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    if (!cfg.params.is_object()) {
+      throw ExecutionError("transform_by_remote_pineapple: params must be an object");
+    }
+    const auto& params = cfg.params.as_object();
 
-        std::string host;
-        if (auto it = params.find("host"); it != params.end() && it->second.is_string())
-            host = it->second.as_string();
-        int64_t port = 0;
-        if (auto it = params.find("port"); it != params.end())
-            port = to_int64_param(it->second);
-        std::string endpoint = "/execute";
-        if (auto it = params.find("endpoint"); it != params.end() && it->second.is_string()) {
-            const auto& s = it->second.as_string();
-            if (!s.empty()) endpoint = s;
-        }
-        url_ = "http://" + host + ":" + std::to_string(port) + endpoint;
-        host_ = host;
+    std::string host;
+    if (auto it = params.find("host"); it != params.end() && it->second.is_string()) {
+      host = it->second.as_string();
+    }
+    int64_t port = 0;
+    if (auto it = params.find("port"); it != params.end()) {
+      port = to_int64_param(it->second);
+    }
+    std::string endpoint = "/execute";
+    if (auto it = params.find("endpoint"); it != params.end() && it->second.is_string()) {
+      const auto& s = it->second.as_string();
+      if (!s.empty()) {
+        endpoint = s;
+      }
+    }
+    url_ = "http://" + host + ":" + std::to_string(port) + endpoint;
+    host_ = host;
 
-        double timeout_seconds = 5.0;
-        if (auto it = params.find("timeout"); it != params.end() && it->second.is_number())
-            timeout_seconds = it->second.as_number();
-        timeout_ms_ = static_cast<int64_t>(timeout_seconds * 1000.0);
+    double timeout_seconds = 5.0;
+    if (auto it = params.find("timeout"); it != params.end() && it->second.is_number()) {
+      timeout_seconds = it->second.as_number();
+    }
+    timeout_ms_ = static_cast<int64_t>(timeout_seconds * 1000.0);
 
-        fail_on_error_ = true;
-        if (auto it = params.find("fail_on_error"); it != params.end() && it->second.is_bool())
-            fail_on_error_ = it->second.as_bool();
-
-        max_response_size_ = 10 * 1024 * 1024;
-        if (auto it = params.find("max_response_size"); it != params.end())
-            max_response_size_ = to_int64_param(it->second);
-
-        allow_private_ = false;
-        if (auto it = params.find("allow_private"); it != params.end() && it->second.is_bool())
-            allow_private_ = it->second.as_bool();
-
-        if (auto it = params.find("common_request"); it != params.end())
-            common_req_ = to_string_slice(it->second);
-        if (auto it = params.find("item_request"); it != params.end())
-            item_req_ = to_string_slice(it->second);
-        if (auto it = params.find("common_response"); it != params.end())
-            common_resp_ = to_string_slice(it->second);
-        if (auto it = params.find("item_response"); it != params.end())
-            item_resp_ = to_string_slice(it->second);
-
-        common_input_ = cfg.metadata.common_input;
-        common_output_ = cfg.metadata.common_output;
-        item_input_ = cfg.metadata.item_input;
-        item_output_ = cfg.metadata.item_output;
-
-        if (!allow_private_) {
-            std::string reason;
-            if (!http::validate_remote_host(host_, &reason))
-                throw ExecutionError("transform_by_remote_pineapple: " + reason);
-        }
+    fail_on_error_ = true;
+    if (auto it = params.find("fail_on_error"); it != params.end() && it->second.is_bool()) {
+      fail_on_error_ = it->second.as_bool();
     }
 
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        const auto& common_req_fields = common_req_.empty() ? common_input_ : common_req_;
-        const auto& item_req_fields = item_req_.empty() ? item_input_ : item_req_;
-        const auto& common_resp_fields = common_resp_.empty() ? common_output_ : common_resp_;
-        const auto& item_resp_fields = item_resp_.empty() ? item_output_ : item_resp_;
-
-        JsonValue::object_t req_common;
-        for (std::size_t i = 0; i < common_input_.size(); ++i) {
-            if (i >= common_req_fields.size()) break;
-            req_common.emplace(common_req_fields[i], input.common(common_input_[i]));
-        }
-
-        JsonValue::array_t req_items;
-        req_items.reserve(input.item_count());
-        for (std::size_t j = 0; j < input.item_count(); ++j) {
-            JsonValue::object_t item;
-            for (std::size_t i = 0; i < item_input_.size(); ++i) {
-                if (i >= item_req_fields.size()) break;
-                item.emplace(item_req_fields[i], input.item(j, item_input_[i]));
-            }
-            req_items.emplace_back(std::move(item));
-        }
-
-        JsonValue::object_t req_body_obj;
-        req_body_obj.emplace("common", JsonValue(std::move(req_common)));
-        req_body_obj.emplace("items", JsonValue(std::move(req_items)));
-        std::string body = dump_json(JsonValue(std::move(req_body_obj)), 0);
-
-        http::PostOptions opts;
-        opts.url = url_;
-        opts.body = std::move(body);
-        opts.timeout = std::chrono::milliseconds(timeout_ms_);
-        opts.max_response_size = max_response_size_;
-        opts.allow_private = allow_private_;
-
-        http::PostResult res = http::post(opts);
-        if (!res.ok) {
-            handle_error(out, res.error);
-            return;
-        }
-        if (res.status_code != 200) {
-            handle_error(out,
-                "transform_by_remote_pineapple: HTTP " + std::to_string(res.status_code) +
-                ": " + truncate_body(res.body));
-            return;
-        }
-
-        JsonValue parsed;
-        try {
-            parsed = parse_json(res.body);
-        } catch (const std::exception& e) {
-            handle_error(out,
-                std::string("transform_by_remote_pineapple: unmarshal response: ") + e.what());
-            return;
-        }
-        if (!parsed.is_object()) {
-            handle_error(out, "transform_by_remote_pineapple: unmarshal response: not an object");
-            return;
-        }
-        const auto& obj = parsed.as_object();
-
-        if (auto it = obj.find("error"); it != obj.end() && it->second.is_string()) {
-            const auto& msg = it->second.as_string();
-            if (!msg.empty()) {
-                handle_error(out, "transform_by_remote_pineapple: downstream error: " + msg);
-                return;
-            }
-        }
-
-        const JsonValue::object_t* resp_common = nullptr;
-        if (auto it = obj.find("common"); it != obj.end() && it->second.is_object())
-            resp_common = &it->second.as_object();
-        const JsonValue::array_t* resp_items = nullptr;
-        if (auto it = obj.find("items"); it != obj.end() && it->second.is_array())
-            resp_items = &it->second.as_array();
-
-        if (resp_common != nullptr) {
-            for (std::size_t i = 0; i < common_output_.size(); ++i) {
-                if (i >= common_resp_fields.size()) break;
-                auto it = resp_common->find(common_resp_fields[i]);
-                if (it != resp_common->end())
-                    out.set_common(common_output_[i], it->second);
-            }
-        }
-        if (resp_items != nullptr) {
-            std::size_t n = std::min(input.item_count(), resp_items->size());
-            for (std::size_t j = 0; j < n; ++j) {
-                if (!(*resp_items)[j].is_object()) continue;
-                const auto& item_obj = (*resp_items)[j].as_object();
-                for (std::size_t i = 0; i < item_output_.size(); ++i) {
-                    if (i >= item_resp_fields.size()) break;
-                    auto it = item_obj.find(item_resp_fields[i]);
-                    if (it != item_obj.end())
-                        out.set_item(static_cast<int>(j), item_output_[i], it->second);
-                }
-            }
-        }
+    max_response_size_ = 10 * 1024 * 1024;
+    if (auto it = params.find("max_response_size"); it != params.end()) {
+      max_response_size_ = to_int64_param(it->second);
     }
 
-private:
-    void handle_error(OperatorOutput& out, const std::string& msg) {
-        if (fail_on_error_)
-            throw ExecutionError(msg);
-        out.set_warning(msg);
+    allow_private_ = false;
+    if (auto it = params.find("allow_private"); it != params.end() && it->second.is_bool()) {
+      allow_private_ = it->second.as_bool();
     }
 
-    // truncate_body clips a downstream-response body to kErrorBodyMax bytes
-    // for inclusion in error messages / warnings. A 5 MB HTML 500 page
-    // should not fan out into log / JSON / exception streams as-is.
-    static constexpr std::size_t kErrorBodyMax = 1024;
-    static std::string truncate_body(const std::string& body) {
-        if (body.size() <= kErrorBodyMax) return body;
-        return body.substr(0, kErrorBodyMax) +
-               "...(truncated, total " + std::to_string(body.size()) + " bytes)";
+    if (auto it = params.find("common_request"); it != params.end()) {
+      common_req_ = to_string_slice(it->second);
+    }
+    if (auto it = params.find("item_request"); it != params.end()) {
+      item_req_ = to_string_slice(it->second);
+    }
+    if (auto it = params.find("common_response"); it != params.end()) {
+      common_resp_ = to_string_slice(it->second);
+    }
+    if (auto it = params.find("item_response"); it != params.end()) {
+      item_resp_ = to_string_slice(it->second);
     }
 
-    std::string op_name_;
-    std::string url_;
-    std::string host_;
-    int64_t timeout_ms_ = 5000;
-    int64_t max_response_size_ = 10 * 1024 * 1024;
-    bool fail_on_error_ = true;
-    bool allow_private_ = false;
+    common_input_ = cfg.metadata.common_input;
+    common_output_ = cfg.metadata.common_output;
+    item_input_ = cfg.metadata.item_input;
+    item_output_ = cfg.metadata.item_output;
 
-    std::vector<std::string> common_req_;
-    std::vector<std::string> item_req_;
-    std::vector<std::string> common_resp_;
-    std::vector<std::string> item_resp_;
+    if (!allow_private_) {
+      std::string reason;
+      if (!http::validate_remote_host(host_, &reason)) {
+        throw ExecutionError("transform_by_remote_pineapple: " + reason);
+      }
+    }
+  }
 
-    std::vector<std::string> common_input_;
-    std::vector<std::string> common_output_;
-    std::vector<std::string> item_input_;
-    std::vector<std::string> item_output_;
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    const auto& common_req_fields = common_req_.empty() ? common_input_ : common_req_;
+    const auto& item_req_fields = item_req_.empty() ? item_input_ : item_req_;
+    const auto& common_resp_fields = common_resp_.empty() ? common_output_ : common_resp_;
+    const auto& item_resp_fields = item_resp_.empty() ? item_output_ : item_resp_;
+
+    JsonValue::object_t req_common;
+    for (std::size_t i = 0; i < common_input_.size(); ++i) {
+      if (i >= common_req_fields.size()) {
+        break;
+      }
+      req_common.emplace(common_req_fields[i], input.common(common_input_[i]));
+    }
+
+    JsonValue::array_t req_items;
+    req_items.reserve(input.item_count());
+    for (std::size_t j = 0; j < input.item_count(); ++j) {
+      JsonValue::object_t item;
+      for (std::size_t i = 0; i < item_input_.size(); ++i) {
+        if (i >= item_req_fields.size()) {
+          break;
+        }
+        item.emplace(item_req_fields[i], input.item(j, item_input_[i]));
+      }
+      req_items.emplace_back(std::move(item));
+    }
+
+    JsonValue::object_t req_body_obj;
+    req_body_obj.emplace("common", JsonValue(std::move(req_common)));
+    req_body_obj.emplace("items", JsonValue(std::move(req_items)));
+    std::string body = dump_json(JsonValue(std::move(req_body_obj)), 0);
+
+    http::PostOptions opts;
+    opts.url = url_;
+    opts.body = std::move(body);
+    opts.timeout = std::chrono::milliseconds(timeout_ms_);
+    opts.max_response_size = max_response_size_;
+    opts.allow_private = allow_private_;
+
+    http::PostResult res = http::post(opts);
+    if (!res.ok) {
+      handle_error(out, res.error);
+      return;
+    }
+    if (res.status_code != 200) {
+      handle_error(out, "transform_by_remote_pineapple: HTTP " + std::to_string(res.status_code) + ": " +
+                            truncate_body(res.body));
+      return;
+    }
+
+    JsonValue parsed;
+    try {
+      parsed = parse_json(res.body);
+    } catch (const std::exception& e) {
+      handle_error(out, std::string("transform_by_remote_pineapple: unmarshal response: ") + e.what());
+      return;
+    }
+    if (!parsed.is_object()) {
+      handle_error(out, "transform_by_remote_pineapple: unmarshal response: not an object");
+      return;
+    }
+    const auto& obj = parsed.as_object();
+
+    if (auto it = obj.find("error"); it != obj.end() && it->second.is_string()) {
+      const auto& msg = it->second.as_string();
+      if (!msg.empty()) {
+        handle_error(out, "transform_by_remote_pineapple: downstream error: " + msg);
+        return;
+      }
+    }
+
+    const JsonValue::object_t* resp_common = nullptr;
+    if (auto it = obj.find("common"); it != obj.end() && it->second.is_object()) {
+      resp_common = &it->second.as_object();
+    }
+    const JsonValue::array_t* resp_items = nullptr;
+    if (auto it = obj.find("items"); it != obj.end() && it->second.is_array()) {
+      resp_items = &it->second.as_array();
+    }
+
+    if (resp_common != nullptr) {
+      for (std::size_t i = 0; i < common_output_.size(); ++i) {
+        if (i >= common_resp_fields.size()) {
+          break;
+        }
+        auto it = resp_common->find(common_resp_fields[i]);
+        if (it != resp_common->end()) {
+          out.set_common(common_output_[i], it->second);
+        }
+      }
+    }
+    if (resp_items != nullptr) {
+      std::size_t n = std::min(input.item_count(), resp_items->size());
+      for (std::size_t j = 0; j < n; ++j) {
+        if (!(*resp_items)[j].is_object()) {
+          continue;
+        }
+        const auto& item_obj = (*resp_items)[j].as_object();
+        for (std::size_t i = 0; i < item_output_.size(); ++i) {
+          if (i >= item_resp_fields.size()) {
+            break;
+          }
+          auto it = item_obj.find(item_resp_fields[i]);
+          if (it != item_obj.end()) {
+            out.set_item(static_cast<int>(j), item_output_[i], it->second);
+          }
+        }
+      }
+    }
+  }
+
+ private:
+  void handle_error(OperatorOutput& out, const std::string& msg) {
+    if (fail_on_error_) {
+      throw ExecutionError(msg);
+    }
+    out.set_warning(msg);
+  }
+
+  // truncate_body clips a downstream-response body to kErrorBodyMax bytes
+  // for inclusion in error messages / warnings. A 5 MB HTML 500 page
+  // should not fan out into log / JSON / exception streams as-is.
+  static constexpr std::size_t kErrorBodyMax = 1024;
+  static std::string truncate_body(const std::string& body) {
+    if (body.size() <= kErrorBodyMax) {
+      return body;
+    }
+    return body.substr(0, kErrorBodyMax) + "...(truncated, total " + std::to_string(body.size()) + " bytes)";
+  }
+
+  std::string op_name_;
+  std::string url_;
+  std::string host_;
+  int64_t timeout_ms_ = 5000;
+  int64_t max_response_size_ = 10 * 1024 * 1024;
+  bool fail_on_error_ = true;
+  bool allow_private_ = false;
+
+  std::vector<std::string> common_req_;
+  std::vector<std::string> item_req_;
+  std::vector<std::string> common_resp_;
+  std::vector<std::string> item_resp_;
+
+  std::vector<std::string> common_input_;
+  std::vector<std::string> common_output_;
+  std::vector<std::string> item_input_;
+  std::vector<std::string> item_output_;
 };
 
 static const OperatorSchema k_transform_by_remote_pineapple_schema{
     .name = "transform_by_remote_pineapple",
     .type = OpType::Transform,
     .description = "Calls a downstream Pineapple service and maps response fields back to the local frame.",
-    .params = {
-        {"host", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                  .description = "Downstream service host."}},
-        {"port", {.type = "int64", .required = true, .default_value = JsonValue(nullptr),
-                  .description = "Downstream service port."}},
-        {"endpoint", {.type = "string", .required = false, .default_value = JsonValue("/execute"),
-                      .description = "Downstream endpoint path."}},
-        {"timeout", {.type = "float64", .required = false, .default_value = JsonValue(5.0),
-                     .description = "Request timeout in seconds."}},
-        {"fail_on_error", {.type = "bool", .required = false, .default_value = JsonValue(true),
-                           .description = "true=fatal on downstream error; false=warning and skip."}},
-        {"max_response_size", {.type = "int64", .required = false,
-                               .default_value = JsonValue(static_cast<double>(10 * 1024 * 1024)),
-                               .description = "Maximum response body size in bytes (default 10 MB)."}},
-        {"allow_private", {.type = "bool", .required = false, .default_value = JsonValue(false),
-                           .description = "Allow connections to private/loopback addresses (dev/internal use)."}},
-        {"common_request", {.type = "any", .required = false, .default_value = JsonValue(nullptr),
-                            .description = "Downstream common field names, positionally mapped to common_input."}},
-        {"item_request", {.type = "any", .required = false, .default_value = JsonValue(nullptr),
-                          .description = "Downstream item field names, positionally mapped to item_input."}},
-        {"common_response", {.type = "any", .required = false, .default_value = JsonValue(nullptr),
-                             .description = "Downstream common response field names, positionally mapped to common_output."}},
-        {"item_response", {.type = "any", .required = false, .default_value = JsonValue(nullptr),
-                           .description = "Downstream item response field names, positionally mapped to item_output."}},
-    },
+    .params =
+        {
+            {"host",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Downstream service host."}},
+            {"port",
+             {.type = "int64",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Downstream service port."}},
+            {"endpoint",
+             {.type = "string",
+              .required = false,
+              .default_value = JsonValue("/execute"),
+              .description = "Downstream endpoint path."}},
+            {"timeout",
+             {.type = "float64",
+              .required = false,
+              .default_value = JsonValue(5.0),
+              .description = "Request timeout in seconds."}},
+            {"fail_on_error",
+             {.type = "bool",
+              .required = false,
+              .default_value = JsonValue(true),
+              .description = "true=fatal on downstream error; false=warning and skip."}},
+            {"max_response_size",
+             {.type = "int64",
+              .required = false,
+              .default_value = JsonValue(static_cast<double>(10 * 1024 * 1024)),
+              .description = "Maximum response body size in bytes (default 10 MB)."}},
+            {"allow_private",
+             {.type = "bool",
+              .required = false,
+              .default_value = JsonValue(false),
+              .description = "Allow connections to private/loopback addresses (dev/internal use)."}},
+            {"common_request",
+             {.type = "any",
+              .required = false,
+              .default_value = JsonValue(nullptr),
+              .description = "Downstream common field names, positionally mapped to common_input."}},
+            {"item_request",
+             {.type = "any",
+              .required = false,
+              .default_value = JsonValue(nullptr),
+              .description = "Downstream item field names, positionally mapped to item_input."}},
+            {"common_response",
+             {.type = "any",
+              .required = false,
+              .default_value = JsonValue(nullptr),
+              .description =
+                  "Downstream common response field names, positionally mapped to common_output."}},
+            {"item_response",
+             {.type = "any",
+              .required = false,
+              .default_value = JsonValue(nullptr),
+              .description = "Downstream item response field names, positionally mapped to item_output."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(TransformByRemotePineappleOp, k_transform_by_remote_pineapple_schema)
 

--- a/pine-cpp/operators/transform/transform_resource_lookup.cpp
+++ b/pine-cpp/operators/transform/transform_resource_lookup.cpp
@@ -1,92 +1,118 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
 
 #include <charconv>
 
+#include "operators/_helpers.hpp"
+
 namespace pine {
 
 class TransformResourceLookupOp : public Operator, public ConcurrentSafe {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        const auto& params = cfg.params.as_object();
-        auto rn_it = params.find("resource_name");
-        if (rn_it == params.end() || !rn_it->second.is_string())
-            throw ExecutionError("transform_resource_lookup: missing resource_name");
-        resource_name_ = rn_it->second.as_string();
-
-        auto lk_it = params.find("lookup_key");
-        if (lk_it == params.end() || !lk_it->second.is_string())
-            throw ExecutionError("transform_resource_lookup: missing lookup_key");
-        lookup_key_ = lk_it->second.as_string();
-
-        auto of_it = params.find("output_field");
-        if (of_it == params.end() || !of_it->second.is_string())
-            throw ExecutionError("transform_resource_lookup: missing output_field");
-        output_field_ = of_it->second.as_string();
-
-        auto dv_it = params.find("default_value");
-        has_default_ = (dv_it != params.end());
-        if (has_default_) default_value_ = dv_it->second;
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    const auto& params = cfg.params.as_object();
+    auto rn_it = params.find("resource_name");
+    if (rn_it == params.end() || !rn_it->second.is_string()) {
+      throw ExecutionError("transform_resource_lookup: missing resource_name");
     }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        if (!input.resources())
-            throw ExecutionError("transform_resource_lookup: no resource provider in context");
-        auto res_it = input.resources()->find(resource_name_);
-        if (res_it == input.resources()->end())
-            throw ExecutionError("transform_resource_lookup: resource \"" + resource_name_ + "\" not found");
-        const auto& resource = res_it->second;
-        if (!resource.is_object())
-            throw ExecutionError("transform_resource_lookup: resource \"" + resource_name_ + "\" is " + pine::operators::json_type_name(resource) + ", want map[string]any");
-        const auto& table = resource.as_object();
+    resource_name_ = rn_it->second.as_string();
 
-        for (std::size_t i = 0; i < input.item_count(); ++i) {
-            JsonValue field_val = input.item(i, lookup_key_);
-            if (field_val.is_null()) {
-                if (has_default_) out.set_item(static_cast<int>(i), output_field_, default_value_);
-                continue;
-            }
-            std::string key;
-            if (field_val.is_string()) {
-                key = field_val.as_string();
-            } else if (field_val.is_number()) {
-                // Lookup keys must use FormatInt / FormatFloat('f')
-                // — never scientific — to match pine-go resource_lookup.go.
-                key = operators::go_format_lookup_key(field_val.as_number());
-            } else {
-                key = operators::sprint_value(field_val);
-            }
-            auto val_it = table.find(key);
-            if (val_it != table.end()) {
-                out.set_item(static_cast<int>(i), output_field_, val_it->second);
-            } else if (has_default_) {
-                out.set_item(static_cast<int>(i), output_field_, default_value_);
-            }
+    auto lk_it = params.find("lookup_key");
+    if (lk_it == params.end() || !lk_it->second.is_string()) {
+      throw ExecutionError("transform_resource_lookup: missing lookup_key");
+    }
+    lookup_key_ = lk_it->second.as_string();
+
+    auto of_it = params.find("output_field");
+    if (of_it == params.end() || !of_it->second.is_string()) {
+      throw ExecutionError("transform_resource_lookup: missing output_field");
+    }
+    output_field_ = of_it->second.as_string();
+
+    auto dv_it = params.find("default_value");
+    has_default_ = (dv_it != params.end());
+    if (has_default_) {
+      default_value_ = dv_it->second;
+    }
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    if (!input.resources()) {
+      throw ExecutionError("transform_resource_lookup: no resource provider in context");
+    }
+    auto res_it = input.resources()->find(resource_name_);
+    if (res_it == input.resources()->end()) {
+      throw ExecutionError("transform_resource_lookup: resource \"" + resource_name_ + "\" not found");
+    }
+    const auto& resource = res_it->second;
+    if (!resource.is_object()) {
+      throw ExecutionError("transform_resource_lookup: resource \"" + resource_name_ + "\" is " +
+                           pine::operators::json_type_name(resource) + ", want map[string]any");
+    }
+    const auto& table = resource.as_object();
+
+    for (std::size_t i = 0; i < input.item_count(); ++i) {
+      JsonValue field_val = input.item(i, lookup_key_);
+      if (field_val.is_null()) {
+        if (has_default_) {
+          out.set_item(static_cast<int>(i), output_field_, default_value_);
         }
+        continue;
+      }
+      std::string key;
+      if (field_val.is_string()) {
+        key = field_val.as_string();
+      } else if (field_val.is_number()) {
+        // Lookup keys must use FormatInt / FormatFloat('f')
+        // — never scientific — to match pine-go resource_lookup.go.
+        key = operators::go_format_lookup_key(field_val.as_number());
+      } else {
+        key = operators::sprint_value(field_val);
+      }
+      auto val_it = table.find(key);
+      if (val_it != table.end()) {
+        out.set_item(static_cast<int>(i), output_field_, val_it->second);
+      } else if (has_default_) {
+        out.set_item(static_cast<int>(i), output_field_, default_value_);
+      }
     }
-private:
-    std::string op_name_;
-    std::string resource_name_;
-    std::string lookup_key_;
-    std::string output_field_;
-    bool has_default_ = false;
-    JsonValue default_value_;
+  }
+
+ private:
+  std::string op_name_;
+  std::string resource_name_;
+  std::string lookup_key_;
+  std::string output_field_;
+  bool has_default_ = false;
+  JsonValue default_value_;
 };
 
 static const OperatorSchema k_transform_resource_lookup_schema{
     .name = "transform_resource_lookup",
     .type = OpType::Transform,
     .description = "Enriches items by looking up values from a named resource.",
-    .params = {
-        {"default_value", {.type = "any", .required = false, .default_value = JsonValue(nullptr),
-                           .description = "Value to use when the key is not found. Missing keys are skipped if unset."}},
-        {"lookup_key", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                        .description = "Item field whose value is used as the lookup key."}},
-        {"output_field", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                          .description = "Item field to write the looked-up value to."}},
-        {"resource_name", {.type = "string", .required = true, .default_value = JsonValue(nullptr),
-                           .description = "Name of the resource to read."}},
-    },
+    .params =
+        {
+            {"default_value",
+             {.type = "any",
+              .required = false,
+              .default_value = JsonValue(nullptr),
+              .description = "Value to use when the key is not found. Missing keys are skipped if unset."}},
+            {"lookup_key",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Item field whose value is used as the lookup key."}},
+            {"output_field",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Item field to write the looked-up value to."}},
+            {"resource_name",
+             {.type = "string",
+              .required = true,
+              .default_value = JsonValue(nullptr),
+              .description = "Name of the resource to read."}},
+        },
 };
 PINE_REGISTER_OPERATOR_T(TransformResourceLookupOp, k_transform_resource_lookup_schema)
 

--- a/pine-cpp/operators/transform/transform_size.cpp
+++ b/pine-cpp/operators/transform/transform_size.cpp
@@ -1,20 +1,22 @@
-#include "operators/_helpers.hpp"
 #include "pine/operator.hpp"
+
+#include "operators/_helpers.hpp"
 
 namespace pine {
 
 class TransformSizeOp : public Operator, public ConsumesRowSet, public ConcurrentSafe {
-public:
-    void init(const OperatorConfig& cfg) override {
-        op_name_ = cfg.name;
-        out_field_ = cfg.metadata.common_output.at(0);
-    }
-    void execute(const OperatorInput& input, OperatorOutput& out) override {
-        out.set_common(out_field_, JsonValue(static_cast<double>(input.item_count())));
-    }
-private:
-    std::string op_name_;
-    std::string out_field_;
+ public:
+  void init(const OperatorConfig& cfg) override {
+    op_name_ = cfg.name;
+    out_field_ = cfg.metadata.common_output.at(0);
+  }
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    out.set_common(out_field_, JsonValue(static_cast<double>(input.item_count())));
+  }
+
+ private:
+  std::string op_name_;
+  std::string out_field_;
 };
 
 static const OperatorSchema k_transform_size_schema{

--- a/pine-cpp/src/config/config.cpp
+++ b/pine-cpp/src/config/config.cpp
@@ -8,291 +8,378 @@ namespace pine {
 namespace {
 
 std::string read_file(const std::string& path) {
-    std::ifstream input(path);
-    if (!input) throw ConfigError("error reading config: " + path);
-    std::ostringstream oss;
-    oss << input.rdbuf();
-    return oss.str();
+  std::ifstream input(path);
+  if (!input) {
+    throw ConfigError("error reading config: " + path);
+  }
+  std::ostringstream oss;
+  oss << input.rdbuf();
+  return oss.str();
 }
 
 std::vector<std::string> as_string_list(const JsonValue::object_t& obj, const std::string& key) {
-    std::vector<std::string> out;
-    auto it = obj.find(key);
-    if (it == obj.end()) return out;
-    for (const auto& item : it->second.as_array()) out.push_back(item.as_string());
+  std::vector<std::string> out;
+  auto it = obj.find(key);
+  if (it == obj.end()) {
     return out;
+  }
+  for (const auto& item : it->second.as_array()) {
+    out.push_back(item.as_string());
+  }
+  return out;
 }
 
 std::map<std::string, JsonValue> as_value_map(const JsonValue::object_t& obj, const std::string& key) {
-    std::map<std::string, JsonValue> out;
-    auto it = obj.find(key);
-    if (it == obj.end()) return out;
-    for (const auto& [name, value] : it->second.as_object()) out[name] = value;
+  std::map<std::string, JsonValue> out;
+  auto it = obj.find(key);
+  if (it == obj.end()) {
     return out;
+  }
+  for (const auto& [name, value] : it->second.as_object()) {
+    out[name] = value;
+  }
+  return out;
 }
 
 Metadata parse_metadata(const JsonValue::object_t& obj) {
-    Metadata meta;
-    auto it = obj.find("$metadata");
-    if (it == obj.end()) throw ConfigError("operator missing $metadata");
-    const auto& mo = it->second.as_object();
-    meta.common_input = as_string_list(mo, "common_input");
-    meta.common_output = as_string_list(mo, "common_output");
-    meta.item_input = as_string_list(mo, "item_input");
-    meta.item_output = as_string_list(mo, "item_output");
-    return meta;
+  Metadata meta;
+  auto it = obj.find("$metadata");
+  if (it == obj.end()) {
+    throw ConfigError("operator missing $metadata");
+  }
+  const auto& mo = it->second.as_object();
+  meta.common_input = as_string_list(mo, "common_input");
+  meta.common_output = as_string_list(mo, "common_output");
+  meta.item_input = as_string_list(mo, "item_input");
+  meta.item_output = as_string_list(mo, "item_output");
+  return meta;
 }
 
 std::vector<std::string> parse_skip(const JsonValue::object_t& obj) {
-    std::vector<std::string> out;
-    auto it = obj.find("skip");
-    if (it == obj.end()) return out;
-    if (it->second.is_string()) {
-        if (!it->second.as_string().empty()) out.push_back(it->second.as_string());
-        return out;
-    }
-    for (const auto& item : it->second.as_array()) out.push_back(item.as_string());
+  std::vector<std::string> out;
+  auto it = obj.find("skip");
+  if (it == obj.end()) {
     return out;
+  }
+  if (it->second.is_string()) {
+    if (!it->second.as_string().empty()) {
+      out.push_back(it->second.as_string());
+    }
+    return out;
+  }
+  for (const auto& item : it->second.as_array()) {
+    out.push_back(item.as_string());
+  }
+  return out;
 }
 
 OperatorConfig parse_operator(const std::string& name, const JsonValue& value) {
-    const auto& obj = value.as_object();
-    OperatorConfig op;
-    op.name = name;
-    auto type_it = obj.find("type_name");
-    if (type_it == obj.end()) throw ConfigError("operator \"" + name + "\": missing type_name");
-    op.type_name = type_it->second.as_string();
-    op.metadata = parse_metadata(obj);
-    op.skip = parse_skip(obj);
-    if (auto it = obj.find("recall"); it != obj.end() && it->second.is_bool()) op.recall = it->second.as_bool();
-    if (auto it = obj.find("consumes_row_set"); it != obj.end() && it->second.is_bool()) op.consumes_row_set = it->second.as_bool();
-    if (auto it = obj.find("mutates_row_set"); it != obj.end() && it->second.is_bool()) op.mutates_row_set = it->second.as_bool();
-    if (auto it = obj.find("additive_writes_row_set"); it != obj.end() && it->second.is_bool()) op.additive_writes_row_set = it->second.as_bool();
-    if (auto it = obj.find("debug"); it != obj.end() && it->second.is_bool()) op.debug = it->second.as_bool();
-    if (auto it = obj.find("for_branch_control"); it != obj.end() && it->second.is_bool()) op.for_branch_control = it->second.as_bool();
-    if (auto it = obj.find("data_parallel"); it != obj.end() && it->second.is_number()) op.data_parallel = static_cast<int>(it->second.as_number());
-    op.common_defaults = as_value_map(obj, "common_defaults");
-    op.item_defaults = as_value_map(obj, "item_defaults");
-    op.strict_common = as_string_list(obj, "strict_common");
-    op.strict_item = as_string_list(obj, "strict_item");
-    op.sources = as_string_list(obj, "sources");
-    JsonValue::object_t params;
-    for (const auto& [key, item] : obj) {
-        if (key == "type_name" || key == "$metadata" || key == "$code_info" || key == "skip" || key == "recall" ||
-            key == "sources" || key == "debug" || key == "consumes_row_set" || key == "mutates_row_set" ||
-            key == "additive_writes_row_set" || key == "common_defaults" || key == "item_defaults" ||
-            key == "strict_common" || key == "strict_item" || key == "for_branch_control" ||
-            key == "data_parallel") {
-            continue;
-        }
-        params[key] = item;
+  const auto& obj = value.as_object();
+  OperatorConfig op;
+  op.name = name;
+  auto type_it = obj.find("type_name");
+  if (type_it == obj.end()) {
+    throw ConfigError("operator \"" + name + "\": missing type_name");
+  }
+  op.type_name = type_it->second.as_string();
+  op.metadata = parse_metadata(obj);
+  op.skip = parse_skip(obj);
+  if (auto it = obj.find("recall"); it != obj.end() && it->second.is_bool()) {
+    op.recall = it->second.as_bool();
+  }
+  if (auto it = obj.find("consumes_row_set"); it != obj.end() && it->second.is_bool()) {
+    op.consumes_row_set = it->second.as_bool();
+  }
+  if (auto it = obj.find("mutates_row_set"); it != obj.end() && it->second.is_bool()) {
+    op.mutates_row_set = it->second.as_bool();
+  }
+  if (auto it = obj.find("additive_writes_row_set"); it != obj.end() && it->second.is_bool()) {
+    op.additive_writes_row_set = it->second.as_bool();
+  }
+  if (auto it = obj.find("debug"); it != obj.end() && it->second.is_bool()) {
+    op.debug = it->second.as_bool();
+  }
+  if (auto it = obj.find("for_branch_control"); it != obj.end() && it->second.is_bool()) {
+    op.for_branch_control = it->second.as_bool();
+  }
+  if (auto it = obj.find("data_parallel"); it != obj.end() && it->second.is_number()) {
+    op.data_parallel = static_cast<int>(it->second.as_number());
+  }
+  op.common_defaults = as_value_map(obj, "common_defaults");
+  op.item_defaults = as_value_map(obj, "item_defaults");
+  op.strict_common = as_string_list(obj, "strict_common");
+  op.strict_item = as_string_list(obj, "strict_item");
+  op.sources = as_string_list(obj, "sources");
+  JsonValue::object_t params;
+  for (const auto& [key, item] : obj) {
+    if (key == "type_name" || key == "$metadata" || key == "$code_info" || key == "skip" || key == "recall" ||
+        key == "sources" || key == "debug" || key == "consumes_row_set" || key == "mutates_row_set" ||
+        key == "additive_writes_row_set" || key == "common_defaults" || key == "item_defaults" ||
+        key == "strict_common" || key == "strict_item" || key == "for_branch_control" ||
+        key == "data_parallel") {
+      continue;
     }
-    op.params = JsonValue(params);
-    return op;
+    params[key] = item;
+  }
+  op.params = JsonValue(params);
+  return op;
 }
 
 void validate_config(const Config& config) {
-    if (config.operators.empty()) throw ConfigError("pipeline_config.operators is empty");
-    if (config.pipeline_group.empty()) throw ConfigError("pipeline_group is empty");
-    for (const auto& [name, op] : config.operators) {
-        for (const auto& skip : op.skip) {
-            if (skip.empty() || skip[0] != '_') {
-                throw ConfigError("operator \"" + name + "\": skip field \"" + skip + "\" must start with '_' (control fields are engine-internal)");
-            }
-            const auto& ci = op.metadata.common_input;
-            if (std::find(ci.begin(), ci.end(), skip) == ci.end()) {
-                throw ConfigError("operator \"" + name + "\": skip field \"" + skip + "\" must also appear in $metadata.common_input to ensure correct DAG ordering");
-            }
-        }
-        for (const auto& src : op.sources) {
-            if (!config.operators.count(src)) {
-                throw ConfigError("operator \"" + name + "\": sources references undefined operator \"" + src + "\"");
-            }
-        }
-        if (op.additive_writes_row_set && op.mutates_row_set) {
-            throw RegistryError("operator \"" + name + "\": additive_writes_row_set and mutates_row_set are mutually exclusive");
-        }
-        if (op.type_name == "filter_condition") {
-            if (!op.params.is_object() || op.params.as_object().find("value") == op.params.as_object().end()) {
-                throw RegistryError("operator \"" + name + "\": required parameter \"value\" missing for operator \"" + name + "\"");
-            }
-        }
-        if (op.type_name == "filter_truncate") {
-            auto pit = op.params.as_object().find("top_n");
-            if (pit != op.params.as_object().end()) {
-                if (!pit->second.is_number()) {
-                    throw RegistryError("operator \"" + name + "\": top_n must be numeric");
-                }
-                double val = pit->second.as_number();
-                if (val < 0) {
-                    throw RegistryError("operator \"" + name + "\": filter_truncate: top_n must be non-negative, got " + std::to_string(static_cast<int>(val)));
-                }
-            }
-        }
-        if (op.type_name == "reorder_sort") {
-            auto oit = op.params.as_object().find("order");
-            if (oit != op.params.as_object().end() && oit->second.is_string()) {
-                const auto& order = oit->second.as_string();
-                if (order != "asc" && order != "desc") {
-                    throw RegistryError("operator \"" + name + "\": unsupported order \"" + order + "\"");
-                }
-            }
-        }
-        if (op.data_parallel < 0) {
-            throw ValidationError("operator \"" + name + "\": data_parallel must be >= 1, got " + std::to_string(op.data_parallel));
-        }
-        if (op.data_parallel > 1) {
-            if (op.operator_type != "transform") {
-                throw ValidationError("operator \"" + name + "\": data_parallel=" + std::to_string(op.data_parallel) + " is only supported for Transform operators, got " + op.operator_type);
-            }
-            if (!op.metadata.common_output.empty()) {
-                throw ValidationError("operator \"" + name + "\": data_parallel=" + std::to_string(op.data_parallel) + " requires empty $metadata.common_output for Transform operators");
-            }
-            if (!op.concurrent_safe) {
-                throw ValidationError("operator \"" + name + "\": data_parallel=" + std::to_string(op.data_parallel) + " requires the operator to implement ConcurrentSafe interface (type \"" + op.type_name + "\" does not)");
-            }
-        }
+  if (config.operators.empty()) {
+    throw ConfigError("pipeline_config.operators is empty");
+  }
+  if (config.pipeline_group.empty()) {
+    throw ConfigError("pipeline_group is empty");
+  }
+  for (const auto& [name, op] : config.operators) {
+    for (const auto& skip : op.skip) {
+      if (skip.empty() || skip[0] != '_') {
+        throw ConfigError("operator \"" + name + "\": skip field \"" + skip +
+                          "\" must start with '_' (control fields are engine-internal)");
+      }
+      const auto& ci = op.metadata.common_input;
+      if (std::find(ci.begin(), ci.end(), skip) == ci.end()) {
+        throw ConfigError("operator \"" + name + "\": skip field \"" + skip +
+                          "\" must also appear in $metadata.common_input to ensure correct DAG ordering");
+      }
     }
-    for (const auto& [name, _] : config.operators) {
-        if (config.pipeline_map.count(name)) {
-            throw ConfigError("name \"" + name + "\" exists in both operators and pipeline_map");
-        }
+    for (const auto& src : op.sources) {
+      if (!config.operators.count(src)) {
+        throw ConfigError("operator \"" + name + "\": sources references undefined operator \"" + src + "\"");
+      }
     }
+    if (op.additive_writes_row_set && op.mutates_row_set) {
+      throw RegistryError("operator \"" + name +
+                          "\": additive_writes_row_set and mutates_row_set are mutually exclusive");
+    }
+    if (op.type_name == "filter_condition") {
+      if (!op.params.is_object() || op.params.as_object().find("value") == op.params.as_object().end()) {
+        throw RegistryError("operator \"" + name +
+                            "\": required parameter \"value\" missing for operator \"" + name + "\"");
+      }
+    }
+    if (op.type_name == "filter_truncate") {
+      auto pit = op.params.as_object().find("top_n");
+      if (pit != op.params.as_object().end()) {
+        if (!pit->second.is_number()) {
+          throw RegistryError("operator \"" + name + "\": top_n must be numeric");
+        }
+        double val = pit->second.as_number();
+        if (val < 0) {
+          throw RegistryError("operator \"" + name + "\": filter_truncate: top_n must be non-negative, got " +
+                              std::to_string(static_cast<int>(val)));
+        }
+      }
+    }
+    if (op.type_name == "reorder_sort") {
+      auto oit = op.params.as_object().find("order");
+      if (oit != op.params.as_object().end() && oit->second.is_string()) {
+        const auto& order = oit->second.as_string();
+        if (order != "asc" && order != "desc") {
+          throw RegistryError("operator \"" + name + "\": unsupported order \"" + order + "\"");
+        }
+      }
+    }
+    if (op.data_parallel < 0) {
+      throw ValidationError("operator \"" + name + "\": data_parallel must be >= 1, got " +
+                            std::to_string(op.data_parallel));
+    }
+    if (op.data_parallel > 1) {
+      if (op.operator_type != "transform") {
+        throw ValidationError("operator \"" + name + "\": data_parallel=" + std::to_string(op.data_parallel) +
+                              " is only supported for Transform operators, got " + op.operator_type);
+      }
+      if (!op.metadata.common_output.empty()) {
+        throw ValidationError("operator \"" + name + "\": data_parallel=" + std::to_string(op.data_parallel) +
+                              " requires empty $metadata.common_output for Transform operators");
+      }
+      if (!op.concurrent_safe) {
+        throw ValidationError("operator \"" + name + "\": data_parallel=" + std::to_string(op.data_parallel) +
+                              " requires the operator to implement ConcurrentSafe interface (type \"" +
+                              op.type_name + "\" does not)");
+      }
+    }
+  }
+  for (const auto& [name, _] : config.operators) {
+    if (config.pipeline_map.count(name)) {
+      throw ConfigError("name \"" + name + "\" exists in both operators and pipeline_map");
+    }
+  }
 }
 
-void expand_entries(const Config& config,
-                    const std::vector<std::string>& entries,
-                    const std::string& parent,
-                    std::vector<std::string>& sequence,
-                    std::map<std::string, std::string>& mapping,
-                    std::set<std::string>& visiting,
-                    std::set<std::string>& seen) {
-    for (const auto& entry : entries) {
-        if (config.operators.count(entry)) {
-            if (seen.count(entry)) throw ConfigError("operator \"" + entry + "\" referenced more than once in pipeline tree");
-            seen.insert(entry);
-            sequence.push_back(entry);
-            mapping[entry] = parent;
-        } else if (config.pipeline_map.count(entry)) {
-            if (visiting.count(entry)) throw ConfigError("cycle detected in sub-flow expansion: \"" + entry + "\"");
-            visiting.insert(entry);
-            expand_entries(config, config.pipeline_map.at(entry), entry, sequence, mapping, visiting, seen);
-            visiting.erase(entry);
-        } else {
-            throw ConfigError("pipeline entry \"" + entry + "\" is neither an operator nor a sub-flow");
-        }
+void expand_entries(const Config& config, const std::vector<std::string>& entries, const std::string& parent,
+                    std::vector<std::string>& sequence, std::map<std::string, std::string>& mapping,
+                    std::set<std::string>& visiting, std::set<std::string>& seen) {
+  for (const auto& entry : entries) {
+    if (config.operators.count(entry)) {
+      if (seen.count(entry)) {
+        throw ConfigError("operator \"" + entry + "\" referenced more than once in pipeline tree");
+      }
+      seen.insert(entry);
+      sequence.push_back(entry);
+      mapping[entry] = parent;
+    } else if (config.pipeline_map.count(entry)) {
+      if (visiting.count(entry)) {
+        throw ConfigError("cycle detected in sub-flow expansion: \"" + entry + "\"");
+      }
+      visiting.insert(entry);
+      expand_entries(config, config.pipeline_map.at(entry), entry, sequence, mapping, visiting, seen);
+      visiting.erase(entry);
+    } else {
+      throw ConfigError("pipeline entry \"" + entry + "\" is neither an operator nor a sub-flow");
     }
+  }
 }
 
 }  // namespace
 
-Config load_config_from_file(const std::string& path) { return load_config_from_json(read_file(path)); }
+Config load_config_from_file(const std::string& path) {
+  return load_config_from_json(read_file(path));
+}
 
 Config load_config_from_json(const std::string& text) {
-    const auto root = parse_json(text).as_object();
-    auto require_obj = [](const JsonValue::object_t& parent, const std::string& key) -> const JsonValue::object_t& {
-        auto it = parent.find(key);
-        if (it == parent.end()) throw ConfigError("missing required top-level field \"" + key + "\"");
-        return it->second.as_object();
-    };
-    Config config;
-    if (auto it = root.find("storage_mode"); it != root.end()) config.storage_mode = it->second.as_string();
-    if (auto it = root.find("debug"); it != root.end() && it->second.is_bool()) config.debug = it->second.as_bool();
-    if (auto it = root.find("log_prefix"); it != root.end() && it->second.is_string()) config.log_prefix = it->second.as_string();
-    if (auto it = root.find("_PINEAPPLE_VERSION"); it != root.end() && it->second.is_string()) config.pineapple_version = it->second.as_string();
-    if (auto it = root.find("_PINEAPPLE_CREATE_TIME"); it != root.end() && it->second.is_string()) config.pineapple_create_time = it->second.as_string();
-    if (auto it = root.find("resource_config"); it != root.end() && it->second.is_object()) {
-        for (const auto& [name, entry] : it->second.as_object()) {
-            if (!entry.is_object()) throw ConfigError("resource_config entry \"" + name + "\" must be an object");
-            const auto& eo = entry.as_object();
-            ResourceEntry re;
-            if (auto tit = eo.find("type"); tit != eo.end() && tit->second.is_string()) re.type = tit->second.as_string();
-            if (auto iit = eo.find("interval"); iit != eo.end() && iit->second.is_number()) re.interval = static_cast<int>(iit->second.as_number());
-            if (auto pit = eo.find("params"); pit != eo.end()) re.params = pit->second;
-            config.resource_config[name] = std::move(re);
-        }
+  const auto root = parse_json(text).as_object();
+  auto require_obj = [](const JsonValue::object_t& parent,
+                        const std::string& key) -> const JsonValue::object_t& {
+    auto it = parent.find(key);
+    if (it == parent.end()) {
+      throw ConfigError("missing required top-level field \"" + key + "\"");
     }
-    // Follow-up: flow_contract is optional in pine-go (struct field
-    // with omitempty semantics defaults to empty FlowContract{}). Match
-    // that — only parse the four input/output lists when the field is
-    // present. Caught by differential fuzz: 17/50 smoke
-    // divergences all hit this strictness.
-    if (auto fit = root.find("flow_contract"); fit != root.end() && fit->second.is_object()) {
-        const auto& flow = fit->second.as_object();
-        if (auto k = flow.find("common_input"); k != flow.end()) {
-            config.flow_contract.common_input = as_string_list(flow, "common_input");
-        }
-        if (auto k = flow.find("item_input"); k != flow.end()) {
-            config.flow_contract.item_input = as_string_list(flow, "item_input");
-        }
-        if (auto k = flow.find("common_output"); k != flow.end()) {
-            config.flow_contract.common_output = as_string_list(flow, "common_output");
-        }
-        if (auto k = flow.find("item_output"); k != flow.end()) {
-            config.flow_contract.item_output = as_string_list(flow, "item_output");
-        }
+    return it->second.as_object();
+  };
+  Config config;
+  if (auto it = root.find("storage_mode"); it != root.end()) {
+    config.storage_mode = it->second.as_string();
+  }
+  if (auto it = root.find("debug"); it != root.end() && it->second.is_bool()) {
+    config.debug = it->second.as_bool();
+  }
+  if (auto it = root.find("log_prefix"); it != root.end() && it->second.is_string()) {
+    config.log_prefix = it->second.as_string();
+  }
+  if (auto it = root.find("_PINEAPPLE_VERSION"); it != root.end() && it->second.is_string()) {
+    config.pineapple_version = it->second.as_string();
+  }
+  if (auto it = root.find("_PINEAPPLE_CREATE_TIME"); it != root.end() && it->second.is_string()) {
+    config.pineapple_create_time = it->second.as_string();
+  }
+  if (auto it = root.find("resource_config"); it != root.end() && it->second.is_object()) {
+    for (const auto& [name, entry] : it->second.as_object()) {
+      if (!entry.is_object()) {
+        throw ConfigError("resource_config entry \"" + name + "\" must be an object");
+      }
+      const auto& eo = entry.as_object();
+      ResourceEntry re;
+      if (auto tit = eo.find("type"); tit != eo.end() && tit->second.is_string()) {
+        re.type = tit->second.as_string();
+      }
+      if (auto iit = eo.find("interval"); iit != eo.end() && iit->second.is_number()) {
+        re.interval = static_cast<int>(iit->second.as_number());
+      }
+      if (auto pit = eo.find("params"); pit != eo.end()) {
+        re.params = pit->second;
+      }
+      config.resource_config[name] = std::move(re);
     }
+  }
+  // Follow-up: flow_contract is optional in pine-go (struct field
+  // with omitempty semantics defaults to empty FlowContract{}). Match
+  // that — only parse the four input/output lists when the field is
+  // present. Caught by differential fuzz: 17/50 smoke
+  // divergences all hit this strictness.
+  if (auto fit = root.find("flow_contract"); fit != root.end() && fit->second.is_object()) {
+    const auto& flow = fit->second.as_object();
+    if (auto k = flow.find("common_input"); k != flow.end()) {
+      config.flow_contract.common_input = as_string_list(flow, "common_input");
+    }
+    if (auto k = flow.find("item_input"); k != flow.end()) {
+      config.flow_contract.item_input = as_string_list(flow, "item_input");
+    }
+    if (auto k = flow.find("common_output"); k != flow.end()) {
+      config.flow_contract.common_output = as_string_list(flow, "common_output");
+    }
+    if (auto k = flow.find("item_output"); k != flow.end()) {
+      config.flow_contract.item_output = as_string_list(flow, "item_output");
+    }
+  }
 
-    const auto& group = require_obj(root, "pipeline_group");
-    for (const auto& [name, value] : group) config.pipeline_group[name] = as_string_list(value.as_object(), "pipeline");
+  const auto& group = require_obj(root, "pipeline_group");
+  for (const auto& [name, value] : group) {
+    config.pipeline_group[name] = as_string_list(value.as_object(), "pipeline");
+  }
 
-    const auto& pipeline_config = require_obj(root, "pipeline_config");
-    if (auto pit = pipeline_config.find("pipeline_map"); pit != pipeline_config.end()) {
-        for (const auto& [name, value] : pit->second.as_object()) config.pipeline_map[name] = as_string_list(value.as_object(), "pipeline");
+  const auto& pipeline_config = require_obj(root, "pipeline_config");
+  if (auto pit = pipeline_config.find("pipeline_map"); pit != pipeline_config.end()) {
+    for (const auto& [name, value] : pit->second.as_object()) {
+      config.pipeline_map[name] = as_string_list(value.as_object(), "pipeline");
     }
-    auto operators_it = pipeline_config.find("operators");
-    if (operators_it == pipeline_config.end()) throw ConfigError("missing required top-level field \"pipeline_config.operators\"");
-    for (const auto& [name, value] : operators_it->second.as_object()) config.operators[name] = parse_operator(name, value);
-    apply_registry_traits(config);
-    validate_config(config);
-    return config;
+  }
+  auto operators_it = pipeline_config.find("operators");
+  if (operators_it == pipeline_config.end()) {
+    throw ConfigError("missing required top-level field \"pipeline_config.operators\"");
+  }
+  for (const auto& [name, value] : operators_it->second.as_object()) {
+    config.operators[name] = parse_operator(name, value);
+  }
+  apply_registry_traits(config);
+  validate_config(config);
+  return config;
 }
 
 ExpandedSequence expand_operator_sequence_with_subflows(const Config& config) {
-    ExpandedSequence out;
-    std::vector<std::string> root_entries;
-    if (auto it = config.pipeline_group.find("main"); it != config.pipeline_group.end()) {
-        root_entries = it->second;
-    } else if (config.pipeline_group.size() == 1) {
-        root_entries = config.pipeline_group.begin()->second;
-    } else {
-        throw ConfigError("pipeline_group must contain a \"main\" entry or exactly one entry");
-    }
-    std::set<std::string> visiting;
-    std::set<std::string> seen;
-    expand_entries(config, root_entries, "", out.sequence, out.op_to_subflow, visiting, seen);
-    return out;
+  ExpandedSequence out;
+  std::vector<std::string> root_entries;
+  if (auto it = config.pipeline_group.find("main"); it != config.pipeline_group.end()) {
+    root_entries = it->second;
+  } else if (config.pipeline_group.size() == 1) {
+    root_entries = config.pipeline_group.begin()->second;
+  } else {
+    throw ConfigError("pipeline_group must contain a \"main\" entry or exactly one entry");
+  }
+  std::set<std::string> visiting;
+  std::set<std::string> seen;
+  expand_entries(config, root_entries, "", out.sequence, out.op_to_subflow, visiting, seen);
+  return out;
 }
 
 Request load_request_from_file(const std::string& path) {
-    const auto root = parse_json(read_file(path)).as_object();
-    Request request;
-    if (auto it = root.find("common"); it != root.end()) {
-        for (const auto& [key, value] : it->second.as_object()) request.common[key] = value;
+  const auto root = parse_json(read_file(path)).as_object();
+  Request request;
+  if (auto it = root.find("common"); it != root.end()) {
+    for (const auto& [key, value] : it->second.as_object()) {
+      request.common[key] = value;
     }
-    if (auto it = root.find("items"); it != root.end()) {
-        for (const auto& item : it->second.as_array()) {
-            std::map<std::string, JsonValue> row;
-            for (const auto& [key, value] : item.as_object()) row[key] = value;
-            request.items.push_back(std::move(row));
-        }
+  }
+  if (auto it = root.find("items"); it != root.end()) {
+    for (const auto& item : it->second.as_array()) {
+      std::map<std::string, JsonValue> row;
+      for (const auto& [key, value] : item.as_object()) {
+        row[key] = value;
+      }
+      request.items.push_back(std::move(row));
     }
-    return request;
+  }
+  return request;
 }
 
 std::string result_to_json(const Result& result) {
-    JsonValue::object_t root;
-    JsonValue::object_t common;
-    for (const auto& [key, value] : result.common) common[key] = value;
-    JsonValue::array_t items;
-    for (const auto& row : result.items) {
-        JsonValue::object_t obj;
-        for (const auto& [key, value] : row) obj[key] = value;
-        items.emplace_back(obj);
+  JsonValue::object_t root;
+  JsonValue::object_t common;
+  for (const auto& [key, value] : result.common) {
+    common[key] = value;
+  }
+  JsonValue::array_t items;
+  for (const auto& row : result.items) {
+    JsonValue::object_t obj;
+    for (const auto& [key, value] : row) {
+      obj[key] = value;
     }
-    root["common"] = JsonValue(common);
-    root["items"] = JsonValue(items);
-    return dump_json(JsonValue(root));
+    items.emplace_back(obj);
+  }
+  root["common"] = JsonValue(common);
+  root["items"] = JsonValue(items);
+  return dump_json(JsonValue(root));
 }
 
 }  // namespace pine

--- a/pine-cpp/src/config/json.cpp
+++ b/pine-cpp/src/config/json.cpp
@@ -10,263 +10,376 @@
 
 namespace pine {
 
-JsonValue::JsonValue() : value_(nullptr) {}
-JsonValue::JsonValue(std::nullptr_t) : value_(nullptr) {}
-JsonValue::JsonValue(bool value) : value_(value) {}
-JsonValue::JsonValue(double value) : value_(value) {}
-JsonValue::JsonValue(int value) : value_(static_cast<double>(value)) {}
-JsonValue::JsonValue(std::string value) : value_(std::move(value)) {}
-JsonValue::JsonValue(const char* value) : value_(std::string(value)) {}
-JsonValue::JsonValue(array_t value) : value_(std::move(value)) {}
-JsonValue::JsonValue(object_t value) : value_(std::move(value)) {}
+JsonValue::JsonValue() : value_(nullptr) {
+}
+JsonValue::JsonValue(std::nullptr_t) : value_(nullptr) {
+}
+JsonValue::JsonValue(bool value) : value_(value) {
+}
+JsonValue::JsonValue(double value) : value_(value) {
+}
+JsonValue::JsonValue(int value) : value_(static_cast<double>(value)) {
+}
+JsonValue::JsonValue(std::string value) : value_(std::move(value)) {
+}
+JsonValue::JsonValue(const char* value) : value_(std::string(value)) {
+}
+JsonValue::JsonValue(array_t value) : value_(std::move(value)) {
+}
+JsonValue::JsonValue(object_t value) : value_(std::move(value)) {
+}
 
-bool JsonValue::is_null() const { return std::holds_alternative<std::nullptr_t>(value_); }
-bool JsonValue::is_bool() const { return std::holds_alternative<bool>(value_); }
-bool JsonValue::is_number() const { return std::holds_alternative<double>(value_); }
-bool JsonValue::is_string() const { return std::holds_alternative<std::string>(value_); }
-bool JsonValue::is_array() const { return std::holds_alternative<array_t>(value_); }
-bool JsonValue::is_object() const { return std::holds_alternative<object_t>(value_); }
+bool JsonValue::is_null() const {
+  return std::holds_alternative<std::nullptr_t>(value_);
+}
+bool JsonValue::is_bool() const {
+  return std::holds_alternative<bool>(value_);
+}
+bool JsonValue::is_number() const {
+  return std::holds_alternative<double>(value_);
+}
+bool JsonValue::is_string() const {
+  return std::holds_alternative<std::string>(value_);
+}
+bool JsonValue::is_array() const {
+  return std::holds_alternative<array_t>(value_);
+}
+bool JsonValue::is_object() const {
+  return std::holds_alternative<object_t>(value_);
+}
 
 bool JsonValue::as_bool() const {
-    if (!is_bool()) throw ConfigError("JSON value is not bool");
-    return std::get<bool>(value_);
+  if (!is_bool()) {
+    throw ConfigError("JSON value is not bool");
+  }
+  return std::get<bool>(value_);
 }
 
 double JsonValue::as_number() const {
-    if (!is_number()) throw ConfigError("JSON value is not number");
-    return std::get<double>(value_);
+  if (!is_number()) {
+    throw ConfigError("JSON value is not number");
+  }
+  return std::get<double>(value_);
 }
 
 const std::string& JsonValue::as_string() const {
-    if (!is_string()) throw ConfigError("JSON value is not string");
-    return std::get<std::string>(value_);
+  if (!is_string()) {
+    throw ConfigError("JSON value is not string");
+  }
+  return std::get<std::string>(value_);
 }
 
 const JsonValue::array_t& JsonValue::as_array() const {
-    if (!is_array()) throw ConfigError("JSON value is not array");
-    return std::get<array_t>(value_);
+  if (!is_array()) {
+    throw ConfigError("JSON value is not array");
+  }
+  return std::get<array_t>(value_);
 }
 
 const JsonValue::object_t& JsonValue::as_object() const {
-    if (!is_object()) throw ConfigError("JSON value is not object");
-    return std::get<object_t>(value_);
+  if (!is_object()) {
+    throw ConfigError("JSON value is not object");
+  }
+  return std::get<object_t>(value_);
 }
 
 JsonValue::array_t& JsonValue::as_array() {
-    if (!is_array()) throw ConfigError("JSON value is not array");
-    return std::get<array_t>(value_);
+  if (!is_array()) {
+    throw ConfigError("JSON value is not array");
+  }
+  return std::get<array_t>(value_);
 }
 
 JsonValue::object_t& JsonValue::as_object() {
-    if (!is_object()) throw ConfigError("JSON value is not object");
-    return std::get<object_t>(value_);
+  if (!is_object()) {
+    throw ConfigError("JSON value is not object");
+  }
+  return std::get<object_t>(value_);
 }
 
 bool JsonValue::truthy() const {
-    if (is_null()) return false;
-    if (is_bool()) return as_bool();
-    return true;
+  if (is_null()) {
+    return false;
+  }
+  if (is_bool()) {
+    return as_bool();
+  }
+  return true;
 }
 
 const JsonValue* JsonValue::find(const std::string& key) const {
-    if (!is_object()) return nullptr;
-    const auto& obj = as_object();
-    auto it = obj.find(key);
-    return it == obj.end() ? nullptr : &it->second;
+  if (!is_object()) {
+    return nullptr;
+  }
+  const auto& obj = as_object();
+  auto it = obj.find(key);
+  return it == obj.end() ? nullptr : &it->second;
 }
 
 JsonValue* JsonValue::find(const std::string& key) {
-    if (!is_object()) return nullptr;
-    auto& obj = as_object();
-    auto it = obj.find(key);
-    return it == obj.end() ? nullptr : &it->second;
+  if (!is_object()) {
+    return nullptr;
+  }
+  auto& obj = as_object();
+  auto it = obj.find(key);
+  return it == obj.end() ? nullptr : &it->second;
 }
 
 namespace {
 
 class Parser {
-public:
-    explicit Parser(const std::string& text) : text_(text) {}
+ public:
+  explicit Parser(const std::string& text) : text_(text) {
+  }
 
-    JsonValue parse() {
-        skip_ws();
-        JsonValue value = parse_value();
-        skip_ws();
-        if (pos_ != text_.size()) throw ConfigError("failed to parse config JSON: trailing characters");
-        return value;
+  JsonValue parse() {
+    skip_ws();
+    JsonValue value = parse_value();
+    skip_ws();
+    if (pos_ != text_.size()) {
+      throw ConfigError("failed to parse config JSON: trailing characters");
     }
+    return value;
+  }
 
-private:
-    const std::string& text_;
-    std::size_t pos_ = 0;
+ private:
+  const std::string& text_;
+  std::size_t pos_ = 0;
 
-    void skip_ws() {
-        while (pos_ < text_.size() && std::isspace(static_cast<unsigned char>(text_[pos_]))) ++pos_;
+  void skip_ws() {
+    while (pos_ < text_.size() && std::isspace(static_cast<unsigned char>(text_[pos_]))) {
+      ++pos_;
     }
+  }
 
-    char peek() const {
-        if (pos_ >= text_.size()) throw ConfigError("failed to parse config JSON: unexpected end of input");
-        return text_[pos_];
+  char peek() const {
+    if (pos_ >= text_.size()) {
+      throw ConfigError("failed to parse config JSON: unexpected end of input");
     }
+    return text_[pos_];
+  }
 
-    bool consume(char ch) {
-        if (pos_ < text_.size() && text_[pos_] == ch) {
-            ++pos_;
-            return true;
+  bool consume(char ch) {
+    if (pos_ < text_.size() && text_[pos_] == ch) {
+      ++pos_;
+      return true;
+    }
+    return false;
+  }
+
+  void expect(const std::string& token) {
+    if (text_.compare(pos_, token.size(), token) != 0) {
+      throw ConfigError("failed to parse config JSON: expected " + token);
+    }
+    pos_ += token.size();
+  }
+
+  JsonValue parse_value() {
+    skip_ws();
+    char ch = peek();
+    if (ch == '{') {
+      return parse_object();
+    }
+    if (ch == '[') {
+      return parse_array();
+    }
+    if (ch == '"') {
+      return JsonValue(parse_string());
+    }
+    if (ch == 't') {
+      expect("true");
+      return JsonValue(true);
+    }
+    if (ch == 'f') {
+      expect("false");
+      return JsonValue(false);
+    }
+    if (ch == 'n') {
+      expect("null");
+      return JsonValue(nullptr);
+    }
+    return JsonValue(parse_number());
+  }
+
+  JsonValue parse_object() {
+    consume('{');
+    JsonValue::object_t object;
+    skip_ws();
+    if (consume('}')) {
+      return JsonValue(object);
+    }
+    while (true) {
+      skip_ws();
+      std::string key = parse_string();
+      skip_ws();
+      if (!consume(':')) {
+        throw ConfigError("failed to parse config JSON: expected ':'");
+      }
+      skip_ws();
+      object.emplace(std::move(key), parse_value());
+      skip_ws();
+      if (consume('}')) {
+        break;
+      }
+      if (!consume(',')) {
+        throw ConfigError("failed to parse config JSON: expected ','");
+      }
+    }
+    return JsonValue(object);
+  }
+
+  JsonValue parse_array() {
+    consume('[');
+    JsonValue::array_t array;
+    skip_ws();
+    if (consume(']')) {
+      return JsonValue(array);
+    }
+    while (true) {
+      skip_ws();
+      array.push_back(parse_value());
+      skip_ws();
+      if (consume(']')) {
+        break;
+      }
+      if (!consume(',')) {
+        throw ConfigError("failed to parse config JSON: expected ','");
+      }
+    }
+    return JsonValue(array);
+  }
+
+  std::string parse_string() {
+    if (!consume('"')) {
+      throw ConfigError("failed to parse config JSON: expected string");
+    }
+    std::string out;
+    while (pos_ < text_.size()) {
+      char ch = text_[pos_++];
+      if (ch == '"') {
+        return out;
+      }
+      if (ch == '\\') {
+        if (pos_ >= text_.size()) {
+          throw ConfigError("failed to parse config JSON: invalid escape");
         }
-        return false;
-    }
-
-    void expect(const std::string& token) {
-        if (text_.compare(pos_, token.size(), token) != 0) {
-            throw ConfigError("failed to parse config JSON: expected " + token);
-        }
-        pos_ += token.size();
-    }
-
-    JsonValue parse_value() {
-        skip_ws();
-        char ch = peek();
-        if (ch == '{') return parse_object();
-        if (ch == '[') return parse_array();
-        if (ch == '"') return JsonValue(parse_string());
-        if (ch == 't') {
-            expect("true");
-            return JsonValue(true);
-        }
-        if (ch == 'f') {
-            expect("false");
-            return JsonValue(false);
-        }
-        if (ch == 'n') {
-            expect("null");
-            return JsonValue(nullptr);
-        }
-        return JsonValue(parse_number());
-    }
-
-    JsonValue parse_object() {
-        consume('{');
-        JsonValue::object_t object;
-        skip_ws();
-        if (consume('}')) return JsonValue(object);
-        while (true) {
-            skip_ws();
-            std::string key = parse_string();
-            skip_ws();
-            if (!consume(':')) throw ConfigError("failed to parse config JSON: expected ':'");
-            skip_ws();
-            object.emplace(std::move(key), parse_value());
-            skip_ws();
-            if (consume('}')) break;
-            if (!consume(',')) throw ConfigError("failed to parse config JSON: expected ','");
-        }
-        return JsonValue(object);
-    }
-
-    JsonValue parse_array() {
-        consume('[');
-        JsonValue::array_t array;
-        skip_ws();
-        if (consume(']')) return JsonValue(array);
-        while (true) {
-            skip_ws();
-            array.push_back(parse_value());
-            skip_ws();
-            if (consume(']')) break;
-            if (!consume(',')) throw ConfigError("failed to parse config JSON: expected ','");
-        }
-        return JsonValue(array);
-    }
-
-    std::string parse_string() {
-        if (!consume('"')) throw ConfigError("failed to parse config JSON: expected string");
-        std::string out;
-        while (pos_ < text_.size()) {
-            char ch = text_[pos_++];
-            if (ch == '"') return out;
-            if (ch == '\\') {
-                if (pos_ >= text_.size()) throw ConfigError("failed to parse config JSON: invalid escape");
-                char esc = text_[pos_++];
-                switch (esc) {
-                    case '"': out.push_back('"'); break;
-                    case '\\': out.push_back('\\'); break;
-                    case '/': out.push_back('/'); break;
-                    case 'b': out.push_back('\b'); break;
-                    case 'f': out.push_back('\f'); break;
-                    case 'n': out.push_back('\n'); break;
-                    case 'r': out.push_back('\r'); break;
-                    case 't': out.push_back('\t'); break;
-                    case 'u': {
-                        if (pos_ + 4 > text_.size()) throw ConfigError("failed to parse config JSON: incomplete unicode escape");
-                        auto hex4 = [&]() -> uint32_t {
-                            uint32_t cp = 0;
-                            for (int k = 0; k < 4; ++k) {
-                                char h = text_[pos_++];
-                                cp <<= 4;
-                                if (h >= '0' && h <= '9') cp |= static_cast<uint32_t>(h - '0');
-                                else if (h >= 'a' && h <= 'f') cp |= static_cast<uint32_t>(h - 'a' + 10);
-                                else if (h >= 'A' && h <= 'F') cp |= static_cast<uint32_t>(h - 'A' + 10);
-                                else throw ConfigError("failed to parse config JSON: invalid unicode escape");
-                            }
-                            return cp;
-                        };
-                        uint32_t cp = hex4();
-                        if (cp >= 0xD800 && cp <= 0xDBFF) {
-                            if (pos_ + 6 > text_.size() || text_[pos_] != '\\' || text_[pos_ + 1] != 'u')
-                                throw ConfigError("failed to parse config JSON: missing low surrogate");
-                            pos_ += 2;
-                            uint32_t lo = hex4();
-                            if (lo < 0xDC00 || lo > 0xDFFF)
-                                throw ConfigError("failed to parse config JSON: invalid low surrogate");
-                            cp = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
-                        }
-                        if (cp < 0x80) {
-                            out.push_back(static_cast<char>(cp));
-                        } else if (cp < 0x800) {
-                            out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
-                            out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-                        } else if (cp < 0x10000) {
-                            out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
-                            out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-                            out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-                        } else {
-                            out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
-                            out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
-                            out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-                            out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-                        }
-                        break;
-                    }
-                    default: throw ConfigError("failed to parse config JSON: unsupported escape");
-                }
-            } else {
-                out.push_back(ch);
+        char esc = text_[pos_++];
+        switch (esc) {
+          case '"':
+            out.push_back('"');
+            break;
+          case '\\':
+            out.push_back('\\');
+            break;
+          case '/':
+            out.push_back('/');
+            break;
+          case 'b':
+            out.push_back('\b');
+            break;
+          case 'f':
+            out.push_back('\f');
+            break;
+          case 'n':
+            out.push_back('\n');
+            break;
+          case 'r':
+            out.push_back('\r');
+            break;
+          case 't':
+            out.push_back('\t');
+            break;
+          case 'u': {
+            if (pos_ + 4 > text_.size()) {
+              throw ConfigError("failed to parse config JSON: incomplete unicode escape");
             }
+            auto hex4 = [&]() -> uint32_t {
+              uint32_t cp = 0;
+              for (int k = 0; k < 4; ++k) {
+                char h = text_[pos_++];
+                cp <<= 4;
+                if (h >= '0' && h <= '9') {
+                  cp |= static_cast<uint32_t>(h - '0');
+                } else if (h >= 'a' && h <= 'f') {
+                  cp |= static_cast<uint32_t>(h - 'a' + 10);
+                } else if (h >= 'A' && h <= 'F') {
+                  cp |= static_cast<uint32_t>(h - 'A' + 10);
+                } else {
+                  throw ConfigError("failed to parse config JSON: invalid unicode escape");
+                }
+              }
+              return cp;
+            };
+            uint32_t cp = hex4();
+            if (cp >= 0xD800 && cp <= 0xDBFF) {
+              if (pos_ + 6 > text_.size() || text_[pos_] != '\\' || text_[pos_ + 1] != 'u') {
+                throw ConfigError("failed to parse config JSON: missing low surrogate");
+              }
+              pos_ += 2;
+              uint32_t lo = hex4();
+              if (lo < 0xDC00 || lo > 0xDFFF) {
+                throw ConfigError("failed to parse config JSON: invalid low surrogate");
+              }
+              cp = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+            }
+            if (cp < 0x80) {
+              out.push_back(static_cast<char>(cp));
+            } else if (cp < 0x800) {
+              out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+              out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+            } else if (cp < 0x10000) {
+              out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+              out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+              out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+            } else {
+              out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+              out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+              out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+              out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+            }
+            break;
+          }
+          default:
+            throw ConfigError("failed to parse config JSON: unsupported escape");
         }
-        throw ConfigError("failed to parse config JSON: unterminated string");
+      } else {
+        out.push_back(ch);
+      }
     }
+    throw ConfigError("failed to parse config JSON: unterminated string");
+  }
 
-    double parse_number() {
-        std::size_t start = pos_;
-        if (text_[pos_] == '-') ++pos_;
-        while (pos_ < text_.size() && std::isdigit(static_cast<unsigned char>(text_[pos_]))) ++pos_;
-        if (pos_ < text_.size() && text_[pos_] == '.') {
-            ++pos_;
-            while (pos_ < text_.size() && std::isdigit(static_cast<unsigned char>(text_[pos_]))) ++pos_;
-        }
-        if (pos_ < text_.size() && (text_[pos_] == 'e' || text_[pos_] == 'E')) {
-            ++pos_;
-            if (pos_ < text_.size() && (text_[pos_] == '+' || text_[pos_] == '-')) ++pos_;
-            while (pos_ < text_.size() && std::isdigit(static_cast<unsigned char>(text_[pos_]))) ++pos_;
-        }
-        double result = 0;
-        auto [ptr, ec] = std::from_chars(text_.data() + start, text_.data() + pos_, result);
-        if (ec != std::errc()) throw ConfigError("failed to parse config JSON: invalid number");
-        return result;
+  double parse_number() {
+    std::size_t start = pos_;
+    if (text_[pos_] == '-') {
+      ++pos_;
     }
+    while (pos_ < text_.size() && std::isdigit(static_cast<unsigned char>(text_[pos_]))) {
+      ++pos_;
+    }
+    if (pos_ < text_.size() && text_[pos_] == '.') {
+      ++pos_;
+      while (pos_ < text_.size() && std::isdigit(static_cast<unsigned char>(text_[pos_]))) {
+        ++pos_;
+      }
+    }
+    if (pos_ < text_.size() && (text_[pos_] == 'e' || text_[pos_] == 'E')) {
+      ++pos_;
+      if (pos_ < text_.size() && (text_[pos_] == '+' || text_[pos_] == '-')) {
+        ++pos_;
+      }
+      while (pos_ < text_.size() && std::isdigit(static_cast<unsigned char>(text_[pos_]))) {
+        ++pos_;
+      }
+    }
+    double result = 0;
+    auto [ptr, ec] = std::from_chars(text_.data() + start, text_.data() + pos_, result);
+    if (ec != std::errc()) {
+      throw ConfigError("failed to parse config JSON: invalid number");
+    }
+    return result;
+  }
 };
-
 
 // go_format_json_number formats a double matching Go's encoding/json byte-for-byte.
 // Go rule (encoding/json/encode.go floatEncoder): for float64, use 'f' format
@@ -274,18 +387,20 @@ private:
 // shortest). Both with precision=-1 (shortest representation). Diverges from
 // Go's fmt.Sprintf("%g") which uses different thresholds — keep them separate.
 std::string go_format_json_number(double d) {
-    if (d == 0.0) return std::signbit(d) ? "-0" : "0";
-    double abs_d = std::abs(d);
-    bool use_scientific = (abs_d < 1e-6) || (abs_d >= 1e21);
-    char buf[64];
-    auto fmt = use_scientific ? std::chars_format::scientific : std::chars_format::fixed;
-    auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), d, fmt);
-    if (ec != std::errc()) {
-        std::ostringstream oss;
-        oss << std::setprecision(17) << d;
-        return oss.str();
-    }
-    return std::string(buf, ptr);
+  if (d == 0.0) {
+    return std::signbit(d) ? "-0" : "0";
+  }
+  double abs_d = std::abs(d);
+  bool use_scientific = (abs_d < 1e-6) || (abs_d >= 1e21);
+  char buf[64];
+  auto fmt = use_scientific ? std::chars_format::scientific : std::chars_format::fixed;
+  auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), d, fmt);
+  if (ec != std::errc()) {
+    std::ostringstream oss;
+    oss << std::setprecision(17) << d;
+    return oss.str();
+  }
+  return std::string(buf, ptr);
 }
 
 // dump_impl writes the JSON serialization of `value` into `out`.
@@ -295,113 +410,154 @@ std::string go_format_json_number(double d) {
 // through the recursion eliminates those temporaries — each character is
 // appended exactly once into the caller's buffer.
 void dump_impl(const JsonValue& value, int indent_size, int depth, std::string& out) {
-    if (value.is_null()) { out += "null"; return; }
-    if (value.is_bool()) { out += value.as_bool() ? "true" : "false"; return; }
-    if (value.is_number()) { out += go_format_json_number(value.as_number()); return; }
-    if (value.is_string()) {
-        const auto& s = value.as_string();
-        out.push_back('"');
-        for (std::size_t i = 0; i < s.size(); ++i) {
-            unsigned char ch = static_cast<unsigned char>(s[i]);
-            switch (ch) {
-                case '"': out += "\\\""; break;
-                case '\\': out += "\\\\"; break;
-                case '\n': out += "\\n"; break;
-                case '\r': out += "\\r"; break;
-                case '\t': out += "\\t"; break;
-                case '<': out += "\\u003c"; break;
-                case '>': out += "\\u003e"; break;
-                case '&': out += "\\u0026"; break;
-                default:
-                    // U+2028 (E2 80 A8) and U+2029 (E2 80 A9): escape like Go's encoding/json
-                    if (ch == 0xE2 && i + 2 < s.size()
-                        && static_cast<unsigned char>(s[i+1]) == 0x80
-                        && (static_cast<unsigned char>(s[i+2]) == 0xA8 || static_cast<unsigned char>(s[i+2]) == 0xA9)) {
-                        out += (static_cast<unsigned char>(s[i+2]) == 0xA8) ? "\\u2028" : "\\u2029";
-                        i += 2;
-                    } else {
-                        out.push_back(static_cast<char>(ch));
-                    }
-                    break;
-            }
-        }
-        out.push_back('"');
-        return;
+  if (value.is_null()) {
+    out += "null";
+    return;
+  }
+  if (value.is_bool()) {
+    out += value.as_bool() ? "true" : "false";
+    return;
+  }
+  if (value.is_number()) {
+    out += go_format_json_number(value.as_number());
+    return;
+  }
+  if (value.is_string()) {
+    const auto& s = value.as_string();
+    out.push_back('"');
+    for (std::size_t i = 0; i < s.size(); ++i) {
+      unsigned char ch = static_cast<unsigned char>(s[i]);
+      switch (ch) {
+        case '"':
+          out += "\\\"";
+          break;
+        case '\\':
+          out += "\\\\";
+          break;
+        case '\n':
+          out += "\\n";
+          break;
+        case '\r':
+          out += "\\r";
+          break;
+        case '\t':
+          out += "\\t";
+          break;
+        case '<':
+          out += "\\u003c";
+          break;
+        case '>':
+          out += "\\u003e";
+          break;
+        case '&':
+          out += "\\u0026";
+          break;
+        default:
+          // U+2028 (E2 80 A8) and U+2029 (E2 80 A9): escape like Go's encoding/json
+          if (ch == 0xE2 && i + 2 < s.size() && static_cast<unsigned char>(s[i + 1]) == 0x80 &&
+              (static_cast<unsigned char>(s[i + 2]) == 0xA8 ||
+               static_cast<unsigned char>(s[i + 2]) == 0xA9)) {
+            out += (static_cast<unsigned char>(s[i + 2]) == 0xA8) ? "\\u2028" : "\\u2029";
+            i += 2;
+          } else {
+            out.push_back(static_cast<char>(ch));
+          }
+          break;
+      }
     }
-    if (value.is_array()) {
-        const auto& array = value.as_array();
-        if (array.empty()) { out += "[]"; return; }
-        // R13-1: compact mode (indent_size == 0) suppresses all '\n' and
-        // indent strings — matches Go json.Marshal output used by
-        // observe_log / [pine-debug] log lines and HTTP /execute trace
-        // payloads. Indented mode kept identical to the original layout.
-        const bool compact = (indent_size == 0);
-        out.push_back('[');
-        if (!compact) out.push_back('\n');
-        const std::string inner_indent = compact ? std::string()
-            : std::string(static_cast<std::size_t>((depth + 1) * indent_size), ' ');
-        const std::string outer_indent = compact ? std::string()
-            : std::string(static_cast<std::size_t>(depth * indent_size), ' ');
-        for (std::size_t i = 0; i < array.size(); ++i) {
-            out += inner_indent;
-            dump_impl(array[i], indent_size, depth + 1, out);
-            if (i + 1 != array.size()) {
-                out.push_back(',');
-                if (compact) {
-                    // no trailing space — Go json.Marshal uses bare ','
-                } else {
-                    out.push_back('\n');
-                }
-            } else if (!compact) {
-                out.push_back('\n');
-            }
-        }
-        out += outer_indent;
-        out.push_back(']');
-        return;
+    out.push_back('"');
+    return;
+  }
+  if (value.is_array()) {
+    const auto& array = value.as_array();
+    if (array.empty()) {
+      out += "[]";
+      return;
     }
-    const auto& object = value.as_object();
-    if (object.empty()) { out += "{}"; return; }
+    // R13-1: compact mode (indent_size == 0) suppresses all '\n' and
+    // indent strings — matches Go json.Marshal output used by
+    // observe_log / [pine-debug] log lines and HTTP /execute trace
+    // payloads. Indented mode kept identical to the original layout.
     const bool compact = (indent_size == 0);
-    out.push_back('{');
-    if (!compact) out.push_back('\n');
-    const std::string inner_indent = compact ? std::string()
-        : std::string(static_cast<std::size_t>((depth + 1) * indent_size), ' ');
-    const std::string outer_indent = compact ? std::string()
-        : std::string(static_cast<std::size_t>(depth * indent_size), ' ');
-    std::size_t index = 0;
-    for (const auto& [key, item] : object) {
-        out += inner_indent;
-        out.push_back('"');
-        out += key;
-        // Go json.Marshal compact form: `"k":v` (no space). Indent form
-        // keeps `"k": v` for human readability.
-        out += compact ? "\":" : "\": ";
-        dump_impl(item, indent_size, depth + 1, out);
-        if (++index != object.size()) {
-            out.push_back(',');
-            if (!compact) out.push_back('\n');
-        } else if (!compact) {
-            out.push_back('\n');
+    out.push_back('[');
+    if (!compact) {
+      out.push_back('\n');
+    }
+    const std::string inner_indent =
+        compact ? std::string() : std::string(static_cast<std::size_t>((depth + 1) * indent_size), ' ');
+    const std::string outer_indent =
+        compact ? std::string() : std::string(static_cast<std::size_t>(depth * indent_size), ' ');
+    for (std::size_t i = 0; i < array.size(); ++i) {
+      out += inner_indent;
+      dump_impl(array[i], indent_size, depth + 1, out);
+      if (i + 1 != array.size()) {
+        out.push_back(',');
+        if (compact) {
+          // no trailing space — Go json.Marshal uses bare ','
+        } else {
+          out.push_back('\n');
         }
+      } else if (!compact) {
+        out.push_back('\n');
+      }
     }
     out += outer_indent;
-    out.push_back('}');
+    out.push_back(']');
+    return;
+  }
+  const auto& object = value.as_object();
+  if (object.empty()) {
+    out += "{}";
+    return;
+  }
+  const bool compact = (indent_size == 0);
+  out.push_back('{');
+  if (!compact) {
+    out.push_back('\n');
+  }
+  const std::string inner_indent =
+      compact ? std::string() : std::string(static_cast<std::size_t>((depth + 1) * indent_size), ' ');
+  const std::string outer_indent =
+      compact ? std::string() : std::string(static_cast<std::size_t>(depth * indent_size), ' ');
+  std::size_t index = 0;
+  for (const auto& [key, item] : object) {
+    out += inner_indent;
+    out.push_back('"');
+    out += key;
+    // Go json.Marshal compact form: `"k":v` (no space). Indent form
+    // keeps `"k": v` for human readability.
+    out += compact ? "\":" : "\": ";
+    dump_impl(item, indent_size, depth + 1, out);
+    if (++index != object.size()) {
+      out.push_back(',');
+      if (!compact) {
+        out.push_back('\n');
+      }
+    } else if (!compact) {
+      out.push_back('\n');
+    }
+  }
+  out += outer_indent;
+  out.push_back('}');
 }
 
 }  // namespace
 
-JsonValue parse_json(const std::string& text) { return Parser(text).parse(); }
+JsonValue parse_json(const std::string& text) {
+  return Parser(text).parse();
+}
 std::string dump_json(const JsonValue& value, int indent) {
-    std::string out;
-    out.reserve(64);
-    dump_impl(value, indent, 0, out);
-    // R13-1: compact mode suppresses the trailing newline too so a single
-    // dump_json(value, 0) result fits in one line (observe_log / pine-debug
-    // log line filters depend on this). Indented mode keeps the trailing
-    // '\n' for human-readable file output.
-    if (indent != 0) out.push_back('\n');
-    return out;
+  std::string out;
+  out.reserve(64);
+  dump_impl(value, indent, 0, out);
+  // R13-1: compact mode suppresses the trailing newline too so a single
+  // dump_json(value, 0) result fits in one line (observe_log / pine-debug
+  // log line filters depend on this). Indented mode keeps the trailing
+  // '\n' for human-readable file output.
+  if (indent != 0) {
+    out.push_back('\n');
+  }
+  return out;
 }
 
 }  // namespace pine

--- a/pine-cpp/src/dag/dag.cpp
+++ b/pine-cpp/src/dag/dag.cpp
@@ -10,160 +10,225 @@ namespace {
 constexpr const char* kRowSet = "_row_set_";
 
 struct FieldTracker {
-    int last_mut_writer = -1;
-    std::vector<int> additive_writers;
-    std::vector<int> active_readers;
+  int last_mut_writer = -1;
+  std::vector<int> additive_writers;
+  std::vector<int> active_readers;
 };
 
 void add_edge(Graph& graph, int from, int to) {
-    if (from == to) return;
-    auto& succs = graph.nodes[from].succs;
-    if (std::find(succs.begin(), succs.end(), to) != succs.end()) return;
-    succs.push_back(to);
-    graph.nodes[to].preds.push_back(from);
+  if (from == to) {
+    return;
+  }
+  auto& succs = graph.nodes[from].succs;
+  if (std::find(succs.begin(), succs.end(), to) != succs.end()) {
+    return;
+  }
+  succs.push_back(to);
+  graph.nodes[to].preds.push_back(from);
 }
 
 void scan_fields(Graph& graph, const ExpandedSequence& expanded, bool common) {
-    std::map<std::string, FieldTracker> trackers;
-    for (std::size_t i = 0; i < expanded.sequence.size(); ++i) {
-        const auto& op = *graph.nodes[i].config;
-        std::vector<std::string> reads = common ? op.metadata.common_input : op.metadata.item_input;
-        std::vector<std::string> writes = common ? op.metadata.common_output : op.metadata.item_output;
-        const bool additive = !common && op.additive_writes_row_set;
-        if (!common) {
-            if (additive) writes.push_back(kRowSet);
-            if (op.consumes_row_set) reads.push_back(kRowSet);
-            if (!additive && !op.consumes_row_set && (!reads.empty() || !writes.empty())) {
-                reads.push_back(kRowSet);
-            }
-        }
-        for (const auto& field : reads) {
-            auto& tracker = trackers[field];
-            if (tracker.last_mut_writer >= 0) add_edge(graph, tracker.last_mut_writer, static_cast<int>(i));
-            for (int writer : tracker.additive_writers) add_edge(graph, writer, static_cast<int>(i));
-            tracker.active_readers.push_back(static_cast<int>(i));
-        }
-        for (const auto& field : writes) {
-            auto& tracker = trackers[field];
-            if (additive) {
-                if (tracker.last_mut_writer >= 0) add_edge(graph, tracker.last_mut_writer, static_cast<int>(i));
-                for (int reader : tracker.active_readers) if (reader != static_cast<int>(i)) add_edge(graph, reader, static_cast<int>(i));
-                tracker.additive_writers.push_back(static_cast<int>(i));
-            } else {
-                if (tracker.last_mut_writer >= 0) add_edge(graph, tracker.last_mut_writer, static_cast<int>(i));
-                for (int writer : tracker.additive_writers) add_edge(graph, writer, static_cast<int>(i));
-                for (int reader : tracker.active_readers) if (reader != static_cast<int>(i)) add_edge(graph, reader, static_cast<int>(i));
-                tracker.last_mut_writer = static_cast<int>(i);
-                tracker.additive_writers.clear();
-                tracker.active_readers.clear();
-            }
-        }
-        if (!common && op.mutates_row_set) {
-            auto& tracker = trackers[kRowSet];
-            if (tracker.last_mut_writer >= 0) add_edge(graph, tracker.last_mut_writer, static_cast<int>(i));
-            for (int writer : tracker.additive_writers) add_edge(graph, writer, static_cast<int>(i));
-            for (int reader : tracker.active_readers) if (reader != static_cast<int>(i)) add_edge(graph, reader, static_cast<int>(i));
-            tracker.last_mut_writer = static_cast<int>(i);
-            tracker.additive_writers.clear();
-            tracker.active_readers.clear();
-        }
+  std::map<std::string, FieldTracker> trackers;
+  for (std::size_t i = 0; i < expanded.sequence.size(); ++i) {
+    const auto& op = *graph.nodes[i].config;
+    std::vector<std::string> reads = common ? op.metadata.common_input : op.metadata.item_input;
+    std::vector<std::string> writes = common ? op.metadata.common_output : op.metadata.item_output;
+    const bool additive = !common && op.additive_writes_row_set;
+    if (!common) {
+      if (additive) {
+        writes.push_back(kRowSet);
+      }
+      if (op.consumes_row_set) {
+        reads.push_back(kRowSet);
+      }
+      if (!additive && !op.consumes_row_set && (!reads.empty() || !writes.empty())) {
+        reads.push_back(kRowSet);
+      }
     }
+    for (const auto& field : reads) {
+      auto& tracker = trackers[field];
+      if (tracker.last_mut_writer >= 0) {
+        add_edge(graph, tracker.last_mut_writer, static_cast<int>(i));
+      }
+      for (int writer : tracker.additive_writers) {
+        add_edge(graph, writer, static_cast<int>(i));
+      }
+      tracker.active_readers.push_back(static_cast<int>(i));
+    }
+    for (const auto& field : writes) {
+      auto& tracker = trackers[field];
+      if (additive) {
+        if (tracker.last_mut_writer >= 0) {
+          add_edge(graph, tracker.last_mut_writer, static_cast<int>(i));
+        }
+        for (int reader : tracker.active_readers) {
+          if (reader != static_cast<int>(i)) {
+            add_edge(graph, reader, static_cast<int>(i));
+          }
+        }
+        tracker.additive_writers.push_back(static_cast<int>(i));
+      } else {
+        if (tracker.last_mut_writer >= 0) {
+          add_edge(graph, tracker.last_mut_writer, static_cast<int>(i));
+        }
+        for (int writer : tracker.additive_writers) {
+          add_edge(graph, writer, static_cast<int>(i));
+        }
+        for (int reader : tracker.active_readers) {
+          if (reader != static_cast<int>(i)) {
+            add_edge(graph, reader, static_cast<int>(i));
+          }
+        }
+        tracker.last_mut_writer = static_cast<int>(i);
+        tracker.additive_writers.clear();
+        tracker.active_readers.clear();
+      }
+    }
+    if (!common && op.mutates_row_set) {
+      auto& tracker = trackers[kRowSet];
+      if (tracker.last_mut_writer >= 0) {
+        add_edge(graph, tracker.last_mut_writer, static_cast<int>(i));
+      }
+      for (int writer : tracker.additive_writers) {
+        add_edge(graph, writer, static_cast<int>(i));
+      }
+      for (int reader : tracker.active_readers) {
+        if (reader != static_cast<int>(i)) {
+          add_edge(graph, reader, static_cast<int>(i));
+        }
+      }
+      tracker.last_mut_writer = static_cast<int>(i);
+      tracker.additive_writers.clear();
+      tracker.active_readers.clear();
+    }
+  }
 }
 
 bool reachable_without(const Graph& graph, int src, int dst) {
-    std::set<int> visited{src};
-    std::deque<int> queue;
-    for (int next : graph.nodes[src].succs) {
-        if (next == dst) continue;
+  std::set<int> visited{src};
+  std::deque<int> queue;
+  for (int next : graph.nodes[src].succs) {
+    if (next == dst) {
+      continue;
+    }
+    visited.insert(next);
+    queue.push_back(next);
+  }
+  while (!queue.empty()) {
+    int current = queue.front();
+    queue.pop_front();
+    if (current == dst) {
+      return true;
+    }
+    for (int next : graph.nodes[current].succs) {
+      if (!visited.count(next)) {
         visited.insert(next);
         queue.push_back(next);
+      }
     }
-    while (!queue.empty()) {
-        int current = queue.front();
-        queue.pop_front();
-        if (current == dst) return true;
-        for (int next : graph.nodes[current].succs) {
-            if (!visited.count(next)) {
-                visited.insert(next);
-                queue.push_back(next);
-            }
-        }
-    }
-    return false;
+  }
+  return false;
 }
 
 void reduce(Graph& graph) {
-    std::vector<std::pair<int, int>> kept;
-    for (std::size_t u = 0; u < graph.nodes.size(); ++u) {
-        for (int v : graph.nodes[u].succs) {
-            if (!reachable_without(graph, static_cast<int>(u), v)) kept.emplace_back(static_cast<int>(u), v);
-        }
+  std::vector<std::pair<int, int>> kept;
+  for (std::size_t u = 0; u < graph.nodes.size(); ++u) {
+    for (int v : graph.nodes[u].succs) {
+      if (!reachable_without(graph, static_cast<int>(u), v)) {
+        kept.emplace_back(static_cast<int>(u), v);
+      }
     }
-    for (auto& node : graph.nodes) {
-        node.preds.clear();
-        node.succs.clear();
-    }
-    for (const auto& [u, v] : kept) add_edge(graph, u, v);
+  }
+  for (auto& node : graph.nodes) {
+    node.preds.clear();
+    node.succs.clear();
+  }
+  for (const auto& [u, v] : kept) {
+    add_edge(graph, u, v);
+  }
 }
 
 void topological_check(const Graph& graph) {
-    std::vector<int> indegree;
-    for (const auto& node : graph.nodes) indegree.push_back(static_cast<int>(node.preds.size()));
-    std::deque<int> queue;
-    for (std::size_t i = 0; i < indegree.size(); ++i) if (indegree[i] == 0) queue.push_back(static_cast<int>(i));
-    int seen = 0;
-    while (!queue.empty()) {
-        int current = queue.front();
-        queue.pop_front();
-        ++seen;
-        for (int succ : graph.nodes[current].succs) if (--indegree[succ] == 0) queue.push_back(succ);
+  std::vector<int> indegree;
+  for (const auto& node : graph.nodes) {
+    indegree.push_back(static_cast<int>(node.preds.size()));
+  }
+  std::deque<int> queue;
+  for (std::size_t i = 0; i < indegree.size(); ++i) {
+    if (indegree[i] == 0) {
+      queue.push_back(static_cast<int>(i));
     }
-    if (seen == static_cast<int>(graph.nodes.size())) return;
-    std::vector<std::string> cycle_nodes;
-    for (std::size_t i = 0; i < indegree.size(); ++i) if (indegree[i] > 0) cycle_nodes.push_back(graph.nodes[i].name);
-    std::string message = "DAG contains a cycle involving operators: [";
-    for (std::size_t i = 0; i < cycle_nodes.size(); ++i) {
-        if (i) message += ' ';
-        message += cycle_nodes[i];
+  }
+  int seen = 0;
+  while (!queue.empty()) {
+    int current = queue.front();
+    queue.pop_front();
+    ++seen;
+    for (int succ : graph.nodes[current].succs) {
+      if (--indegree[succ] == 0) {
+        queue.push_back(succ);
+      }
     }
-    message += ']';
-    throw ConfigError(message);
+  }
+  if (seen == static_cast<int>(graph.nodes.size())) {
+    return;
+  }
+  std::vector<std::string> cycle_nodes;
+  for (std::size_t i = 0; i < indegree.size(); ++i) {
+    if (indegree[i] > 0) {
+      cycle_nodes.push_back(graph.nodes[i].name);
+    }
+  }
+  std::string message = "DAG contains a cycle involving operators: [";
+  for (std::size_t i = 0; i < cycle_nodes.size(); ++i) {
+    if (i) {
+      message += ' ';
+    }
+    message += cycle_nodes[i];
+  }
+  message += ']';
+  throw ConfigError(message);
 }
 
 }  // namespace
 
 Graph build_dag(const Config& config, const ExpandedSequence& expanded) {
-    Graph graph;
-    for (std::size_t i = 0; i < expanded.sequence.size(); ++i) {
-        const auto& name = expanded.sequence[i];
-        auto op_it = config.operators.find(name);
-        if (op_it == config.operators.end()) throw ConfigError("operator \"" + name + "\" not found");
-        Node node;
-        node.name = name;
-        node.subflow = expanded.op_to_subflow.count(name) ? expanded.op_to_subflow.at(name) : "";
-        node.config = &op_it->second;
-        graph.name_to_index[name] = static_cast<int>(i);
-        graph.nodes.push_back(std::move(node));
+  Graph graph;
+  for (std::size_t i = 0; i < expanded.sequence.size(); ++i) {
+    const auto& name = expanded.sequence[i];
+    auto op_it = config.operators.find(name);
+    if (op_it == config.operators.end()) {
+      throw ConfigError("operator \"" + name + "\" not found");
     }
-    scan_fields(graph, expanded, true);
-    scan_fields(graph, expanded, false);
-    for (std::size_t i = 0; i < expanded.sequence.size(); ++i) {
-        const auto& op = *graph.nodes[i].config;
-        for (const auto& src : op.sources) {
-            if (!graph.name_to_index.count(src)) throw ConfigError("operator \"" + op.name + "\" sources references unknown operator \"" + src + "\"");
-            if (graph.name_to_index.at(src) >= static_cast<int>(i)) {
-                // Forward-reference checks raise a ValidationError to match
-                // pine-go validateSourcesOrder / pine-java Engine.validate /
-                // pine-python engine._validate_sources_order. The error text
-                // is part of the cross-runtime contract.
-                throw ValidationError("operator \"" + op.name + "\": sources references \"" + src + "\" which is declared after the current operator (forward reference)");
-            }
-            add_edge(graph, graph.name_to_index[src], static_cast<int>(i));
-        }
+    Node node;
+    node.name = name;
+    node.subflow = expanded.op_to_subflow.count(name) ? expanded.op_to_subflow.at(name) : "";
+    node.config = &op_it->second;
+    graph.name_to_index[name] = static_cast<int>(i);
+    graph.nodes.push_back(std::move(node));
+  }
+  scan_fields(graph, expanded, true);
+  scan_fields(graph, expanded, false);
+  for (std::size_t i = 0; i < expanded.sequence.size(); ++i) {
+    const auto& op = *graph.nodes[i].config;
+    for (const auto& src : op.sources) {
+      if (!graph.name_to_index.count(src)) {
+        throw ConfigError("operator \"" + op.name + "\" sources references unknown operator \"" + src + "\"");
+      }
+      if (graph.name_to_index.at(src) >= static_cast<int>(i)) {
+        // Forward-reference checks raise a ValidationError to match
+        // pine-go validateSourcesOrder / pine-java Engine.validate /
+        // pine-python engine._validate_sources_order. The error text
+        // is part of the cross-runtime contract.
+        throw ValidationError("operator \"" + op.name + "\": sources references \"" + src +
+                              "\" which is declared after the current operator (forward reference)");
+      }
+      add_edge(graph, graph.name_to_index[src], static_cast<int>(i));
     }
-    topological_check(graph);
-    reduce(graph);
-    return graph;
+  }
+  topological_check(graph);
+  reduce(graph);
+  return graph;
 }
 
 }  // namespace pine

--- a/pine-cpp/src/dataframe/column.cpp
+++ b/pine-cpp/src/dataframe/column.cpp
@@ -7,180 +7,265 @@
 namespace pine {
 
 const char* column_type_name(ColumnType t) {
-    switch (t) {
-        case ColumnType::Int64:  return "int64";
-        case ColumnType::Double: return "double";
-        case ColumnType::String: return "string";
-        case ColumnType::Bool:   return "bool";
-        case ColumnType::Json:   return "json";
-    }
-    return "unknown";
+  switch (t) {
+    case ColumnType::Int64:
+      return "int64";
+    case ColumnType::Double:
+      return "double";
+    case ColumnType::String:
+      return "string";
+    case ColumnType::Bool:
+      return "bool";
+    case ColumnType::Json:
+      return "json";
+  }
+  return "unknown";
 }
 
 namespace {
 
 bool is_integral_number(const JsonValue& v) {
-    if (!v.is_number()) return false;
-    double d = v.as_number();
-    return std::isfinite(d) && std::trunc(d) == d &&
-           d > -9.2233720368547758e18 && d < 9.2233720368547758e18;
+  if (!v.is_number()) {
+    return false;
+  }
+  double d = v.as_number();
+  return std::isfinite(d) && std::trunc(d) == d && d > -9.2233720368547758e18 && d < 9.2233720368547758e18;
 }
 
 void apply_remove(std::vector<bool>& validity, const std::set<int>& indices) {
-    std::vector<bool> out;
-    out.reserve(validity.size() - indices.size());
-    for (std::size_t i = 0; i < validity.size(); ++i) {
-        if (!indices.count(static_cast<int>(i))) out.push_back(validity[i]);
+  std::vector<bool> out;
+  out.reserve(validity.size() - indices.size());
+  for (std::size_t i = 0; i < validity.size(); ++i) {
+    if (!indices.count(static_cast<int>(i))) {
+      out.push_back(validity[i]);
     }
-    validity = std::move(out);
+  }
+  validity = std::move(out);
 }
 
 template <typename V>
 void apply_remove_data(std::vector<V>& data, const std::set<int>& indices) {
-    std::vector<V> out;
-    out.reserve(data.size() - indices.size());
-    for (std::size_t i = 0; i < data.size(); ++i) {
-        if (!indices.count(static_cast<int>(i))) out.push_back(std::move(data[i]));
+  std::vector<V> out;
+  out.reserve(data.size() - indices.size());
+  for (std::size_t i = 0; i < data.size(); ++i) {
+    if (!indices.count(static_cast<int>(i))) {
+      out.push_back(std::move(data[i]));
     }
-    data = std::move(out);
+  }
+  data = std::move(out);
 }
 
 }  // namespace
 
 // ---------------- TypedColumn ----------------
 
-template <> ColumnType Int64Column::type() const  { return ColumnType::Int64; }
-template <> ColumnType DoubleColumn::type() const { return ColumnType::Double; }
-template <> ColumnType StringColumn::type() const { return ColumnType::String; }
-template <> ColumnType BoolColumn::type() const   { return ColumnType::Bool; }
-
-template <> JsonValue Int64Column::get(std::size_t i) const {
-    if (is_null(i)) return JsonValue();
-    // Int64Column stores the original int64 precisely, but JsonValue only
-    // carries double — for |v| > 2^53 the returned value will not round-trip.
-    // pine-go / pine-java / pine-python store numeric columns as double
-    // natively, so the loss is symmetric across runtimes; the precision
-    // boundary is documented here and pine::int64_lossy_as_double()
-    // exposes the detection seam.
-    return JsonValue(static_cast<double>(data_[i]));
+template <>
+ColumnType Int64Column::type() const {
+  return ColumnType::Int64;
 }
-template <> JsonValue DoubleColumn::get(std::size_t i) const {
-    if (is_null(i)) return JsonValue();
-    return JsonValue(data_[i]);
+template <>
+ColumnType DoubleColumn::type() const {
+  return ColumnType::Double;
 }
-template <> JsonValue StringColumn::get(std::size_t i) const {
-    if (is_null(i)) return JsonValue();
-    return JsonValue(data_[i]);
+template <>
+ColumnType StringColumn::type() const {
+  return ColumnType::String;
 }
-template <> JsonValue BoolColumn::get(std::size_t i) const {
-    if (is_null(i)) return JsonValue();
-    return JsonValue(data_[i]);
+template <>
+ColumnType BoolColumn::type() const {
+  return ColumnType::Bool;
 }
 
-template <> bool Int64Column::set(std::size_t i, const JsonValue& v) {
-    if (v.is_null()) return false;  // typed cannot hold present-null; caller promotes.
-    if (!is_integral_number(v)) return false;
-    if (i >= data_.size()) return false;
-    data_[i] = static_cast<int64_t>(v.as_number());
-    validity_[i] = true;
-    return true;
+template <>
+JsonValue Int64Column::get(std::size_t i) const {
+  if (is_null(i)) {
+    return JsonValue();
+  }
+  // Int64Column stores the original int64 precisely, but JsonValue only
+  // carries double — for |v| > 2^53 the returned value will not round-trip.
+  // pine-go / pine-java / pine-python store numeric columns as double
+  // natively, so the loss is symmetric across runtimes; the precision
+  // boundary is documented here and pine::int64_lossy_as_double()
+  // exposes the detection seam.
+  return JsonValue(static_cast<double>(data_[i]));
 }
-template <> bool DoubleColumn::set(std::size_t i, const JsonValue& v) {
-    if (v.is_null()) return false;
-    if (!v.is_number()) return false;
-    if (i >= data_.size()) return false;
-    data_[i] = v.as_number();
-    validity_[i] = true;
-    return true;
+template <>
+JsonValue DoubleColumn::get(std::size_t i) const {
+  if (is_null(i)) {
+    return JsonValue();
+  }
+  return JsonValue(data_[i]);
 }
-template <> bool StringColumn::set(std::size_t i, const JsonValue& v) {
-    if (v.is_null()) return false;
-    if (!v.is_string()) return false;
-    if (i >= data_.size()) return false;
-    data_[i] = v.as_string();
-    validity_[i] = true;
-    return true;
+template <>
+JsonValue StringColumn::get(std::size_t i) const {
+  if (is_null(i)) {
+    return JsonValue();
+  }
+  return JsonValue(data_[i]);
 }
-template <> bool BoolColumn::set(std::size_t i, const JsonValue& v) {
-    if (v.is_null()) return false;
-    if (!v.is_bool()) return false;
-    if (i >= data_.size()) return false;
-    data_[i] = v.as_bool();
-    validity_[i] = true;
-    return true;
+template <>
+JsonValue BoolColumn::get(std::size_t i) const {
+  if (is_null(i)) {
+    return JsonValue();
+  }
+  return JsonValue(data_[i]);
 }
 
-template <> bool Int64Column::append(const JsonValue& v) {
-    if (v.is_null()) return false;
-    if (!is_integral_number(v)) return false;
-    data_.push_back(static_cast<int64_t>(v.as_number()));
-    validity_.push_back(true);
-    return true;
+template <>
+bool Int64Column::set(std::size_t i, const JsonValue& v) {
+  if (v.is_null()) {
+    return false;  // typed cannot hold present-null; caller promotes.
+  }
+  if (!is_integral_number(v)) {
+    return false;
+  }
+  if (i >= data_.size()) {
+    return false;
+  }
+  data_[i] = static_cast<int64_t>(v.as_number());
+  validity_[i] = true;
+  return true;
 }
-template <> bool DoubleColumn::append(const JsonValue& v) {
-    if (v.is_null()) return false;
-    if (!v.is_number()) return false;
-    data_.push_back(v.as_number());
-    validity_.push_back(true);
-    return true;
+template <>
+bool DoubleColumn::set(std::size_t i, const JsonValue& v) {
+  if (v.is_null()) {
+    return false;
+  }
+  if (!v.is_number()) {
+    return false;
+  }
+  if (i >= data_.size()) {
+    return false;
+  }
+  data_[i] = v.as_number();
+  validity_[i] = true;
+  return true;
 }
-template <> bool StringColumn::append(const JsonValue& v) {
-    if (v.is_null()) return false;
-    if (!v.is_string()) return false;
-    data_.push_back(v.as_string());
-    validity_.push_back(true);
-    return true;
+template <>
+bool StringColumn::set(std::size_t i, const JsonValue& v) {
+  if (v.is_null()) {
+    return false;
+  }
+  if (!v.is_string()) {
+    return false;
+  }
+  if (i >= data_.size()) {
+    return false;
+  }
+  data_[i] = v.as_string();
+  validity_[i] = true;
+  return true;
 }
-template <> bool BoolColumn::append(const JsonValue& v) {
-    if (v.is_null()) return false;
-    if (!v.is_bool()) return false;
-    data_.push_back(v.as_bool());
-    validity_.push_back(true);
-    return true;
+template <>
+bool BoolColumn::set(std::size_t i, const JsonValue& v) {
+  if (v.is_null()) {
+    return false;
+  }
+  if (!v.is_bool()) {
+    return false;
+  }
+  if (i >= data_.size()) {
+    return false;
+  }
+  data_[i] = v.as_bool();
+  validity_[i] = true;
+  return true;
+}
+
+template <>
+bool Int64Column::append(const JsonValue& v) {
+  if (v.is_null()) {
+    return false;
+  }
+  if (!is_integral_number(v)) {
+    return false;
+  }
+  data_.push_back(static_cast<int64_t>(v.as_number()));
+  validity_.push_back(true);
+  return true;
+}
+template <>
+bool DoubleColumn::append(const JsonValue& v) {
+  if (v.is_null()) {
+    return false;
+  }
+  if (!v.is_number()) {
+    return false;
+  }
+  data_.push_back(v.as_number());
+  validity_.push_back(true);
+  return true;
+}
+template <>
+bool StringColumn::append(const JsonValue& v) {
+  if (v.is_null()) {
+    return false;
+  }
+  if (!v.is_string()) {
+    return false;
+  }
+  data_.push_back(v.as_string());
+  validity_.push_back(true);
+  return true;
+}
+template <>
+bool BoolColumn::append(const JsonValue& v) {
+  if (v.is_null()) {
+    return false;
+  }
+  if (!v.is_bool()) {
+    return false;
+  }
+  data_.push_back(v.as_bool());
+  validity_.push_back(true);
+  return true;
 }
 
 template <typename T>
 void TypedColumn<T>::append_null() {
-    data_.push_back(T{});
-    validity_.push_back(false);
+  data_.push_back(T{});
+  validity_.push_back(false);
 }
 
 template <typename T>
 void TypedColumn<T>::remove(const std::set<int>& indices) {
-    apply_remove_data(data_, indices);
-    apply_remove(validity_, indices);
+  apply_remove_data(data_, indices);
+  apply_remove(validity_, indices);
 }
 
 template <typename T>
 void TypedColumn<T>::reorder(const std::vector<int>& order) {
-    std::vector<T> new_data;
-    std::vector<bool> new_valid;
-    new_data.reserve(order.size());
-    new_valid.reserve(order.size());
-    for (int idx : order) {
-        new_data.push_back(data_[static_cast<std::size_t>(idx)]);
-        new_valid.push_back(validity_[static_cast<std::size_t>(idx)]);
-    }
-    data_ = std::move(new_data);
-    validity_ = std::move(new_valid);
+  std::vector<T> new_data;
+  std::vector<bool> new_valid;
+  new_data.reserve(order.size());
+  new_valid.reserve(order.size());
+  for (int idx : order) {
+    new_data.push_back(data_[static_cast<std::size_t>(idx)]);
+    new_valid.push_back(validity_[static_cast<std::size_t>(idx)]);
+  }
+  data_ = std::move(new_data);
+  validity_ = std::move(new_valid);
 }
 
 template <typename T>
 std::unique_ptr<Column> TypedColumn<T>::clone() const {
-    auto c = std::make_unique<TypedColumn<T>>();
-    c->data_ = data_;
-    c->validity_ = validity_;
-    return c;
+  auto c = std::make_unique<TypedColumn<T>>();
+  c->data_ = data_;
+  c->validity_ = validity_;
+  return c;
 }
 
 template <typename T>
 std::unique_ptr<Column> TypedColumn<T>::to_json_column() const {
-    auto c = std::make_unique<JsonColumn>();
-    for (std::size_t i = 0; i < data_.size(); ++i) {
-        if (validity_[i]) c->append(this->get(i));
-        else c->append_null();
+  auto c = std::make_unique<JsonColumn>();
+  for (std::size_t i = 0; i < data_.size(); ++i) {
+    if (validity_[i]) {
+      c->append(this->get(i));
+    } else {
+      c->append_null();
     }
-    return c;
+  }
+  return c;
 }
 
 template class TypedColumn<int64_t>;
@@ -191,106 +276,131 @@ template class TypedColumn<bool>;
 // ---------------- JsonColumn ----------------
 
 JsonValue JsonColumn::get(std::size_t i) const {
-    if (i >= validity_.size() || !validity_[i]) return JsonValue();
-    return data_[i];
+  if (i >= validity_.size() || !validity_[i]) {
+    return JsonValue();
+  }
+  return data_[i];
 }
 
 bool JsonColumn::set(std::size_t i, const JsonValue& v) {
-    if (i >= data_.size()) return false;
-    // Present-null is allowed: store the null value and mark present=true.
-    data_[i] = v;
-    validity_[i] = true;
-    return true;
+  if (i >= data_.size()) {
+    return false;
+  }
+  // Present-null is allowed: store the null value and mark present=true.
+  data_[i] = v;
+  validity_[i] = true;
+  return true;
 }
 
 bool JsonColumn::append(const JsonValue& v) {
-    // append always marks the new slot as present (value may itself be null).
-    data_.push_back(v);
-    validity_.push_back(true);
-    return true;
+  // append always marks the new slot as present (value may itself be null).
+  data_.push_back(v);
+  validity_.push_back(true);
+  return true;
 }
 
 void JsonColumn::append_null() {
-    data_.push_back(JsonValue());
-    validity_.push_back(false);
+  data_.push_back(JsonValue());
+  validity_.push_back(false);
 }
 
 void JsonColumn::remove(const std::set<int>& indices) {
-    apply_remove_data(data_, indices);
-    apply_remove(validity_, indices);
+  apply_remove_data(data_, indices);
+  apply_remove(validity_, indices);
 }
 
 void JsonColumn::reorder(const std::vector<int>& order) {
-    std::vector<JsonValue> new_data;
-    std::vector<bool> new_valid;
-    new_data.reserve(order.size());
-    new_valid.reserve(order.size());
-    for (int idx : order) {
-        new_data.push_back(data_[static_cast<std::size_t>(idx)]);
-        new_valid.push_back(validity_[static_cast<std::size_t>(idx)]);
-    }
-    data_ = std::move(new_data);
-    validity_ = std::move(new_valid);
+  std::vector<JsonValue> new_data;
+  std::vector<bool> new_valid;
+  new_data.reserve(order.size());
+  new_valid.reserve(order.size());
+  for (int idx : order) {
+    new_data.push_back(data_[static_cast<std::size_t>(idx)]);
+    new_valid.push_back(validity_[static_cast<std::size_t>(idx)]);
+  }
+  data_ = std::move(new_data);
+  validity_ = std::move(new_valid);
 }
 
 std::unique_ptr<Column> JsonColumn::clone() const {
-    auto c = std::make_unique<JsonColumn>();
-    c->data_ = data_;
-    c->validity_ = validity_;
-    return c;
+  auto c = std::make_unique<JsonColumn>();
+  c->data_ = data_;
+  c->validity_ = validity_;
+  return c;
 }
 
 std::unique_ptr<Column> JsonColumn::to_json_column() const {
-    return clone();
+  return clone();
 }
 
 // ---------------- Factories ----------------
 
 std::unique_ptr<Column> make_column(const std::vector<JsonValue>& values) {
-    // Probe non-null values for a homogeneous type.
-    enum class Cand { Unknown, Int64, Double, String, Bool, Json };
-    Cand cand = Cand::Unknown;
-    for (const auto& v : values) {
-        if (v.is_null()) continue;
-        Cand c;
-        if (v.is_bool()) c = Cand::Bool;
-        else if (v.is_number()) c = is_integral_number(v) ? Cand::Int64 : Cand::Double;
-        else if (v.is_string()) c = Cand::String;
-        else c = Cand::Json;
-
-        if (cand == Cand::Unknown) { cand = c; continue; }
-        if (cand == c) continue;
-        // Allow Int64 ↔ Double widening.
-        if ((cand == Cand::Int64 && c == Cand::Double) ||
-            (cand == Cand::Double && c == Cand::Int64)) {
-            cand = Cand::Double;
-            continue;
-        }
-        cand = Cand::Json;
-        break;
+  // Probe non-null values for a homogeneous type.
+  enum class Cand { Unknown, Int64, Double, String, Bool, Json };
+  Cand cand = Cand::Unknown;
+  for (const auto& v : values) {
+    if (v.is_null()) {
+      continue;
+    }
+    Cand c;
+    if (v.is_bool()) {
+      c = Cand::Bool;
+    } else if (v.is_number()) {
+      c = is_integral_number(v) ? Cand::Int64 : Cand::Double;
+    } else if (v.is_string()) {
+      c = Cand::String;
+    } else {
+      c = Cand::Json;
     }
 
-    std::unique_ptr<Column> col;
-    switch (cand) {
-        case Cand::Int64:   col = std::make_unique<Int64Column>(); break;
-        case Cand::Double:  col = std::make_unique<DoubleColumn>(); break;
-        case Cand::String:  col = std::make_unique<StringColumn>(); break;
-        case Cand::Bool:    col = std::make_unique<BoolColumn>(); break;
-        default:            col = std::make_unique<JsonColumn>(); break;
+    if (cand == Cand::Unknown) {
+      cand = c;
+      continue;
     }
-    for (const auto& v : values) {
-        if (!col->append(v)) {
-            // Should not happen given the probe above, but guard anyway.
-            col = col->to_json_column();
-            col->append(v);
-        }
+    if (cand == c) {
+      continue;
     }
-    return col;
+    // Allow Int64 ↔ Double widening.
+    if ((cand == Cand::Int64 && c == Cand::Double) || (cand == Cand::Double && c == Cand::Int64)) {
+      cand = Cand::Double;
+      continue;
+    }
+    cand = Cand::Json;
+    break;
+  }
+
+  std::unique_ptr<Column> col;
+  switch (cand) {
+    case Cand::Int64:
+      col = std::make_unique<Int64Column>();
+      break;
+    case Cand::Double:
+      col = std::make_unique<DoubleColumn>();
+      break;
+    case Cand::String:
+      col = std::make_unique<StringColumn>();
+      break;
+    case Cand::Bool:
+      col = std::make_unique<BoolColumn>();
+      break;
+    default:
+      col = std::make_unique<JsonColumn>();
+      break;
+  }
+  for (const auto& v : values) {
+    if (!col->append(v)) {
+      // Should not happen given the probe above, but guard anyway.
+      col = col->to_json_column();
+      col->append(v);
+    }
+  }
+  return col;
 }
 
 std::unique_ptr<Column> make_null_column(std::size_t n) {
-    auto c = std::make_unique<JsonColumn>(n);
-    return c;
+  auto c = std::make_unique<JsonColumn>(n);
+  return c;
 }
 
 }  // namespace pine

--- a/pine-cpp/src/dataframe/column_frame.cpp
+++ b/pine-cpp/src/dataframe/column_frame.cpp
@@ -16,397 +16,420 @@ namespace {
 // apply_output's three write phases (common, items, additions). Returns
 // the violation message (without `pine:`/op prefix) or empty when OK.
 std::string validate_value(const std::string& field, const JsonValue& value) {
-    if (value.is_null()) return "";
-    if (value.is_number()) {
-        double d = value.as_number();
-        if (std::isnan(d) || std::isinf(d)) {
-            return "field \"" + field + "\": NaN/Inf is not a valid JSON value";
-        }
-    }
-    // JsonValue only carries the JSON-representable types (null / number /
-    // string / bool / array / object) so the "unsupported type" branch in
-    // Go's validateValue cannot fire here — the type system forbids it.
+  if (value.is_null()) {
     return "";
+  }
+  if (value.is_number()) {
+    double d = value.as_number();
+    if (std::isnan(d) || std::isinf(d)) {
+      return "field \"" + field + "\": NaN/Inf is not a valid JSON value";
+    }
+  }
+  // JsonValue only carries the JSON-representable types (null / number /
+  // string / bool / array / object) so the "unsupported type" branch in
+  // Go's validateValue cannot fire here — the type system forbids it.
+  return "";
 }
 
 }  // namespace
 
-ColumnFrame::ColumnFrame() : items_(std::make_unique<TypedColumnStore>(0)) {}
+ColumnFrame::ColumnFrame() : items_(std::make_unique<TypedColumnStore>(0)) {
+}
 
 ColumnFrame::ColumnFrame(std::map<std::string, JsonValue> common,
                          std::vector<std::map<std::string, JsonValue>> items)
-    : common_(std::move(common)),
-      items_(std::make_unique<TypedColumnStore>(items.size())) {
-    // Collect the union of fields across items, preserving first-seen order.
-    std::vector<std::string> field_order;
-    std::set<std::string> seen;
+    : common_(std::move(common)), items_(std::make_unique<TypedColumnStore>(items.size())) {
+  // Collect the union of fields across items, preserving first-seen order.
+  std::vector<std::string> field_order;
+  std::set<std::string> seen;
+  for (const auto& row : items) {
+    for (const auto& [k, _] : row) {
+      if (seen.insert(k).second) {
+        field_order.push_back(k);
+      }
+    }
+  }
+  // For each field, infer column type from present non-null values and
+  // then fill row by row, distinguishing ABSENT (field missing in row,
+  // append_null → validity=false) from PRESENT-NULL (field present with
+  // null value — requires JsonColumn so the null is kept as a value).
+  for (const auto& field : field_order) {
+    bool any_present_null = false;
+    std::vector<JsonValue> present_values;
     for (const auto& row : items) {
-        for (const auto& [k, _] : row) {
-            if (seen.insert(k).second) field_order.push_back(k);
-        }
+      auto it = row.find(field);
+      if (it == row.end()) {
+        continue;
+      }
+      if (it->second.is_null()) {
+        any_present_null = true;
+      } else {
+        present_values.push_back(it->second);
+      }
     }
-    // For each field, infer column type from present non-null values and
-    // then fill row by row, distinguishing ABSENT (field missing in row,
-    // append_null → validity=false) from PRESENT-NULL (field present with
-    // null value — requires JsonColumn so the null is kept as a value).
-    for (const auto& field : field_order) {
-        bool any_present_null = false;
-        std::vector<JsonValue> present_values;
-        for (const auto& row : items) {
-            auto it = row.find(field);
-            if (it == row.end()) continue;
-            if (it->second.is_null()) any_present_null = true;
-            else present_values.push_back(it->second);
-        }
 
-        std::unique_ptr<Column> col;
-        if (any_present_null) {
-            col = std::make_unique<JsonColumn>();
-        } else {
-            // Probe type via a sample column; we only need its type tag.
-            auto sample = make_column(present_values);
-            switch (sample->type()) {
-                case ColumnType::Int64:  col = std::make_unique<Int64Column>();  break;
-                case ColumnType::Double: col = std::make_unique<DoubleColumn>(); break;
-                case ColumnType::String: col = std::make_unique<StringColumn>(); break;
-                case ColumnType::Bool:   col = std::make_unique<BoolColumn>();   break;
-                case ColumnType::Json:   col = std::make_unique<JsonColumn>();   break;
-            }
-        }
-
-        for (const auto& row : items) {
-            auto it = row.find(field);
-            if (it == row.end()) {
-                col->append_null();
-            } else if (!col->append(it->second)) {
-                col = col->to_json_column();
-                col->append(it->second);
-            }
-        }
-        items_->set_column(field, std::move(col));
+    std::unique_ptr<Column> col;
+    if (any_present_null) {
+      col = std::make_unique<JsonColumn>();
+    } else {
+      // Probe type via a sample column; we only need its type tag.
+      auto sample = make_column(present_values);
+      switch (sample->type()) {
+        case ColumnType::Int64:
+          col = std::make_unique<Int64Column>();
+          break;
+        case ColumnType::Double:
+          col = std::make_unique<DoubleColumn>();
+          break;
+        case ColumnType::String:
+          col = std::make_unique<StringColumn>();
+          break;
+        case ColumnType::Bool:
+          col = std::make_unique<BoolColumn>();
+          break;
+        case ColumnType::Json:
+          col = std::make_unique<JsonColumn>();
+          break;
+      }
     }
+
+    for (const auto& row : items) {
+      auto it = row.find(field);
+      if (it == row.end()) {
+        col->append_null();
+      } else if (!col->append(it->second)) {
+        col = col->to_json_column();
+        col->append(it->second);
+      }
+    }
+    items_->set_column(field, std::move(col));
+  }
 }
 
-std::unique_ptr<Frame> ColumnFrame::make_window_view(std::size_t row_offset,
-                                                       std::size_t row_count) const {
-    // Frame-interface override delegates to the static ColumnFrame factory
-    // and returns a base-class pointer for parallel_execute, which holds
-    // shards as unique_ptr<Frame>.
-    return std::unique_ptr<Frame>(make_window_view(*this, row_offset, row_count).release());
+std::unique_ptr<Frame> ColumnFrame::make_window_view(std::size_t row_offset, std::size_t row_count) const {
+  // Frame-interface override delegates to the static ColumnFrame factory
+  // and returns a base-class pointer for parallel_execute, which holds
+  // shards as unique_ptr<Frame>.
+  return std::unique_ptr<Frame>(make_window_view(*this, row_offset, row_count).release());
 }
 
-std::unique_ptr<ColumnFrame> ColumnFrame::make_window_view(
-    const ColumnFrame& parent,
-    std::size_t row_offset,
-    std::size_t row_count) {
-    // The CONTRACT in column_frame.hpp says parent is read-only during the
-    // view's lifetime. Read parent.items_ unlocked: the only writer that
-    // could race is apply_output, and parallel_execute (the sole caller)
-    // guarantees the parent frame is not being mutated for the duration.
-    const std::size_t parent_rows = parent.items_ ? parent.items_->row_count() : 0;
-    if (row_offset + row_count > parent_rows) {
-        throw Error("ColumnFrame::make_window_view: window ("
-                    + std::to_string(row_offset) + ", "
-                    + std::to_string(row_count) + ") exceeds parent row count "
-                    + std::to_string(parent_rows));
-    }
-    auto v = std::unique_ptr<ColumnFrame>(new ColumnFrame());
-    // Drop the empty owned items_ allocated by the default ctor — view
-    // never reads its own items_; reads route through view_items_.
-    v->items_.reset();
-    v->view_common_ = &parent.common_;
-    v->view_items_  = parent.items_.get();
-    v->view_offset_ = row_offset;
-    v->view_count_  = row_count;
-    v->resources_   = parent.resources_;
-    return v;
+std::unique_ptr<ColumnFrame> ColumnFrame::make_window_view(const ColumnFrame& parent, std::size_t row_offset,
+                                                           std::size_t row_count) {
+  // The CONTRACT in column_frame.hpp says parent is read-only during the
+  // view's lifetime. Read parent.items_ unlocked: the only writer that
+  // could race is apply_output, and parallel_execute (the sole caller)
+  // guarantees the parent frame is not being mutated for the duration.
+  const std::size_t parent_rows = parent.items_ ? parent.items_->row_count() : 0;
+  if (row_offset + row_count > parent_rows) {
+    throw Error("ColumnFrame::make_window_view: window (" + std::to_string(row_offset) + ", " +
+                std::to_string(row_count) + ") exceeds parent row count " + std::to_string(parent_rows));
+  }
+  auto v = std::unique_ptr<ColumnFrame>(new ColumnFrame());
+  // Drop the empty owned items_ allocated by the default ctor — view
+  // never reads its own items_; reads route through view_items_.
+  v->items_.reset();
+  v->view_common_ = &parent.common_;
+  v->view_items_ = parent.items_.get();
+  v->view_offset_ = row_offset;
+  v->view_count_ = row_count;
+  v->resources_ = parent.resources_;
+  return v;
 }
 
 JsonValue ColumnFrame::common(const std::string& field) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const auto& src = view_common_ ? *view_common_ : common_;
-    auto it = src.find(field);
-    if (it == src.end()) return JsonValue();
-    return it->second;
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const auto& src = view_common_ ? *view_common_ : common_;
+  auto it = src.find(field);
+  if (it == src.end()) {
+    return JsonValue();
+  }
+  return it->second;
 }
 
 bool ColumnFrame::has_common(const std::string& field) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const auto& src = view_common_ ? *view_common_ : common_;
-    auto it = src.find(field);
-    return it != src.end();
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const auto& src = view_common_ ? *view_common_ : common_;
+  auto it = src.find(field);
+  return it != src.end();
 }
 
 void ColumnFrame::set_common(const std::string& field, JsonValue value) {
-    if (is_window_view()) {
-        throw Error("ColumnFrame::set_common called on window view "
-                    "(parallel shard contract violation)");
-    }
-    std::unique_lock<std::shared_mutex> lk(mu_);
-    common_[field] = std::move(value);
+  if (is_window_view()) {
+    throw Error(
+        "ColumnFrame::set_common called on window view "
+        "(parallel shard contract violation)");
+  }
+  std::unique_lock<std::shared_mutex> lk(mu_);
+  common_[field] = std::move(value);
 }
 
 std::vector<std::string> ColumnFrame::common_fields() const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const auto& src = view_common_ ? *view_common_ : common_;
-    std::vector<std::string> out;
-    out.reserve(src.size());
-    for (const auto& [k, _] : src) out.push_back(k);
-    return out;
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const auto& src = view_common_ ? *view_common_ : common_;
+  std::vector<std::string> out;
+  out.reserve(src.size());
+  for (const auto& [k, _] : src) {
+    out.push_back(k);
+  }
+  return out;
 }
 
 std::size_t ColumnFrame::item_count() const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    return view_items_ ? view_count_ : items_->row_count();
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  return view_items_ ? view_count_ : items_->row_count();
 }
 
 JsonValue ColumnFrame::item(std::size_t index, const std::string& field) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const ColumnStore* store = view_items_ ? view_items_ : items_.get();
-    if (view_items_) {
-        if (index >= view_count_) return JsonValue();
-        index += view_offset_;
-    } else if (index >= store->row_count()) {
-        return JsonValue();
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const ColumnStore* store = view_items_ ? view_items_ : items_.get();
+  if (view_items_) {
+    if (index >= view_count_) {
+      return JsonValue();
     }
-    const Column* col = store->column(field);
-    if (!col) return JsonValue();
-    if (col->is_null(index)) return JsonValue();
-    return col->get(index);
+    index += view_offset_;
+  } else if (index >= store->row_count()) {
+    return JsonValue();
+  }
+  const Column* col = store->column(field);
+  if (!col) {
+    return JsonValue();
+  }
+  if (col->is_null(index)) {
+    return JsonValue();
+  }
+  return col->get(index);
 }
 
 bool ColumnFrame::item_has(std::size_t index, const std::string& field) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const ColumnStore* store = view_items_ ? view_items_ : items_.get();
-    if (view_items_) {
-        if (index >= view_count_) return false;
-        index += view_offset_;
-    } else if (index >= store->row_count()) {
-        return false;
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const ColumnStore* store = view_items_ ? view_items_ : items_.get();
+  if (view_items_) {
+    if (index >= view_count_) {
+      return false;
     }
-    const Column* col = store->column(field);
-    if (!col) return false;
-    return col->is_present(index);
+    index += view_offset_;
+  } else if (index >= store->row_count()) {
+    return false;
+  }
+  const Column* col = store->column(field);
+  if (!col) {
+    return false;
+  }
+  return col->is_present(index);
 }
 
 std::vector<std::string> ColumnFrame::item_fields() const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const ColumnStore* store = view_items_ ? view_items_ : items_.get();
-    return store->fields();
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const ColumnStore* store = view_items_ ? view_items_ : items_.get();
+  return store->fields();
 }
 
 void ColumnFrame::push_warning(std::string msg) {
-    if (is_window_view()) {
-        throw Error("ColumnFrame::push_warning called on window view "
-                    "(parallel shard contract violation)");
-    }
-    std::unique_lock<std::shared_mutex> lk(mu_);
-    warnings_.push_back(std::move(msg));
+  if (is_window_view()) {
+    throw Error(
+        "ColumnFrame::push_warning called on window view "
+        "(parallel shard contract violation)");
+  }
+  std::unique_lock<std::shared_mutex> lk(mu_);
+  warnings_.push_back(std::move(msg));
 }
 
 std::vector<std::string> ColumnFrame::take_warnings() {
-    std::unique_lock<std::shared_mutex> lk(mu_);
-    return std::move(warnings_);
+  std::unique_lock<std::shared_mutex> lk(mu_);
+  return std::move(warnings_);
 }
 
-void ColumnFrame::write_item_field_locked(std::size_t idx,
-                                          const std::string& field,
-                                          const JsonValue& value) {
-    Column* col = items_->mutate_column(field);
-    if (!col) {
-        // New column — start as JsonColumn so any value type (including
-        // explicit nulls) can be stored without further promotion.
-        auto new_col = std::make_unique<JsonColumn>(items_->row_count());
-        items_->set_column(field, std::move(new_col));
-        col = items_->mutate_column(field);
-    }
-    // A null write must mark the slot as present-null. Typed columns
-    // cannot represent that, so promote to JsonColumn first.
-    if (value.is_null() && col->type() != ColumnType::Json) {
-        auto promoted = col->to_json_column();
-        items_->set_column(field, std::move(promoted));
-        col = items_->mutate_column(field);
-    }
-    if (!col->set(idx, value)) {
-        // Type mismatch: promote to JsonColumn and retry.
-        auto promoted = col->to_json_column();
-        promoted->set(idx, value);
-        items_->set_column(field, std::move(promoted));
-    }
+void ColumnFrame::write_item_field_locked(std::size_t idx, const std::string& field, const JsonValue& value) {
+  Column* col = items_->mutate_column(field);
+  if (!col) {
+    // New column — start as JsonColumn so any value type (including
+    // explicit nulls) can be stored without further promotion.
+    auto new_col = std::make_unique<JsonColumn>(items_->row_count());
+    items_->set_column(field, std::move(new_col));
+    col = items_->mutate_column(field);
+  }
+  // A null write must mark the slot as present-null. Typed columns
+  // cannot represent that, so promote to JsonColumn first.
+  if (value.is_null() && col->type() != ColumnType::Json) {
+    auto promoted = col->to_json_column();
+    items_->set_column(field, std::move(promoted));
+    col = items_->mutate_column(field);
+  }
+  if (!col->set(idx, value)) {
+    // Type mismatch: promote to JsonColumn and retry.
+    auto promoted = col->to_json_column();
+    promoted->set(idx, value);
+    items_->set_column(field, std::move(promoted));
+  }
 }
 
-void ColumnFrame::apply_output(const OperatorOutput& out,
-                               const std::string& op_name,
-                               bool is_recall) {
-    if (is_window_view()) {
-        throw Error("ColumnFrame::apply_output called on window view "
-                    "(parallel shard contract violation)");
-    }
-    std::unique_lock<std::shared_mutex> lk(mu_);
+void ColumnFrame::apply_output(const OperatorOutput& out, const std::string& op_name, bool is_recall) {
+  if (is_window_view()) {
+    throw Error(
+        "ColumnFrame::apply_output called on window view "
+        "(parallel shard contract violation)");
+  }
+  std::unique_lock<std::shared_mutex> lk(mu_);
 
-    // 1. common writes
-    for (const auto& [field, value] : out.common_writes()) {
+  // 1. common writes
+  for (const auto& [field, value] : out.common_writes()) {
+    if (auto v = validate_value(field, value); !v.empty()) {
+      throw ExecutionError(op_name, "common write: " + v);
+    }
+    common_[field] = value;
+  }
+
+  // 2. item writes
+  for (const auto& [idx, field, value] : out.item_writes()) {
+    if (idx < 0 || static_cast<std::size_t>(idx) >= items_->row_count()) {
+      throw ExecutionError(op_name, "SetItem index " + std::to_string(idx) + " out of range [0, " +
+                                        std::to_string(items_->row_count()) + ")");
+    }
+    if (auto v = validate_value(field, value); !v.empty()) {
+      throw ExecutionError(op_name, "item[" + std::to_string(idx) + "] write: " + v);
+    }
+    write_item_field_locked(static_cast<std::size_t>(idx), field, value);
+  }
+
+  // 3. removals
+  if (!out.removed_items().empty()) {
+    const auto& removed = out.removed_items();
+    for (int idx : removed) {
+      if (idx < 0 || static_cast<std::size_t>(idx) >= items_->row_count()) {
+        throw ExecutionError(op_name, "RemoveItem index " + std::to_string(idx) + " out of range [0, " +
+                                          std::to_string(items_->row_count()) + ")");
+      }
+    }
+    items_->remove_rows(removed);
+  }
+
+  // 4. reorder
+  if (out.has_item_order()) {
+    const auto& order = out.item_order();
+    if (order.size() != items_->row_count()) {
+      throw ExecutionError(op_name, "SetItemOrder length " + std::to_string(order.size()) +
+                                        " does not match item count " + std::to_string(items_->row_count()));
+    }
+    // Validate every index is in [0, row_count) AND that the order is a
+    // true permutation (each index appears exactly once). Without the
+    // permutation check, `set_item_order([0,0,0])` silently makes every
+    // item a copy of item 0 — a data-loss bug with no observable error.
+    std::vector<bool> seen(items_->row_count(), false);
+    for (int idx : order) {
+      if (idx < 0 || static_cast<std::size_t>(idx) >= items_->row_count()) {
+        throw ExecutionError(op_name, "SetItemOrder index " + std::to_string(idx) + " out of range [0, " +
+                                          std::to_string(items_->row_count()) + ")");
+      }
+      if (seen[idx]) {
+        throw ExecutionError(op_name, "SetItemOrder duplicate index " + std::to_string(idx) +
+                                          " (order must be a permutation)");
+      }
+      seen[idx] = true;
+    }
+    items_->reorder_rows(order);
+  }
+
+  // 5. additions
+  if (!out.added_items().empty()) {
+    std::size_t base = items_->row_count();
+    items_->extend_rows(out.added_items().size());
+    for (std::size_t i = 0; i < out.added_items().size(); ++i) {
+      const auto& added = out.added_items()[i];
+      for (const auto& [field, value] : added) {
         if (auto v = validate_value(field, value); !v.empty()) {
-            throw ExecutionError(op_name, "common write: " + v);
+          throw ExecutionError(op_name, "added item write: " + v);
         }
-        common_[field] = value;
+        write_item_field_locked(base + i, field, value);
+      }
+      if (is_recall) {
+        write_item_field_locked(base + i, "_source", JsonValue(op_name));
+      }
     }
+  }
 
-    // 2. item writes
-    for (const auto& [idx, field, value] : out.item_writes()) {
-        if (idx < 0 || static_cast<std::size_t>(idx) >= items_->row_count()) {
-            throw ExecutionError(op_name, "SetItem index " +
-                                 std::to_string(idx) + " out of range [0, " +
-                                 std::to_string(items_->row_count()) + ")");
-        }
-        if (auto v = validate_value(field, value); !v.empty()) {
-            throw ExecutionError(op_name, "item[" + std::to_string(idx) + "] write: " + v);
-        }
-        write_item_field_locked(static_cast<std::size_t>(idx), field, value);
-    }
-
-    // 3. removals
-    if (!out.removed_items().empty()) {
-        const auto& removed = out.removed_items();
-        for (int idx : removed) {
-            if (idx < 0 || static_cast<std::size_t>(idx) >= items_->row_count()) {
-                throw ExecutionError(op_name, "RemoveItem index " +
-                                     std::to_string(idx) + " out of range [0, " +
-                                     std::to_string(items_->row_count()) + ")");
-            }
-        }
-        items_->remove_rows(removed);
-    }
-
-    // 4. reorder
-    if (out.has_item_order()) {
-        const auto& order = out.item_order();
-        if (order.size() != items_->row_count()) {
-            throw ExecutionError(op_name, "SetItemOrder length " +
-                                 std::to_string(order.size()) +
-                                 " does not match item count " +
-                                 std::to_string(items_->row_count()));
-        }
-        // Validate every index is in [0, row_count) AND that the order is a
-        // true permutation (each index appears exactly once). Without the
-        // permutation check, `set_item_order([0,0,0])` silently makes every
-        // item a copy of item 0 — a data-loss bug with no observable error.
-        std::vector<bool> seen(items_->row_count(), false);
-        for (int idx : order) {
-            if (idx < 0 || static_cast<std::size_t>(idx) >= items_->row_count()) {
-                throw ExecutionError(op_name, "SetItemOrder index " +
-                                     std::to_string(idx) + " out of range [0, " +
-                                     std::to_string(items_->row_count()) + ")");
-            }
-            if (seen[idx]) {
-                throw ExecutionError(op_name, "SetItemOrder duplicate index " +
-                                     std::to_string(idx) +
-                                     " (order must be a permutation)");
-            }
-            seen[idx] = true;
-        }
-        items_->reorder_rows(order);
-    }
-
-    // 5. additions
-    if (!out.added_items().empty()) {
-        std::size_t base = items_->row_count();
-        items_->extend_rows(out.added_items().size());
-        for (std::size_t i = 0; i < out.added_items().size(); ++i) {
-            const auto& added = out.added_items()[i];
-            for (const auto& [field, value] : added) {
-                if (auto v = validate_value(field, value); !v.empty()) {
-                    throw ExecutionError(op_name, "added item write: " + v);
-                }
-                write_item_field_locked(base + i, field, value);
-            }
-            if (is_recall) {
-                write_item_field_locked(base + i, "_source", JsonValue(op_name));
-            }
-        }
-    }
-
-    // 6. warning (collected per-operator on the frame — every warning recorded).
-    // Mirrors pine-go pine.go:246 (`fmt.Errorf("operator %q: %w", w.Operator, w.Err)`):
-    // operator code emits the bare message; the engine layer prepends the
-    // `operator "name": ` prefix uniformly here.
-    if (out.has_warning()) {
-        warnings_.push_back("operator \"" + op_name + "\": " + out.warning());
-    }
+  // 6. warning (collected per-operator on the frame — every warning recorded).
+  // Mirrors pine-go pine.go:246 (`fmt.Errorf("operator %q: %w", w.Operator, w.Err)`):
+  // operator code emits the bare message; the engine layer prepends the
+  // `operator "name": ` prefix uniformly here.
+  if (out.has_warning()) {
+    warnings_.push_back("operator \"" + op_name + "\": " + out.warning());
+  }
 }
 
 Result ColumnFrame::to_result(const std::vector<std::string>& common_out,
                               const std::vector<std::string>& item_out) const {
-    // Window views are read-only temporary projections meant for parallel
-    // shard dispatch; to_result is the response-rendering surface and only
-    // makes sense on the master frame after apply_output. Reject early to
-    // surface programming errors before they segfault on the null items_.
-    // (review #8 R8-1)
-    if (is_window_view()) {
-        throw Error("ColumnFrame::to_result called on window view "
-                    "(window views are read-only shard projections, "
-                    "not response sources)");
+  // Window views are read-only temporary projections meant for parallel
+  // shard dispatch; to_result is the response-rendering surface and only
+  // makes sense on the master frame after apply_output. Reject early to
+  // surface programming errors before they segfault on the null items_.
+  // (review #8 R8-1)
+  if (is_window_view()) {
+    throw Error(
+        "ColumnFrame::to_result called on window view "
+        "(window views are read-only shard projections, "
+        "not response sources)");
+  }
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  Result r;
+  for (const auto& field : common_out) {
+    auto it = common_.find(field);
+    if (it != common_.end()) {
+      r.common[field] = it->second;
     }
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    Result r;
-    for (const auto& field : common_out) {
-        auto it = common_.find(field);
-        if (it != common_.end()) {
-            r.common[field] = it->second;
-        }
+  }
+  r.items.reserve(items_->row_count());
+  for (std::size_t i = 0; i < items_->row_count(); ++i) {
+    std::map<std::string, JsonValue> row;
+    for (const auto& field : item_out) {
+      const Column* col = items_->column(field);
+      if (col && col->is_present(i)) {
+        row[field] = col->get(i);
+      }
     }
-    r.items.reserve(items_->row_count());
-    for (std::size_t i = 0; i < items_->row_count(); ++i) {
-        std::map<std::string, JsonValue> row;
-        for (const auto& field : item_out) {
-            const Column* col = items_->column(field);
-            if (col && col->is_present(i)) {
-                row[field] = col->get(i);
-            }
-        }
-        r.items.push_back(std::move(row));
-    }
-    return r;
+    r.items.push_back(std::move(row));
+  }
+  return r;
 }
 
 JsonValue::object_t ColumnFrame::item_object(std::size_t index) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    JsonValue::object_t out;
-    const ColumnStore* store = view_items_ ? view_items_ : items_.get();
-    if (view_items_) {
-        if (index >= view_count_) return out;
-        index += view_offset_;
-    } else if (index >= store->row_count()) {
-        return out;
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  JsonValue::object_t out;
+  const ColumnStore* store = view_items_ ? view_items_ : items_.get();
+  if (view_items_) {
+    if (index >= view_count_) {
+      return out;
     }
-    for (const auto& field : store->fields()) {
-        const Column* col = store->column(field);
-        if (col && col->is_present(index)) {
-            out[field] = col->get(index);
-        }
-    }
+    index += view_offset_;
+  } else if (index >= store->row_count()) {
     return out;
+  }
+  for (const auto& field : store->fields()) {
+    const Column* col = store->column(field);
+    if (col && col->is_present(index)) {
+      out[field] = col->get(index);
+    }
+  }
+  return out;
 }
 
-std::pair<std::string, int> ColumnFrame::validate_strict_items(
-    const std::vector<std::string>& fields) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const ColumnStore* store = view_items_ ? view_items_ : items_.get();
-    std::size_t offset = view_items_ ? view_offset_ : 0;
-    std::size_t count = view_items_ ? view_count_ : store->row_count();
+std::pair<std::string, int> ColumnFrame::validate_strict_items(const std::vector<std::string>& fields) const {
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const ColumnStore* store = view_items_ ? view_items_ : items_.get();
+  std::size_t offset = view_items_ ? view_offset_ : 0;
+  std::size_t count = view_items_ ? view_count_ : store->row_count();
 
-    for (const auto& field : fields) {
-        const Column* col = store->column(field);
-        if (!col) {
-            return {field, 0};
-        }
-        for (std::size_t i = 0; i < count; ++i) {
-            if (col->is_null(offset + i)) {
-                return {field, static_cast<int>(i)};
-            }
-        }
+  for (const auto& field : fields) {
+    const Column* col = store->column(field);
+    if (!col) {
+      return {field, 0};
     }
-    return {"", -1};
+    for (std::size_t i = 0; i < count; ++i) {
+      if (col->is_null(offset + i)) {
+        return {field, static_cast<int>(i)};
+      }
+    }
+  }
+  return {"", -1};
 }
 
 }  // namespace pine

--- a/pine-cpp/src/dataframe/column_store.cpp
+++ b/pine-cpp/src/dataframe/column_store.cpp
@@ -5,81 +5,94 @@
 namespace pine {
 
 std::vector<std::string> TypedColumnStore::fields() const {
-    std::vector<std::string> out;
-    out.reserve(cols_.size());
-    for (const auto& [k, _] : cols_) out.push_back(k);
-    return out;
+  std::vector<std::string> out;
+  out.reserve(cols_.size());
+  for (const auto& [k, _] : cols_) {
+    out.push_back(k);
+  }
+  return out;
 }
 
 bool TypedColumnStore::has_column(const std::string& field) const {
-    return cols_.count(field) > 0;
+  return cols_.count(field) > 0;
 }
 
 const Column* TypedColumnStore::column(const std::string& field) const {
-    auto it = cols_.find(field);
-    return it == cols_.end() ? nullptr : it->second.get();
+  auto it = cols_.find(field);
+  return it == cols_.end() ? nullptr : it->second.get();
 }
 
 void TypedColumnStore::set_column(const std::string& field, std::unique_ptr<Column> col) {
-    if (!col) throw std::invalid_argument("TypedColumnStore::set_column: null column");
-    if (cols_.empty() && col->size() != row_count_) {
-        // First column establishes row_count if store is empty.
-        if (row_count_ == 0) {
-            row_count_ = col->size();
-        } else if (col->size() != row_count_) {
-            throw std::invalid_argument("TypedColumnStore::set_column: column size mismatch");
-        }
+  if (!col) {
+    throw std::invalid_argument("TypedColumnStore::set_column: null column");
+  }
+  if (cols_.empty() && col->size() != row_count_) {
+    // First column establishes row_count if store is empty.
+    if (row_count_ == 0) {
+      row_count_ = col->size();
     } else if (col->size() != row_count_) {
-        throw std::invalid_argument("TypedColumnStore::set_column: column size mismatch");
+      throw std::invalid_argument("TypedColumnStore::set_column: column size mismatch");
     }
-    cols_[field] = std::move(col);
+  } else if (col->size() != row_count_) {
+    throw std::invalid_argument("TypedColumnStore::set_column: column size mismatch");
+  }
+  cols_[field] = std::move(col);
 }
 
 Column* TypedColumnStore::mutate_column(const std::string& field) {
-    auto it = cols_.find(field);
-    return it == cols_.end() ? nullptr : it->second.get();
+  auto it = cols_.find(field);
+  return it == cols_.end() ? nullptr : it->second.get();
 }
 
 void TypedColumnStore::remove_rows(const std::set<int>& indices) {
-    if (indices.empty()) return;
-    // Validate OOB at the public-API boundary so any caller (apply_output
-    // path or future direct consumers) gets a consistent error instead of
-    // silently corrupting `row_count_` vs column-internal sizes. The
-    // ColumnFrame::apply_output path pre-validates, but ColumnStore is a
-    // public surface and other callers (Arrow store, COW snapshot, ...)
-    // would otherwise step into the same trap.
-    for (int i : indices) {
-        if (i < 0 || static_cast<std::size_t>(i) >= row_count_) {
-            throw std::invalid_argument(
-                "TypedColumnStore::remove_rows: index " + std::to_string(i) +
-                " out of range [0, " + std::to_string(row_count_) + ")");
-        }
+  if (indices.empty()) {
+    return;
+  }
+  // Validate OOB at the public-API boundary so any caller (apply_output
+  // path or future direct consumers) gets a consistent error instead of
+  // silently corrupting `row_count_` vs column-internal sizes. The
+  // ColumnFrame::apply_output path pre-validates, but ColumnStore is a
+  // public surface and other callers (Arrow store, COW snapshot, ...)
+  // would otherwise step into the same trap.
+  for (int i : indices) {
+    if (i < 0 || static_cast<std::size_t>(i) >= row_count_) {
+      throw std::invalid_argument("TypedColumnStore::remove_rows: index " + std::to_string(i) +
+                                  " out of range [0, " + std::to_string(row_count_) + ")");
     }
-    for (auto& [_, col] : cols_) col->remove(indices);
-    row_count_ -= indices.size();
+  }
+  for (auto& [_, col] : cols_) {
+    col->remove(indices);
+  }
+  row_count_ -= indices.size();
 }
 
 void TypedColumnStore::reorder_rows(const std::vector<int>& order) {
-    if (order.size() != row_count_) {
-        throw std::invalid_argument("TypedColumnStore::reorder_rows: order length mismatch");
-    }
-    for (auto& [_, col] : cols_) col->reorder(order);
+  if (order.size() != row_count_) {
+    throw std::invalid_argument("TypedColumnStore::reorder_rows: order length mismatch");
+  }
+  for (auto& [_, col] : cols_) {
+    col->reorder(order);
+  }
 }
 
 void TypedColumnStore::extend_rows(std::size_t n) {
-    if (n == 0) return;
-    for (auto& [_, col] : cols_) {
-        for (std::size_t i = 0; i < n; ++i) col->append_null();
+  if (n == 0) {
+    return;
+  }
+  for (auto& [_, col] : cols_) {
+    for (std::size_t i = 0; i < n; ++i) {
+      col->append_null();
     }
-    row_count_ += n;
+  }
+  row_count_ += n;
 }
 
 std::unique_ptr<ColumnStore> TypedColumnStore::clone() const {
-    auto out = std::make_unique<TypedColumnStore>(row_count_);
-    for (const auto& [k, v] : cols_) {
-        out->cols_[k] = v->clone();
-    }
-    return out;
+  auto out = std::make_unique<TypedColumnStore>(row_count_);
+  for (const auto& [k, v] : cols_) {
+    out->cols_[k] = v->clone();
+  }
+  return out;
 }
 
 }  // namespace pine

--- a/pine-cpp/src/dataframe/operator_input.cpp
+++ b/pine-cpp/src/dataframe/operator_input.cpp
@@ -1,128 +1,152 @@
 #include "pine/operator_input.hpp"
+
 #include "pine/frame.hpp"
 
 #include <set>
 
 namespace pine {
 
-OperatorInput::OperatorInput(const Frame& frame, const InputFieldSpec& spec)
-    : frame_(&frame), spec_(&spec) {}
+OperatorInput::OperatorInput(const Frame& frame, const InputFieldSpec& spec) : frame_(&frame), spec_(&spec) {
+}
 
 JsonValue OperatorInput::common(const std::string& field) const {
-    JsonValue v = frame_->common(field);
-    if (!v.is_null()) return v;
-    for (const auto& df : spec_->defaulted_common) {
-        if (df.name == field) return df.default_value;
+  JsonValue v = frame_->common(field);
+  if (!v.is_null()) {
+    return v;
+  }
+  for (const auto& df : spec_->defaulted_common) {
+    if (df.name == field) {
+      return df.default_value;
     }
-    return JsonValue(nullptr);
+  }
+  return JsonValue(nullptr);
 }
 
 std::size_t OperatorInput::item_count() const {
-    return frame_->item_count();
+  return frame_->item_count();
 }
 
 JsonValue OperatorInput::item(std::size_t index, const std::string& field) const {
-    if (index >= frame_->item_count()) return JsonValue(nullptr);
-    JsonValue v = frame_->item(index, field);
-    if (!v.is_null()) return v;
-    for (const auto& df : spec_->defaulted_item) {
-        if (df.name == field) return df.default_value;
-    }
+  if (index >= frame_->item_count()) {
     return JsonValue(nullptr);
+  }
+  JsonValue v = frame_->item(index, field);
+  if (!v.is_null()) {
+    return v;
+  }
+  for (const auto& df : spec_->defaulted_item) {
+    if (df.name == field) {
+      return df.default_value;
+    }
+  }
+  return JsonValue(nullptr);
 }
 
 std::vector<std::string> OperatorInput::common_keys() const {
-    std::vector<std::string> keys;
-    for (const auto& f : spec_->strict_common) keys.push_back(f);
-    for (const auto& df : spec_->defaulted_common) keys.push_back(df.name);
-    for (const auto& f : spec_->nullable_common) keys.push_back(f);
-    return keys;
+  std::vector<std::string> keys;
+  for (const auto& f : spec_->strict_common) {
+    keys.push_back(f);
+  }
+  for (const auto& df : spec_->defaulted_common) {
+    keys.push_back(df.name);
+  }
+  for (const auto& f : spec_->nullable_common) {
+    keys.push_back(f);
+  }
+  return keys;
 }
 
 std::vector<std::string> OperatorInput::item_keys(std::size_t index) const {
-    (void)index;
-    std::vector<std::string> keys;
-    for (const auto& f : spec_->strict_item) keys.push_back(f);
-    for (const auto& df : spec_->defaulted_item) keys.push_back(df.name);
-    for (const auto& f : spec_->nullable_item) keys.push_back(f);
-    return keys;
+  (void)index;
+  std::vector<std::string> keys;
+  for (const auto& f : spec_->strict_item) {
+    keys.push_back(f);
+  }
+  for (const auto& df : spec_->defaulted_item) {
+    keys.push_back(df.name);
+  }
+  for (const auto& f : spec_->nullable_item) {
+    keys.push_back(f);
+  }
+  return keys;
 }
 
 const std::map<std::string, JsonValue>* OperatorInput::resources() const {
-    return frame_->resources();
+  return frame_->resources();
 }
 
 InputFieldSpec compute_input_field_spec(const OperatorConfig& config) {
-    InputFieldSpec spec;
+  InputFieldSpec spec;
 
-    // Build skip and strict sets for O(1) lookup
-    std::set<std::string> skip_set(config.skip.begin(), config.skip.end());
-    std::set<std::string> strict_common_set(config.strict_common.begin(),
-                                             config.strict_common.end());
-    std::set<std::string> strict_item_set(config.strict_item.begin(),
-                                           config.strict_item.end());
+  // Build skip and strict sets for O(1) lookup
+  std::set<std::string> skip_set(config.skip.begin(), config.skip.end());
+  std::set<std::string> strict_common_set(config.strict_common.begin(), config.strict_common.end());
+  std::set<std::string> strict_item_set(config.strict_item.begin(), config.strict_item.end());
 
-    for (const auto& field : config.metadata.common_input) {
-        if (skip_set.count(field)) continue;
-        auto def_it = config.common_defaults.find(field);
-        if (def_it != config.common_defaults.end()) {
-            spec.defaulted_common.push_back({field, def_it->second});
-        } else if (strict_common_set.count(field)) {
-            spec.strict_common.push_back(field);
-        } else {
-            spec.nullable_common.push_back(field);
-        }
+  for (const auto& field : config.metadata.common_input) {
+    if (skip_set.count(field)) {
+      continue;
     }
-    for (const auto& field : config.metadata.item_input) {
-        auto def_it = config.item_defaults.find(field);
-        if (def_it != config.item_defaults.end()) {
-            spec.defaulted_item.push_back({field, def_it->second});
-        } else if (strict_item_set.count(field)) {
-            spec.strict_item.push_back(field);
-        } else {
-            spec.nullable_item.push_back(field);
-        }
+    auto def_it = config.common_defaults.find(field);
+    if (def_it != config.common_defaults.end()) {
+      spec.defaulted_common.push_back({field, def_it->second});
+    } else if (strict_common_set.count(field)) {
+      spec.strict_common.push_back(field);
+    } else {
+      spec.nullable_common.push_back(field);
     }
-    return spec;
+  }
+  for (const auto& field : config.metadata.item_input) {
+    auto def_it = config.item_defaults.find(field);
+    if (def_it != config.item_defaults.end()) {
+      spec.defaulted_item.push_back({field, def_it->second});
+    } else if (strict_item_set.count(field)) {
+      spec.strict_item.push_back(field);
+    } else {
+      spec.nullable_item.push_back(field);
+    }
+  }
+  return spec;
 }
 
-OperatorInput build_operator_input(const Frame& frame,
-                                   const std::string& op_name,
+OperatorInput build_operator_input(const Frame& frame, const std::string& op_name,
                                    const InputFieldSpec& spec) {
-    // Validate strict common fields
-    for (const auto& field : spec.strict_common) {
-        JsonValue v = frame.common(field);
-        if (v.is_null()) {
-            throw ExecutionError(op_name, "required field \"" + field + "\" is nil in common");
-        }
+  // Validate strict common fields
+  for (const auto& field : spec.strict_common) {
+    JsonValue v = frame.common(field);
+    if (v.is_null()) {
+      throw ExecutionError(op_name, "required field \"" + field + "\" is nil in common");
     }
+  }
 
-    // Validate nullable common fields: missing → error, null → pass through
-    for (const auto& field : spec.nullable_common) {
-        if (!frame.has_common(field)) {
-            throw ExecutionError(op_name, "required field \"" + field + "\" is missing in common");
-        }
+  // Validate nullable common fields: missing → error, null → pass through
+  for (const auto& field : spec.nullable_common) {
+    if (!frame.has_common(field)) {
+      throw ExecutionError(op_name, "required field \"" + field + "\" is missing in common");
     }
+  }
 
-    // Batch-validate strict item fields (PERF-1a)
-    if (!spec.strict_item.empty()) {
-        auto [bad_field, bad_row] = frame.validate_strict_items(spec.strict_item);
-        if (bad_row >= 0) {
-            throw ExecutionError(op_name, "required field \"" + bad_field + "\" is nil on item[" + std::to_string(bad_row) + "]");
-        }
+  // Batch-validate strict item fields (PERF-1a)
+  if (!spec.strict_item.empty()) {
+    auto [bad_field, bad_row] = frame.validate_strict_items(spec.strict_item);
+    if (bad_row >= 0) {
+      throw ExecutionError(
+          op_name, "required field \"" + bad_field + "\" is nil on item[" + std::to_string(bad_row) + "]");
     }
+  }
 
-    // Validate nullable item fields: missing → error, null → pass through
-    for (const auto& field : spec.nullable_item) {
-        for (std::size_t i = 0; i < frame.item_count(); ++i) {
-            if (!frame.item_has(i, field)) {
-                throw ExecutionError(op_name, "required field \"" + field + "\" is missing on item[" + std::to_string(i) + "]");
-            }
-        }
+  // Validate nullable item fields: missing → error, null → pass through
+  for (const auto& field : spec.nullable_item) {
+    for (std::size_t i = 0; i < frame.item_count(); ++i) {
+      if (!frame.item_has(i, field)) {
+        throw ExecutionError(
+            op_name, "required field \"" + field + "\" is missing on item[" + std::to_string(i) + "]");
+      }
     }
+  }
 
-    // Return lazy proxy — no eager reify of items (PERF-1b)
-    return OperatorInput(frame, spec);
+  // Return lazy proxy — no eager reify of items (PERF-1b)
+  return OperatorInput(frame, spec);
 }
 
 }  // namespace pine

--- a/pine-cpp/src/dataframe/row_frame.cpp
+++ b/pine-cpp/src/dataframe/row_frame.cpp
@@ -1,4 +1,5 @@
 #include "pine/row_frame.hpp"
+
 #include "pine/column_frame.hpp"
 
 #include <algorithm>
@@ -10,14 +11,16 @@ namespace pine {
 
 namespace {
 std::string validate_value_row(const std::string& field, const JsonValue& value) {
-    if (value.is_null()) return "";
-    if (value.is_number()) {
-        double d = value.as_number();
-        if (std::isnan(d) || std::isinf(d)) {
-            return "field \"" + field + "\": NaN/Inf is not a valid JSON value";
-        }
-    }
+  if (value.is_null()) {
     return "";
+  }
+  if (value.is_number()) {
+    double d = value.as_number();
+    if (std::isnan(d) || std::isinf(d)) {
+      return "field \"" + field + "\": NaN/Inf is not a valid JSON value";
+    }
+  }
+  return "";
 }
 }  // namespace
 
@@ -25,301 +28,311 @@ RowFrame::RowFrame() = default;
 
 RowFrame::RowFrame(std::map<std::string, JsonValue> common,
                    std::vector<std::map<std::string, JsonValue>> items)
-    : common_(std::move(common)), items_(std::move(items)) {}
+    : common_(std::move(common)), items_(std::move(items)) {
+}
 
 JsonValue RowFrame::common(const std::string& field) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const auto& src = view_common_ ? *view_common_ : common_;
-    auto it = src.find(field);
-    if (it == src.end()) return JsonValue();
-    return it->second;
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const auto& src = view_common_ ? *view_common_ : common_;
+  auto it = src.find(field);
+  if (it == src.end()) {
+    return JsonValue();
+  }
+  return it->second;
 }
 
 bool RowFrame::has_common(const std::string& field) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const auto& src = view_common_ ? *view_common_ : common_;
-    auto it = src.find(field);
-    return it != src.end();
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const auto& src = view_common_ ? *view_common_ : common_;
+  auto it = src.find(field);
+  return it != src.end();
 }
 
 void RowFrame::set_common(const std::string& field, JsonValue value) {
-    if (is_window_view()) {
-        throw Error("RowFrame::set_common called on window view "
-                    "(parallel shard contract violation)");
-    }
-    std::unique_lock<std::shared_mutex> lk(mu_);
-    common_[field] = std::move(value);
+  if (is_window_view()) {
+    throw Error(
+        "RowFrame::set_common called on window view "
+        "(parallel shard contract violation)");
+  }
+  std::unique_lock<std::shared_mutex> lk(mu_);
+  common_[field] = std::move(value);
 }
 
 std::vector<std::string> RowFrame::common_fields() const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const auto& src = view_common_ ? *view_common_ : common_;
-    std::vector<std::string> out;
-    out.reserve(src.size());
-    for (const auto& [k, _] : src) out.push_back(k);
-    return out;
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const auto& src = view_common_ ? *view_common_ : common_;
+  std::vector<std::string> out;
+  out.reserve(src.size());
+  for (const auto& [k, _] : src) {
+    out.push_back(k);
+  }
+  return out;
 }
 
 std::size_t RowFrame::item_count() const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    if (view_items_) return view_count_;
-    return items_.size();
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  if (view_items_) {
+    return view_count_;
+  }
+  return items_.size();
 }
 
 JsonValue RowFrame::item(std::size_t index, const std::string& field) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const auto& src = view_items_ ? *view_items_ : items_;
-    if (view_items_) {
-        if (index >= view_count_) return JsonValue();
-        index += view_offset_;
-    } else if (index >= src.size()) {
-        return JsonValue();
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const auto& src = view_items_ ? *view_items_ : items_;
+  if (view_items_) {
+    if (index >= view_count_) {
+      return JsonValue();
     }
-    auto it = src[index].find(field);
-    if (it == src[index].end()) return JsonValue();
-    return it->second;
+    index += view_offset_;
+  } else if (index >= src.size()) {
+    return JsonValue();
+  }
+  auto it = src[index].find(field);
+  if (it == src[index].end()) {
+    return JsonValue();
+  }
+  return it->second;
 }
 
 bool RowFrame::item_has(std::size_t index, const std::string& field) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const auto& src = view_items_ ? *view_items_ : items_;
-    if (view_items_) {
-        if (index >= view_count_) return false;
-        index += view_offset_;
-    } else if (index >= src.size()) {
-        return false;
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const auto& src = view_items_ ? *view_items_ : items_;
+  if (view_items_) {
+    if (index >= view_count_) {
+      return false;
     }
-    auto it = src[index].find(field);
-    return it != src[index].end();
+    index += view_offset_;
+  } else if (index >= src.size()) {
+    return false;
+  }
+  auto it = src[index].find(field);
+  return it != src[index].end();
 }
 
 std::vector<std::string> RowFrame::item_fields() const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const auto& src = view_items_ ? *view_items_ : items_;
-    std::set<std::string> seen;
-    std::vector<std::string> out;
-    std::size_t begin = view_items_ ? view_offset_ : 0;
-    std::size_t end = view_items_ ? (view_offset_ + view_count_) : src.size();
-    for (std::size_t i = begin; i < end; ++i) {
-        for (const auto& [k, _] : src[i]) {
-            if (seen.insert(k).second) out.push_back(k);
-        }
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const auto& src = view_items_ ? *view_items_ : items_;
+  std::set<std::string> seen;
+  std::vector<std::string> out;
+  std::size_t begin = view_items_ ? view_offset_ : 0;
+  std::size_t end = view_items_ ? (view_offset_ + view_count_) : src.size();
+  for (std::size_t i = begin; i < end; ++i) {
+    for (const auto& [k, _] : src[i]) {
+      if (seen.insert(k).second) {
+        out.push_back(k);
+      }
     }
-    return out;
+  }
+  return out;
 }
 
 void RowFrame::push_warning(std::string msg) {
-    if (is_window_view()) {
-        throw Error("RowFrame::push_warning called on window view "
-                    "(parallel shard contract violation)");
-    }
-    std::unique_lock<std::shared_mutex> lk(mu_);
-    warnings_.push_back(std::move(msg));
+  if (is_window_view()) {
+    throw Error(
+        "RowFrame::push_warning called on window view "
+        "(parallel shard contract violation)");
+  }
+  std::unique_lock<std::shared_mutex> lk(mu_);
+  warnings_.push_back(std::move(msg));
 }
 
 std::vector<std::string> RowFrame::take_warnings() {
-    std::unique_lock<std::shared_mutex> lk(mu_);
-    return std::move(warnings_);
+  std::unique_lock<std::shared_mutex> lk(mu_);
+  return std::move(warnings_);
 }
 
-void RowFrame::apply_output(const OperatorOutput& out,
-                            const std::string& op_name,
-                            bool is_recall) {
-    if (is_window_view()) {
-        throw Error("RowFrame::apply_output called on window view "
-                    "(parallel shard contract violation)");
-    }
-    std::unique_lock<std::shared_mutex> lk(mu_);
+void RowFrame::apply_output(const OperatorOutput& out, const std::string& op_name, bool is_recall) {
+  if (is_window_view()) {
+    throw Error(
+        "RowFrame::apply_output called on window view "
+        "(parallel shard contract violation)");
+  }
+  std::unique_lock<std::shared_mutex> lk(mu_);
 
-    // 1. common writes
-    for (const auto& [field, value] : out.common_writes()) {
+  // 1. common writes
+  for (const auto& [field, value] : out.common_writes()) {
+    if (auto v = validate_value_row(field, value); !v.empty()) {
+      throw ExecutionError(op_name, "common write: " + v);
+    }
+    common_[field] = value;
+  }
+
+  // 2. item writes
+  for (const auto& [idx, field, value] : out.item_writes()) {
+    if (idx < 0 || static_cast<std::size_t>(idx) >= items_.size()) {
+      throw ExecutionError(op_name, "SetItem index " + std::to_string(idx) + " out of range [0, " +
+                                        std::to_string(items_.size()) + ")");
+    }
+    if (auto v = validate_value_row(field, value); !v.empty()) {
+      throw ExecutionError(op_name, "item[" + std::to_string(idx) + "] write: " + v);
+    }
+    items_[static_cast<std::size_t>(idx)][field] = value;
+  }
+
+  // 3. removals
+  if (!out.removed_items().empty()) {
+    const auto& removed = out.removed_items();
+    for (int idx : removed) {
+      if (idx < 0 || static_cast<std::size_t>(idx) >= items_.size()) {
+        throw ExecutionError(op_name, "RemoveItem index " + std::to_string(idx) + " out of range [0, " +
+                                          std::to_string(items_.size()) + ")");
+      }
+    }
+    std::vector<std::map<std::string, JsonValue>> kept;
+    kept.reserve(items_.size() - removed.size());
+    for (std::size_t i = 0; i < items_.size(); ++i) {
+      if (removed.count(static_cast<int>(i)) == 0) {
+        kept.push_back(std::move(items_[i]));
+      }
+    }
+    items_ = std::move(kept);
+  }
+
+  // 4. reorder
+  if (out.has_item_order()) {
+    const auto& order = out.item_order();
+    if (order.size() != items_.size()) {
+      throw ExecutionError(op_name, "SetItemOrder length " + std::to_string(order.size()) +
+                                        " does not match item count " + std::to_string(items_.size()));
+    }
+    std::vector<bool> seen(items_.size(), false);
+    for (int idx : order) {
+      if (idx < 0 || static_cast<std::size_t>(idx) >= items_.size()) {
+        throw ExecutionError(op_name, "SetItemOrder index " + std::to_string(idx) + " out of range [0, " +
+                                          std::to_string(items_.size()) + ")");
+      }
+      if (seen[idx]) {
+        throw ExecutionError(op_name, "SetItemOrder duplicate index " + std::to_string(idx) +
+                                          " (order must be a permutation)");
+      }
+      seen[idx] = true;
+    }
+    std::vector<std::map<std::string, JsonValue>> reordered;
+    reordered.reserve(order.size());
+    for (int idx : order) {
+      reordered.push_back(std::move(items_[static_cast<std::size_t>(idx)]));
+    }
+    items_ = std::move(reordered);
+  }
+
+  // 5. additions
+  if (!out.added_items().empty()) {
+    for (const auto& added : out.added_items()) {
+      for (const auto& [field, value] : added) {
         if (auto v = validate_value_row(field, value); !v.empty()) {
-            throw ExecutionError(op_name, "common write: " + v);
+          throw ExecutionError(op_name, "added item write: " + v);
         }
-        common_[field] = value;
+      }
+      auto row = added;
+      if (is_recall) {
+        row["_source"] = JsonValue(op_name);
+      }
+      items_.push_back(std::move(row));
     }
+  }
 
-    // 2. item writes
-    for (const auto& [idx, field, value] : out.item_writes()) {
-        if (idx < 0 || static_cast<std::size_t>(idx) >= items_.size()) {
-            throw ExecutionError(op_name, "SetItem index " +
-                                 std::to_string(idx) + " out of range [0, " +
-                                 std::to_string(items_.size()) + ")");
-        }
-        if (auto v = validate_value_row(field, value); !v.empty()) {
-            throw ExecutionError(op_name, "item[" + std::to_string(idx) + "] write: " + v);
-        }
-        items_[static_cast<std::size_t>(idx)][field] = value;
-    }
-
-    // 3. removals
-    if (!out.removed_items().empty()) {
-        const auto& removed = out.removed_items();
-        for (int idx : removed) {
-            if (idx < 0 || static_cast<std::size_t>(idx) >= items_.size()) {
-                throw ExecutionError(op_name, "RemoveItem index " +
-                                     std::to_string(idx) + " out of range [0, " +
-                                     std::to_string(items_.size()) + ")");
-            }
-        }
-        std::vector<std::map<std::string, JsonValue>> kept;
-        kept.reserve(items_.size() - removed.size());
-        for (std::size_t i = 0; i < items_.size(); ++i) {
-            if (removed.count(static_cast<int>(i)) == 0) {
-                kept.push_back(std::move(items_[i]));
-            }
-        }
-        items_ = std::move(kept);
-    }
-
-    // 4. reorder
-    if (out.has_item_order()) {
-        const auto& order = out.item_order();
-        if (order.size() != items_.size()) {
-            throw ExecutionError(op_name, "SetItemOrder length " +
-                                 std::to_string(order.size()) +
-                                 " does not match item count " +
-                                 std::to_string(items_.size()));
-        }
-        std::vector<bool> seen(items_.size(), false);
-        for (int idx : order) {
-            if (idx < 0 || static_cast<std::size_t>(idx) >= items_.size()) {
-                throw ExecutionError(op_name, "SetItemOrder index " +
-                                     std::to_string(idx) + " out of range [0, " +
-                                     std::to_string(items_.size()) + ")");
-            }
-            if (seen[idx]) {
-                throw ExecutionError(op_name, "SetItemOrder duplicate index " +
-                                     std::to_string(idx) +
-                                     " (order must be a permutation)");
-            }
-            seen[idx] = true;
-        }
-        std::vector<std::map<std::string, JsonValue>> reordered;
-        reordered.reserve(order.size());
-        for (int idx : order) {
-            reordered.push_back(std::move(items_[static_cast<std::size_t>(idx)]));
-        }
-        items_ = std::move(reordered);
-    }
-
-    // 5. additions
-    if (!out.added_items().empty()) {
-        for (const auto& added : out.added_items()) {
-            for (const auto& [field, value] : added) {
-                if (auto v = validate_value_row(field, value); !v.empty()) {
-                    throw ExecutionError(op_name, "added item write: " + v);
-                }
-            }
-            auto row = added;
-            if (is_recall) {
-                row["_source"] = JsonValue(op_name);
-            }
-            items_.push_back(std::move(row));
-        }
-    }
-
-    // 6. warning
-    if (out.has_warning()) {
-        warnings_.push_back("operator \"" + op_name + "\": " + out.warning());
-    }
+  // 6. warning
+  if (out.has_warning()) {
+    warnings_.push_back("operator \"" + op_name + "\": " + out.warning());
+  }
 }
 
 Result RowFrame::to_result(const std::vector<std::string>& common_out,
                            const std::vector<std::string>& item_out) const {
-    if (is_window_view()) {
-        throw Error("RowFrame::to_result called on window view "
-                    "(window views are read-only shard projections, "
-                    "not response sources)");
+  if (is_window_view()) {
+    throw Error(
+        "RowFrame::to_result called on window view "
+        "(window views are read-only shard projections, "
+        "not response sources)");
+  }
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  Result r;
+  for (const auto& field : common_out) {
+    auto it = common_.find(field);
+    if (it != common_.end()) {
+      r.common[field] = it->second;
     }
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    Result r;
-    for (const auto& field : common_out) {
-        auto it = common_.find(field);
-        if (it != common_.end()) {
-            r.common[field] = it->second;
-        }
+  }
+  r.items.reserve(items_.size());
+  for (const auto& row : items_) {
+    std::map<std::string, JsonValue> out_row;
+    for (const auto& field : item_out) {
+      auto it = row.find(field);
+      // Keep explicit nulls — pine-go RowFrame.ToResult / projectMap
+      // and pine-cpp ColumnFrame.to_result (via Column::is_present)
+      // both preserve PRESENT-NULL. Only ABSENT keys are stripped.
+      // (Dual-impl equivalence demands the same rule.)
+      if (it != row.end()) {
+        out_row[field] = it->second;
+      }
     }
-    r.items.reserve(items_.size());
-    for (const auto& row : items_) {
-        std::map<std::string, JsonValue> out_row;
-        for (const auto& field : item_out) {
-            auto it = row.find(field);
-            // Keep explicit nulls — pine-go RowFrame.ToResult / projectMap
-            // and pine-cpp ColumnFrame.to_result (via Column::is_present)
-            // both preserve PRESENT-NULL. Only ABSENT keys are stripped.
-            // (Dual-impl equivalence demands the same rule.)
-            if (it != row.end()) {
-                out_row[field] = it->second;
-            }
-        }
-        r.items.push_back(std::move(out_row));
-    }
-    return r;
+    r.items.push_back(std::move(out_row));
+  }
+  return r;
 }
 
 JsonValue::object_t RowFrame::item_object(std::size_t index) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    JsonValue::object_t out;
-    const auto& src = view_items_ ? *view_items_ : items_;
-    if (view_items_) {
-        if (index >= view_count_) return out;
-        index += view_offset_;
-    } else if (index >= src.size()) {
-        return out;
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  JsonValue::object_t out;
+  const auto& src = view_items_ ? *view_items_ : items_;
+  if (view_items_) {
+    if (index >= view_count_) {
+      return out;
     }
-    for (const auto& [k, v] : src[index]) {
-        if (!v.is_null()) out[k] = v;
-    }
+    index += view_offset_;
+  } else if (index >= src.size()) {
     return out;
+  }
+  for (const auto& [k, v] : src[index]) {
+    if (!v.is_null()) {
+      out[k] = v;
+    }
+  }
+  return out;
 }
 
-std::unique_ptr<Frame> RowFrame::make_window_view(std::size_t row_offset,
-                                                   std::size_t row_count) const {
-    const std::size_t parent_rows = items_.size();
-    if (row_offset + row_count > parent_rows) {
-        throw Error("RowFrame::make_window_view: window ("
-                    + std::to_string(row_offset) + ", "
-                    + std::to_string(row_count) + ") exceeds parent row count "
-                    + std::to_string(parent_rows));
-    }
-    auto v = std::unique_ptr<RowFrame>(new RowFrame());
-    v->view_common_ = &common_;
-    v->view_items_ = &items_;
-    v->view_offset_ = row_offset;
-    v->view_count_ = row_count;
-    v->resources_ = resources_;
-    return std::unique_ptr<Frame>(std::move(v));
+std::unique_ptr<Frame> RowFrame::make_window_view(std::size_t row_offset, std::size_t row_count) const {
+  const std::size_t parent_rows = items_.size();
+  if (row_offset + row_count > parent_rows) {
+    throw Error("RowFrame::make_window_view: window (" + std::to_string(row_offset) + ", " +
+                std::to_string(row_count) + ") exceeds parent row count " + std::to_string(parent_rows));
+  }
+  auto v = std::unique_ptr<RowFrame>(new RowFrame());
+  v->view_common_ = &common_;
+  v->view_items_ = &items_;
+  v->view_offset_ = row_offset;
+  v->view_count_ = row_count;
+  v->resources_ = resources_;
+  return std::unique_ptr<Frame>(std::move(v));
 }
 
-std::pair<std::string, int> RowFrame::validate_strict_items(
-    const std::vector<std::string>& fields) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    const auto& rows = view_items_ ? *view_items_ : items_;
-    std::size_t offset = view_items_ ? view_offset_ : 0;
-    std::size_t count = view_items_ ? view_count_ : rows.size();
+std::pair<std::string, int> RowFrame::validate_strict_items(const std::vector<std::string>& fields) const {
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  const auto& rows = view_items_ ? *view_items_ : items_;
+  std::size_t offset = view_items_ ? view_offset_ : 0;
+  std::size_t count = view_items_ ? view_count_ : rows.size();
 
-    for (const auto& field : fields) {
-        for (std::size_t i = 0; i < count; ++i) {
-            const auto& row = rows[offset + i];
-            auto it = row.find(field);
-            if (it == row.end() || it->second.is_null()) {
-                return {field, static_cast<int>(i)};
-            }
-        }
+  for (const auto& field : fields) {
+    for (std::size_t i = 0; i < count; ++i) {
+      const auto& row = rows[offset + i];
+      auto it = row.find(field);
+      if (it == row.end() || it->second.is_null()) {
+        return {field, static_cast<int>(i)};
+      }
     }
-    return {"", -1};
+  }
+  return {"", -1};
 }
 
 // Factory selecting Frame implementation by storage_mode. Unknown
 // values fall back to "column" — mirrors pine-go NewFrame behavior.
-std::unique_ptr<Frame> make_frame(const std::string& storage_mode,
-                                   std::map<std::string, JsonValue> common,
-                                   std::vector<std::map<std::string, JsonValue>> items) {
-    if (storage_mode == "row") {
-        return std::make_unique<RowFrame>(std::move(common), std::move(items));
-    }
-    return std::make_unique<ColumnFrame>(std::move(common), std::move(items));
+std::unique_ptr<Frame> make_frame(const std::string& storage_mode, std::map<std::string, JsonValue> common,
+                                  std::vector<std::map<std::string, JsonValue>> items) {
+  if (storage_mode == "row") {
+    return std::make_unique<RowFrame>(std::move(common), std::move(items));
+  }
+  return std::make_unique<ColumnFrame>(std::move(common), std::move(items));
 }
 
 }  // namespace pine

--- a/pine-cpp/src/http/http_client.cpp
+++ b/pine-cpp/src/http/http_client.cpp
@@ -1,14 +1,14 @@
 #include "http/http_client.hpp"
-#include "http/ssrf.hpp"
 
 #include <curl/curl.h>
-
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 #include <mutex>
 #include <string>
+
+#include "http/ssrf.hpp"
 
 namespace pine {
 namespace http {
@@ -18,19 +18,21 @@ namespace {
 std::once_flag g_curl_init_flag;
 
 size_t write_callback(char* ptr, size_t size, size_t nmemb, void* userdata) {
-    auto* state = static_cast<std::pair<std::string*, int64_t>*>(userdata);
-    size_t bytes = size * nmemb;
-    auto* buf = state->first;
-    int64_t cap = state->second;
-    if (cap >= 0 && static_cast<int64_t>(buf->size() + bytes) > cap) {
-        // Overrun by one extra byte so the caller can detect the limit.
-        size_t remaining = static_cast<size_t>(cap - static_cast<int64_t>(buf->size()) + 1);
-        if (remaining > bytes) remaining = bytes;
-        buf->append(ptr, remaining);
-        return 0;  // libcurl treats short write as error → abort transfer
+  auto* state = static_cast<std::pair<std::string*, int64_t>*>(userdata);
+  size_t bytes = size * nmemb;
+  auto* buf = state->first;
+  int64_t cap = state->second;
+  if (cap >= 0 && static_cast<int64_t>(buf->size() + bytes) > cap) {
+    // Overrun by one extra byte so the caller can detect the limit.
+    size_t remaining = static_cast<size_t>(cap - static_cast<int64_t>(buf->size()) + 1);
+    if (remaining > bytes) {
+      remaining = bytes;
     }
-    buf->append(ptr, bytes);
-    return bytes;
+    buf->append(ptr, remaining);
+    return 0;  // libcurl treats short write as error → abort transfer
+  }
+  buf->append(ptr, bytes);
+  return bytes;
 }
 
 // Dial-time SSRF guard. libcurl invokes this just before opening a socket
@@ -42,119 +44,134 @@ size_t write_callback(char* ptr, size_t size, size_t nmemb, void* userdata) {
 //
 // `clientp` carries the caller's `allow_private` flag; when set, we skip
 // the check so local testing still works.
-curl_socket_t opensocket_ssrf_callback(void* clientp,
-                                        curlsocktype /*purpose*/,
-                                        struct curl_sockaddr* address) {
-    if (address == nullptr) return CURL_SOCKET_BAD;
-    bool allow_private = (clientp != nullptr) && *static_cast<bool*>(clientp);
-    if (!allow_private && sockaddr_is_private(&address->addr)) {
-        return CURL_SOCKET_BAD;
-    }
-    return ::socket(address->family, address->socktype, address->protocol);
+curl_socket_t opensocket_ssrf_callback(void* clientp, curlsocktype /*purpose*/,
+                                       struct curl_sockaddr* address) {
+  if (address == nullptr) {
+    return CURL_SOCKET_BAD;
+  }
+  bool allow_private = (clientp != nullptr) && *static_cast<bool*>(clientp);
+  if (!allow_private && sockaddr_is_private(&address->addr)) {
+    return CURL_SOCKET_BAD;
+  }
+  return ::socket(address->family, address->socktype, address->protocol);
 }
 
 }  // namespace
 
 void global_init() {
-    std::call_once(g_curl_init_flag, [] {
-        curl_global_init(CURL_GLOBAL_DEFAULT);
-    });
+  std::call_once(g_curl_init_flag, [] { curl_global_init(CURL_GLOBAL_DEFAULT); });
 }
 
 PostResult post(const PostOptions& opts) {
-    global_init();
+  global_init();
 
-    PostResult result;
+  PostResult result;
 
-    // SSRF guard — refuse loopback/private targets unless allow_private is on.
-    if (!opts.allow_private) {
-        // Extract host from the URL for validation. We expect http://host[:port]/path
-        // style URLs; rely on libcurl's URL parser for correctness.
-        CURLU* uh = curl_url();
-        if (uh == nullptr) {
-            result.error = "transform_by_remote_pineapple: curl_url init failed";
-            return result;
-        }
-        struct UrlScope { CURLU* h; ~UrlScope() { if (h) curl_url_cleanup(h); } } scope{uh};
-        if (curl_url_set(uh, CURLUPART_URL, opts.url.c_str(), 0) != CURLUE_OK) {
-            result.error = "transform_by_remote_pineapple: malformed URL: " + opts.url;
-            return result;
-        }
-        char* host_cstr = nullptr;
-        if (curl_url_get(uh, CURLUPART_HOST, &host_cstr, 0) != CURLUE_OK || host_cstr == nullptr) {
-            result.error = "transform_by_remote_pineapple: cannot extract host from URL: " + opts.url;
-            return result;
-        }
-        std::string host = host_cstr;
-        curl_free(host_cstr);
-        std::string reason;
-        if (!validate_remote_host(host, &reason)) {
-            result.error = "transform_by_remote_pineapple: " + reason;
-            return result;
-        }
+  // SSRF guard — refuse loopback/private targets unless allow_private is on.
+  if (!opts.allow_private) {
+    // Extract host from the URL for validation. We expect http://host[:port]/path
+    // style URLs; rely on libcurl's URL parser for correctness.
+    CURLU* uh = curl_url();
+    if (uh == nullptr) {
+      result.error = "transform_by_remote_pineapple: curl_url init failed";
+      return result;
     }
-
-    CURL* curl = curl_easy_init();
-    if (curl == nullptr) {
-        result.error = "transform_by_remote_pineapple: curl_easy_init failed";
-        return result;
-    }
-    struct EasyScope { CURL* h; ~EasyScope() { if (h) curl_easy_cleanup(h); } } scope{curl};
-
-    auto buf_state = std::make_pair(&result.body, opts.max_response_size);
-    struct curl_slist* headers = curl_slist_append(nullptr,
-        ("Content-Type: " + opts.content_type).c_str());
-    struct HdrScope { curl_slist* h; ~HdrScope() { if (h) curl_slist_free_all(h); } } hscope{headers};
-
-    bool allow_private_flag = opts.allow_private;
-
-    curl_easy_setopt(curl, CURLOPT_URL, opts.url.c_str());
-    curl_easy_setopt(curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, opts.body.data());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(opts.body.size()));
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS,
-        static_cast<long>(opts.timeout.count()));
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &write_callback);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buf_state);
-    // Dial-time SSRF guard — defeats DNS rebinding by checking the actual
-    // peer IP libcurl chose, not the one we resolved during init-time host
-    // validation.
-    curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, &opensocket_ssrf_callback);
-    curl_easy_setopt(curl, CURLOPT_OPENSOCKETDATA, &allow_private_flag);
-    // Disable redirect-follow to keep the SSRF guard authoritative.
-    // libcurl's OPENSOCKETFUNCTION fires on redirects too, but disabling
-    // follow makes the security boundary more explicit for auditors.
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
-
-    CURLcode rc = curl_easy_perform(curl);
-    if (rc != CURLE_OK) {
-        // Size overflow surfaces as CURLE_WRITE_ERROR with body already
-        // containing max_response_size + 1 bytes.
-        if (rc == CURLE_WRITE_ERROR &&
-            opts.max_response_size >= 0 &&
-            static_cast<int64_t>(result.body.size()) > opts.max_response_size) {
-            result.error = "transform_by_remote_pineapple: response body exceeds " +
-                           std::to_string(opts.max_response_size) + " bytes limit";
-        } else if (rc == CURLE_COULDNT_CONNECT || rc == CURLE_COULDNT_RESOLVE_HOST) {
-            // CURL_SOCKET_BAD from the open-socket callback surfaces here as
-            // a "couldn't connect"; relabel it so the cause is obvious.
-            result.error = std::string("transform_by_remote_pineapple: request failed: ") +
-                           curl_easy_strerror(rc) +
-                           " (peer rejected by SSRF dial-time guard if hostname resolved to a private address)";
-        } else {
-            result.error = std::string("transform_by_remote_pineapple: request failed: ") +
-                           curl_easy_strerror(rc);
+    struct UrlScope {
+      CURLU* h;
+      ~UrlScope() {
+        if (h) {
+          curl_url_cleanup(h);
         }
-        return result;
+      }
+    } scope{uh};
+    if (curl_url_set(uh, CURLUPART_URL, opts.url.c_str(), 0) != CURLUE_OK) {
+      result.error = "transform_by_remote_pineapple: malformed URL: " + opts.url;
+      return result;
     }
+    char* host_cstr = nullptr;
+    if (curl_url_get(uh, CURLUPART_HOST, &host_cstr, 0) != CURLUE_OK || host_cstr == nullptr) {
+      result.error = "transform_by_remote_pineapple: cannot extract host from URL: " + opts.url;
+      return result;
+    }
+    std::string host = host_cstr;
+    curl_free(host_cstr);
+    std::string reason;
+    if (!validate_remote_host(host, &reason)) {
+      result.error = "transform_by_remote_pineapple: " + reason;
+      return result;
+    }
+  }
 
-    long status = 0;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
-    result.status_code = static_cast<int>(status);
-    result.ok = true;
+  CURL* curl = curl_easy_init();
+  if (curl == nullptr) {
+    result.error = "transform_by_remote_pineapple: curl_easy_init failed";
     return result;
+  }
+  struct EasyScope {
+    CURL* h;
+    ~EasyScope() {
+      if (h) {
+        curl_easy_cleanup(h);
+      }
+    }
+  } scope{curl};
+
+  auto buf_state = std::make_pair(&result.body, opts.max_response_size);
+  struct curl_slist* headers = curl_slist_append(nullptr, ("Content-Type: " + opts.content_type).c_str());
+  struct HdrScope {
+    curl_slist* h;
+    ~HdrScope() {
+      if (h) {
+        curl_slist_free_all(h);
+      }
+    }
+  } hscope{headers};
+
+  bool allow_private_flag = opts.allow_private;
+
+  curl_easy_setopt(curl, CURLOPT_URL, opts.url.c_str());
+  curl_easy_setopt(curl, CURLOPT_POST, 1L);
+  curl_easy_setopt(curl, CURLOPT_POSTFIELDS, opts.body.data());
+  curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(opts.body.size()));
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(opts.timeout.count()));
+  curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &write_callback);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buf_state);
+  // Dial-time SSRF guard — defeats DNS rebinding by checking the actual
+  // peer IP libcurl chose, not the one we resolved during init-time host
+  // validation.
+  curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, &opensocket_ssrf_callback);
+  curl_easy_setopt(curl, CURLOPT_OPENSOCKETDATA, &allow_private_flag);
+  // Disable redirect-follow to keep the SSRF guard authoritative.
+  // libcurl's OPENSOCKETFUNCTION fires on redirects too, but disabling
+  // follow makes the security boundary more explicit for auditors.
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
+
+  CURLcode rc = curl_easy_perform(curl);
+  if (rc != CURLE_OK) {
+    // Size overflow surfaces as CURLE_WRITE_ERROR with body already
+    // containing max_response_size + 1 bytes.
+    if (rc == CURLE_WRITE_ERROR && opts.max_response_size >= 0 &&
+        static_cast<int64_t>(result.body.size()) > opts.max_response_size) {
+      result.error = "transform_by_remote_pineapple: response body exceeds " +
+                     std::to_string(opts.max_response_size) + " bytes limit";
+    } else if (rc == CURLE_COULDNT_CONNECT || rc == CURLE_COULDNT_RESOLVE_HOST) {
+      // CURL_SOCKET_BAD from the open-socket callback surfaces here as
+      // a "couldn't connect"; relabel it so the cause is obvious.
+      result.error = std::string("transform_by_remote_pineapple: request failed: ") + curl_easy_strerror(rc) +
+                     " (peer rejected by SSRF dial-time guard if hostname resolved to a private address)";
+    } else {
+      result.error = std::string("transform_by_remote_pineapple: request failed: ") + curl_easy_strerror(rc);
+    }
+    return result;
+  }
+
+  long status = 0;
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
+  result.status_code = static_cast<int>(status);
+  result.ok = true;
+  return result;
 }
 
 }  // namespace http

--- a/pine-cpp/src/http/http_client.hpp
+++ b/pine-cpp/src/http/http_client.hpp
@@ -8,25 +8,25 @@ namespace pine {
 namespace http {
 
 struct PostOptions {
-    std::string url;
-    std::string body;
-    std::string content_type = "application/json";
-    std::chrono::milliseconds timeout = std::chrono::seconds(5);
-    int64_t max_response_size = 10 * 1024 * 1024;
-    // When false, refuse to connect to loopback / private / link-local
-    // addresses. The actual host validation happens in ssrf.hpp; this flag
-    // only toggles the IP-resolution guard inside the libcurl callback.
-    bool allow_private = false;
+  std::string url;
+  std::string body;
+  std::string content_type = "application/json";
+  std::chrono::milliseconds timeout = std::chrono::seconds(5);
+  int64_t max_response_size = 10 * 1024 * 1024;
+  // When false, refuse to connect to loopback / private / link-local
+  // addresses. The actual host validation happens in ssrf.hpp; this flag
+  // only toggles the IP-resolution guard inside the libcurl callback.
+  bool allow_private = false;
 };
 
 // Result of an HTTP request. `ok == false` means the request itself failed
 // (DNS / connect / TLS / timeout / SSRF block / size cap). `ok == true` means
 // a response was received; check `status_code`.
 struct PostResult {
-    bool ok = false;
-    int status_code = 0;
-    std::string body;
-    std::string error;  // populated when ok == false
+  bool ok = false;
+  int status_code = 0;
+  std::string body;
+  std::string error;  // populated when ok == false
 };
 
 // One-shot POST. Thread-safe: caller owns the lifetime of input strings.

--- a/pine-cpp/src/http/ssrf.cpp
+++ b/pine-cpp/src/http/ssrf.cpp
@@ -15,97 +15,131 @@ namespace http {
 namespace {
 
 bool ipv4_is_private(uint32_t ip_host_order) {
-    // Documented ranges from RFC 6890 / RFC 6598 / RFC 5735 / RFC 3927 etc.
-    // Reject anything not safe to dial from a production HTTP client.
-    //
-    //   0.0.0.0/8         "this network"                  RFC 1122
-    //   10.0.0.0/8        private use                     RFC 1918
-    //   100.64.0.0/10     carrier-grade NAT (CGN)         RFC 6598
-    //   127.0.0.0/8       loopback                        RFC 1122
-    //   169.254.0.0/16    link-local                      RFC 3927
-    //   172.16.0.0/12     private use                     RFC 1918
-    //   192.0.0.0/24      IETF protocol assignments       RFC 6890
-    //   192.0.2.0/24      documentation (TEST-NET-1)      RFC 5737
-    //   192.88.99.0/24    6to4 relay anycast (deprecated) RFC 7526
-    //   192.168.0.0/16    private use                     RFC 1918
-    //   198.18.0.0/15     benchmark testing               RFC 2544
-    //   198.51.100.0/24   documentation (TEST-NET-2)      RFC 5737
-    //   203.0.113.0/24    documentation (TEST-NET-3)      RFC 5737
-    //   224.0.0.0/4       multicast                       RFC 5771
-    //   240.0.0.0/4       reserved (former class E) + 255.255.255.255 broadcast
-    uint8_t a = (ip_host_order >> 24) & 0xff;
-    uint8_t b = (ip_host_order >> 16) & 0xff;
-    uint8_t c = (ip_host_order >> 8) & 0xff;
-    // Whole /8 blocks
-    if (a == 0 || a == 10 || a == 127) return true;
-    // /12 RFC 1918
-    if (a == 172 && (b & 0xf0) == 16) return true;
-    // /16 ranges
-    if (a == 169 && b == 254) return true;
-    if (a == 192 && b == 168) return true;
-    // /10 CGN
-    if (a == 100 && (b & 0xc0) == 64) return true;
-    // /24 protocol / documentation blocks under 192.x
-    if (a == 192 && b == 0 && c == 0) return true;     // IETF protocol assignments
-    if (a == 192 && b == 0 && c == 2) return true;     // TEST-NET-1
-    if (a == 192 && b == 88 && c == 99) return true;   // 6to4 relay anycast
-    // /24 documentation
-    if (a == 198 && b == 51 && c == 100) return true;  // TEST-NET-2
-    if (a == 203 && b == 0 && c == 113) return true;   // TEST-NET-3
-    // /15 benchmark
-    if (a == 198 && (b == 18 || b == 19)) return true;
-    // Multicast 224.0.0.0/4 and reserved 240.0.0.0/4 (covers 255.255.255.255)
-    if (a >= 224) return true;
-    return false;
+  // Documented ranges from RFC 6890 / RFC 6598 / RFC 5735 / RFC 3927 etc.
+  // Reject anything not safe to dial from a production HTTP client.
+  //
+  //   0.0.0.0/8         "this network"                  RFC 1122
+  //   10.0.0.0/8        private use                     RFC 1918
+  //   100.64.0.0/10     carrier-grade NAT (CGN)         RFC 6598
+  //   127.0.0.0/8       loopback                        RFC 1122
+  //   169.254.0.0/16    link-local                      RFC 3927
+  //   172.16.0.0/12     private use                     RFC 1918
+  //   192.0.0.0/24      IETF protocol assignments       RFC 6890
+  //   192.0.2.0/24      documentation (TEST-NET-1)      RFC 5737
+  //   192.88.99.0/24    6to4 relay anycast (deprecated) RFC 7526
+  //   192.168.0.0/16    private use                     RFC 1918
+  //   198.18.0.0/15     benchmark testing               RFC 2544
+  //   198.51.100.0/24   documentation (TEST-NET-2)      RFC 5737
+  //   203.0.113.0/24    documentation (TEST-NET-3)      RFC 5737
+  //   224.0.0.0/4       multicast                       RFC 5771
+  //   240.0.0.0/4       reserved (former class E) + 255.255.255.255 broadcast
+  uint8_t a = (ip_host_order >> 24) & 0xff;
+  uint8_t b = (ip_host_order >> 16) & 0xff;
+  uint8_t c = (ip_host_order >> 8) & 0xff;
+  // Whole /8 blocks
+  if (a == 0 || a == 10 || a == 127) {
+    return true;
+  }
+  // /12 RFC 1918
+  if (a == 172 && (b & 0xf0) == 16) {
+    return true;
+  }
+  // /16 ranges
+  if (a == 169 && b == 254) {
+    return true;
+  }
+  if (a == 192 && b == 168) {
+    return true;
+  }
+  // /10 CGN
+  if (a == 100 && (b & 0xc0) == 64) {
+    return true;
+  }
+  // /24 protocol / documentation blocks under 192.x
+  if (a == 192 && b == 0 && c == 0) {
+    return true;  // IETF protocol assignments
+  }
+  if (a == 192 && b == 0 && c == 2) {
+    return true;  // TEST-NET-1
+  }
+  if (a == 192 && b == 88 && c == 99) {
+    return true;  // 6to4 relay anycast
+  }
+  // /24 documentation
+  if (a == 198 && b == 51 && c == 100) {
+    return true;  // TEST-NET-2
+  }
+  if (a == 203 && b == 0 && c == 113) {
+    return true;  // TEST-NET-3
+  }
+  // /15 benchmark
+  if (a == 198 && (b == 18 || b == 19)) {
+    return true;
+  }
+  // Multicast 224.0.0.0/4 and reserved 240.0.0.0/4 (covers 255.255.255.255)
+  if (a >= 224) {
+    return true;
+  }
+  return false;
 }
 
 bool ipv6_is_private(const struct in6_addr& a) {
-    // Documented ranges from RFC 6890 / RFC 4291 / RFC 4193 etc.
-    //
-    //   ::/128                unspecified
-    //   ::1/128               loopback
-    //   ::ffff:0:0/96         IPv4-mapped (delegated to IPv4 rules)
-    //   100::/64              discard-only address block        RFC 6666
-    //   2001:db8::/32         documentation                     RFC 3849
-    //   fc00::/7              unique local                       RFC 4193
-    //   fe80::/10             link-local                         RFC 4291
-    //   fec0::/10             site-local (deprecated, historic)
-    //   ff00::/8              multicast                          RFC 4291
-    if (IN6_IS_ADDR_LOOPBACK(&a)) return true;
-    if (IN6_IS_ADDR_LINKLOCAL(&a)) return true;
-    if (IN6_IS_ADDR_SITELOCAL(&a)) return true;
-    if (IN6_IS_ADDR_UNSPECIFIED(&a)) return true;
-    if (IN6_IS_ADDR_MULTICAST(&a)) return true;
-    // fc00::/7 — unique local
-    if ((a.s6_addr[0] & 0xfe) == 0xfc) return true;
-    // 100::/64 — discard prefix (RFC 6666)
-    if (a.s6_addr[0] == 0x01 && a.s6_addr[1] == 0x00 &&
-        a.s6_addr[2] == 0x00 && a.s6_addr[3] == 0x00 &&
-        a.s6_addr[4] == 0x00 && a.s6_addr[5] == 0x00 &&
-        a.s6_addr[6] == 0x00 && a.s6_addr[7] == 0x00) {
-        return true;
-    }
-    // 2001:db8::/32 — documentation prefix (RFC 3849)
-    if (a.s6_addr[0] == 0x20 && a.s6_addr[1] == 0x01 &&
-        a.s6_addr[2] == 0x0d && a.s6_addr[3] == 0xb8) {
-        return true;
-    }
-    // IPv4-mapped: ::ffff:a.b.c.d → reuse IPv4 rules
-    if (IN6_IS_ADDR_V4MAPPED(&a)) {
-        uint32_t ip = (static_cast<uint32_t>(a.s6_addr[12]) << 24) |
-                      (static_cast<uint32_t>(a.s6_addr[13]) << 16) |
-                      (static_cast<uint32_t>(a.s6_addr[14]) << 8) |
-                      (static_cast<uint32_t>(a.s6_addr[15]));
-        return ipv4_is_private(ip);
-    }
-    return false;
+  // Documented ranges from RFC 6890 / RFC 4291 / RFC 4193 etc.
+  //
+  //   ::/128                unspecified
+  //   ::1/128               loopback
+  //   ::ffff:0:0/96         IPv4-mapped (delegated to IPv4 rules)
+  //   100::/64              discard-only address block        RFC 6666
+  //   2001:db8::/32         documentation                     RFC 3849
+  //   fc00::/7              unique local                       RFC 4193
+  //   fe80::/10             link-local                         RFC 4291
+  //   fec0::/10             site-local (deprecated, historic)
+  //   ff00::/8              multicast                          RFC 4291
+  if (IN6_IS_ADDR_LOOPBACK(&a)) {
+    return true;
+  }
+  if (IN6_IS_ADDR_LINKLOCAL(&a)) {
+    return true;
+  }
+  if (IN6_IS_ADDR_SITELOCAL(&a)) {
+    return true;
+  }
+  if (IN6_IS_ADDR_UNSPECIFIED(&a)) {
+    return true;
+  }
+  if (IN6_IS_ADDR_MULTICAST(&a)) {
+    return true;
+  }
+  // fc00::/7 — unique local
+  if ((a.s6_addr[0] & 0xfe) == 0xfc) {
+    return true;
+  }
+  // 100::/64 — discard prefix (RFC 6666)
+  if (a.s6_addr[0] == 0x01 && a.s6_addr[1] == 0x00 && a.s6_addr[2] == 0x00 && a.s6_addr[3] == 0x00 &&
+      a.s6_addr[4] == 0x00 && a.s6_addr[5] == 0x00 && a.s6_addr[6] == 0x00 && a.s6_addr[7] == 0x00) {
+    return true;
+  }
+  // 2001:db8::/32 — documentation prefix (RFC 3849)
+  if (a.s6_addr[0] == 0x20 && a.s6_addr[1] == 0x01 && a.s6_addr[2] == 0x0d && a.s6_addr[3] == 0xb8) {
+    return true;
+  }
+  // IPv4-mapped: ::ffff:a.b.c.d → reuse IPv4 rules
+  if (IN6_IS_ADDR_V4MAPPED(&a)) {
+    uint32_t ip = (static_cast<uint32_t>(a.s6_addr[12]) << 24) |
+                  (static_cast<uint32_t>(a.s6_addr[13]) << 16) | (static_cast<uint32_t>(a.s6_addr[14]) << 8) |
+                  (static_cast<uint32_t>(a.s6_addr[15]));
+    return ipv4_is_private(ip);
+  }
+  return false;
 }
 
 std::string to_lower(const std::string& s) {
-    std::string out;
-    out.reserve(s.size());
-    for (char c : s) out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
-    return out;
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) {
+    out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+  }
+  return out;
 }
 
 // Returns true if `host` syntactically looks like an obfuscated IPv4 literal
@@ -115,161 +149,184 @@ std::string to_lower(const std::string& s) {
 // almost always loopback/private and they exist precisely to evade naive
 // string-matching guards.
 bool looks_like_obfuscated_ipv4(const std::string& host) {
-    if (host.empty()) return false;
-    // 0x prefix (hex form): 0x7f000001
-    if (host.size() >= 2 && host[0] == '0' && (host[1] == 'x' || host[1] == 'X')) {
-        return true;
-    }
-    // Pure digits (no dot): 2130706433
-    bool all_digits = true;
-    for (char c : host) {
-        if (!std::isdigit(static_cast<unsigned char>(c))) {
-            all_digits = false;
-            break;
-        }
-    }
-    if (all_digits) return true;
-    // Dotted but with fewer than 4 segments: 127.1, 127.0.1
-    // (RFC 1123 hostnames can have any number of labels, so we only flag
-    // shapes that look numeric in every segment — those are unambiguously
-    // attempts at IPv4 short-form, not real hostnames.)
-    if (host.find('.') != std::string::npos) {
-        bool all_numeric_segments = true;
-        size_t segment_count = 1;
-        for (char c : host) {
-            if (c == '.') {
-                ++segment_count;
-            } else if (!std::isdigit(static_cast<unsigned char>(c))) {
-                all_numeric_segments = false;
-                break;
-            }
-        }
-        if (all_numeric_segments && segment_count != 4) return true;
-    }
+  if (host.empty()) {
     return false;
+  }
+  // 0x prefix (hex form): 0x7f000001
+  if (host.size() >= 2 && host[0] == '0' && (host[1] == 'x' || host[1] == 'X')) {
+    return true;
+  }
+  // Pure digits (no dot): 2130706433
+  bool all_digits = true;
+  for (char c : host) {
+    if (!std::isdigit(static_cast<unsigned char>(c))) {
+      all_digits = false;
+      break;
+    }
+  }
+  if (all_digits) {
+    return true;
+  }
+  // Dotted but with fewer than 4 segments: 127.1, 127.0.1
+  // (RFC 1123 hostnames can have any number of labels, so we only flag
+  // shapes that look numeric in every segment — those are unambiguously
+  // attempts at IPv4 short-form, not real hostnames.)
+  if (host.find('.') != std::string::npos) {
+    bool all_numeric_segments = true;
+    size_t segment_count = 1;
+    for (char c : host) {
+      if (c == '.') {
+        ++segment_count;
+      } else if (!std::isdigit(static_cast<unsigned char>(c))) {
+        all_numeric_segments = false;
+        break;
+      }
+    }
+    if (all_numeric_segments && segment_count != 4) {
+      return true;
+    }
+  }
+  return false;
 }
 
 }  // namespace
 
 bool ip_literal_is_private(const std::string& ip) {
-    struct in_addr v4;
-    if (inet_pton(AF_INET, ip.c_str(), &v4) == 1) {
-        return ipv4_is_private(ntohl(v4.s_addr));
-    }
-    struct in6_addr v6;
-    if (inet_pton(AF_INET6, ip.c_str(), &v6) == 1) {
-        return ipv6_is_private(v6);
-    }
-    return false;
+  struct in_addr v4;
+  if (inet_pton(AF_INET, ip.c_str(), &v4) == 1) {
+    return ipv4_is_private(ntohl(v4.s_addr));
+  }
+  struct in6_addr v6;
+  if (inet_pton(AF_INET6, ip.c_str(), &v6) == 1) {
+    return ipv6_is_private(v6);
+  }
+  return false;
 }
 
 bool sockaddr_is_private(const struct sockaddr* sa) {
-    if (sa == nullptr) return false;
-    if (sa->sa_family == AF_INET) {
-        const auto* in4 = reinterpret_cast<const sockaddr_in*>(sa);
-        return ipv4_is_private(ntohl(in4->sin_addr.s_addr));
-    }
-    if (sa->sa_family == AF_INET6) {
-        const auto* in6 = reinterpret_cast<const sockaddr_in6*>(sa);
-        return ipv6_is_private(in6->sin6_addr);
-    }
+  if (sa == nullptr) {
     return false;
+  }
+  if (sa->sa_family == AF_INET) {
+    const auto* in4 = reinterpret_cast<const sockaddr_in*>(sa);
+    return ipv4_is_private(ntohl(in4->sin_addr.s_addr));
+  }
+  if (sa->sa_family == AF_INET6) {
+    const auto* in6 = reinterpret_cast<const sockaddr_in6*>(sa);
+    return ipv6_is_private(in6->sin6_addr);
+  }
+  return false;
 }
 
 bool host_is_private(const std::string& host, std::string* error_out) {
-    // Case-insensitive textual aliases.
-    const std::string host_lower = to_lower(host);
-    if (host_lower.empty() || host_lower == "localhost") {
-        if (error_out) *error_out = "host \"" + host + "\" is not allowed (private/loopback)";
+  // Case-insensitive textual aliases.
+  const std::string host_lower = to_lower(host);
+  if (host_lower.empty() || host_lower == "localhost") {
+    if (error_out) {
+      *error_out = "host \"" + host + "\" is not allowed (private/loopback)";
+    }
+    return true;
+  }
+  // Reject any character outside the RFC 1123 hostname charset
+  // (letters, digits, dot, hyphen) or IPv6 literal charset (hex, colon).
+  // Stops URL-smuggling shapes like `trusted.com/@127.0.0.1` where the
+  // libcurl parser would interpret the `/@127.0.0.1` tail as userinfo /
+  // path and connect to 127.0.0.1 anyway. inet_pton() and addrinfo
+  // recognise IPv6 explicitly so we don't need to be lenient here.
+  for (char c : host) {
+    const unsigned char u = static_cast<unsigned char>(c);
+    if (!(std::isalnum(u) || c == '-' || c == '.' || c == ':')) {
+      if (error_out) {
+        *error_out = "host \"" + host +
+                     "\" contains invalid character; "
+                     "only RFC 1123 hostnames and IPv6 literals are accepted";
+      }
+      return true;
+    }
+  }
+  // Reject obfuscated IPv4 shapes that bypass inet_pton but resolve to
+  // private addresses in libcurl's own parser (DNS rebinding precursor).
+  if (looks_like_obfuscated_ipv4(host)) {
+    if (error_out) {
+      *error_out =
+          "host \"" + host + "\" looks like a non-canonical IPv4 literal (rejected to defeat SSRF evasion)";
+    }
+    return true;
+  }
+  // If it parses as an IP literal, check directly.
+  {
+    struct in_addr v4;
+    if (inet_pton(AF_INET, host.c_str(), &v4) == 1) {
+      if (ipv4_is_private(ntohl(v4.s_addr))) {
+        if (error_out) {
+          *error_out = "host \"" + host + "\" is a private/loopback address";
+        }
         return true;
+      }
+      return false;
     }
-    // Reject any character outside the RFC 1123 hostname charset
-    // (letters, digits, dot, hyphen) or IPv6 literal charset (hex, colon).
-    // Stops URL-smuggling shapes like `trusted.com/@127.0.0.1` where the
-    // libcurl parser would interpret the `/@127.0.0.1` tail as userinfo /
-    // path and connect to 127.0.0.1 anyway. inet_pton() and addrinfo
-    // recognise IPv6 explicitly so we don't need to be lenient here.
-    for (char c : host) {
-        const unsigned char u = static_cast<unsigned char>(c);
-        if (!(std::isalnum(u) || c == '-' || c == '.' || c == ':')) {
-            if (error_out) *error_out =
-                "host \"" + host + "\" contains invalid character; "
-                "only RFC 1123 hostnames and IPv6 literals are accepted";
-            return true;
+    struct in6_addr v6;
+    if (inet_pton(AF_INET6, host.c_str(), &v6) == 1) {
+      if (ipv6_is_private(v6)) {
+        if (error_out) {
+          *error_out = "host \"" + host + "\" is a private/loopback address";
         }
-    }
-    // Reject obfuscated IPv4 shapes that bypass inet_pton but resolve to
-    // private addresses in libcurl's own parser (DNS rebinding precursor).
-    if (looks_like_obfuscated_ipv4(host)) {
-        if (error_out) *error_out = "host \"" + host + "\" looks like a non-canonical IPv4 literal (rejected to defeat SSRF evasion)";
         return true;
+      }
+      return false;
     }
-    // If it parses as an IP literal, check directly.
-    {
-        struct in_addr v4;
-        if (inet_pton(AF_INET, host.c_str(), &v4) == 1) {
-            if (ipv4_is_private(ntohl(v4.s_addr))) {
-                if (error_out) *error_out = "host \"" + host + "\" is a private/loopback address";
-                return true;
-            }
-            return false;
-        }
-        struct in6_addr v6;
-        if (inet_pton(AF_INET6, host.c_str(), &v6) == 1) {
-            if (ipv6_is_private(v6)) {
-                if (error_out) *error_out = "host \"" + host + "\" is a private/loopback address";
-                return true;
-            }
-            return false;
-        }
-    }
-    // Symbolic hostname — best-effort DNS lookup. A failure does not classify
-    // as "private"; the dial-time guard is the real defense.
-    struct addrinfo hints{};
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    struct addrinfo* res = nullptr;
-    int rc = getaddrinfo(host.c_str(), nullptr, &hints, &res);
-    if (rc != 0 || res == nullptr) {
-        return false;
-    }
-    bool found_private = false;
-    std::string offending;
-    for (auto* p = res; p != nullptr; p = p->ai_next) {
-        char buf[INET6_ADDRSTRLEN] = {0};
-        if (p->ai_family == AF_INET) {
-            auto* sa = reinterpret_cast<sockaddr_in*>(p->ai_addr);
-            inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf));
-            if (ipv4_is_private(ntohl(sa->sin_addr.s_addr))) {
-                found_private = true;
-                offending = buf;
-                break;
-            }
-        } else if (p->ai_family == AF_INET6) {
-            auto* sa = reinterpret_cast<sockaddr_in6*>(p->ai_addr);
-            inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf));
-            if (ipv6_is_private(sa->sin6_addr)) {
-                found_private = true;
-                offending = buf;
-                break;
-            }
-        }
-    }
-    freeaddrinfo(res);
-    if (found_private) {
-        if (error_out) *error_out = "host \"" + host + "\" resolves to private address " + offending;
-        return true;
-    }
+  }
+  // Symbolic hostname — best-effort DNS lookup. A failure does not classify
+  // as "private"; the dial-time guard is the real defense.
+  struct addrinfo hints{};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  struct addrinfo* res = nullptr;
+  int rc = getaddrinfo(host.c_str(), nullptr, &hints, &res);
+  if (rc != 0 || res == nullptr) {
     return false;
+  }
+  bool found_private = false;
+  std::string offending;
+  for (auto* p = res; p != nullptr; p = p->ai_next) {
+    char buf[INET6_ADDRSTRLEN] = {0};
+    if (p->ai_family == AF_INET) {
+      auto* sa = reinterpret_cast<sockaddr_in*>(p->ai_addr);
+      inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf));
+      if (ipv4_is_private(ntohl(sa->sin_addr.s_addr))) {
+        found_private = true;
+        offending = buf;
+        break;
+      }
+    } else if (p->ai_family == AF_INET6) {
+      auto* sa = reinterpret_cast<sockaddr_in6*>(p->ai_addr);
+      inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf));
+      if (ipv6_is_private(sa->sin6_addr)) {
+        found_private = true;
+        offending = buf;
+        break;
+      }
+    }
+  }
+  freeaddrinfo(res);
+  if (found_private) {
+    if (error_out) {
+      *error_out = "host \"" + host + "\" resolves to private address " + offending;
+    }
+    return true;
+  }
+  return false;
 }
 
 bool validate_remote_host(const std::string& host, std::string* error_out) {
-    std::string reason;
-    if (host_is_private(host, &reason)) {
-        if (error_out) *error_out = reason;
-        return false;
+  std::string reason;
+  if (host_is_private(host, &reason)) {
+    if (error_out) {
+      *error_out = reason;
     }
-    return true;
+    return false;
+  }
+  return true;
 }
 
 }  // namespace http

--- a/pine-cpp/src/lua/lua_bridge.cpp
+++ b/pine-cpp/src/lua/lua_bridge.cpp
@@ -3,8 +3,8 @@
 #include "lua_bridge.hpp"
 
 extern "C" {
-#include <lua.h>
 #include <lauxlib.h>
+#include <lua.h>
 #include <lualib.h>
 }
 
@@ -23,233 +23,236 @@ namespace pine {
 namespace lua {
 
 LuaSnapshot::LuaSnapshot(lua_State* L) {
-    lua_pushglobaltable(L);
-    lua_pushnil(L);
-    while (lua_next(L, -2) != 0) {
-        if (lua_type(L, -2) == LUA_TSTRING) {
-            std::string key = lua_tostring(L, -2);
-            globals.insert(key);
-        }
-        lua_pop(L, 1);
+  lua_pushglobaltable(L);
+  lua_pushnil(L);
+  while (lua_next(L, -2) != 0) {
+    if (lua_type(L, -2) == LUA_TSTRING) {
+      std::string key = lua_tostring(L, -2);
+      globals.insert(key);
     }
     lua_pop(L, 1);
+  }
+  lua_pop(L, 1);
 }
 
 std::map<std::string, int> LuaSnapshot::capture_values(lua_State* L) const {
-    std::map<std::string, int> values;
-    // Pushing references to the registry to keep them alive
-    for (const auto& key : globals) {
-        lua_getglobal(L, key.c_str());
-        int ref = luaL_ref(L, LUA_REGISTRYINDEX);
-        values[key] = ref;
-    }
-    return values;
+  std::map<std::string, int> values;
+  // Pushing references to the registry to keep them alive
+  for (const auto& key : globals) {
+    lua_getglobal(L, key.c_str());
+    int ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    values[key] = ref;
+  }
+  return values;
 }
 
 void LuaSnapshot::reset_to_baseline(lua_State* L, const std::map<std::string, int>& borrow_snap) const {
-    lua_pushglobaltable(L);
-    lua_pushnil(L);
-    std::vector<std::string> to_remove;
-    while (lua_next(L, -2) != 0) {
-        if (lua_type(L, -2) == LUA_TSTRING) {
-            std::string key = lua_tostring(L, -2);
-            if (globals.find(key) == globals.end()) {
-                to_remove.push_back(key);
-            }
-        }
-        lua_pop(L, 1);
+  lua_pushglobaltable(L);
+  lua_pushnil(L);
+  std::vector<std::string> to_remove;
+  while (lua_next(L, -2) != 0) {
+    if (lua_type(L, -2) == LUA_TSTRING) {
+      std::string key = lua_tostring(L, -2);
+      if (globals.find(key) == globals.end()) {
+        to_remove.push_back(key);
+      }
     }
     lua_pop(L, 1);
+  }
+  lua_pop(L, 1);
 
-    for (const auto& key : to_remove) {
-        lua_pushnil(L);
-        lua_setglobal(L, key.c_str());
-    }
+  for (const auto& key : to_remove) {
+    lua_pushnil(L);
+    lua_setglobal(L, key.c_str());
+  }
 
-    // Re-open the safe built-in libraries so any sub-table mutation
-    // done by the script (`math.huge = 0`, `string.format = nil`, ...) is
-    // wiped before the next borrow. This is the effective equivalent of
-    // deep-cloning the baseline tables — luaopen_* allocates fresh table
-    // instances on every call and registers fresh C closures into them.
-    // Cheaper than maintaining a cross-state native deep-clone and avoids
-    // the Lua-to-C-state mapping headache (registry refs are per-state).
-    static const struct { const char* name; lua_CFunction fn; } kSafeLibs[] = {
-        {"",              luaopen_base},
-        {LUA_TABLIBNAME,  luaopen_table},
-        {LUA_STRLIBNAME,  luaopen_string},
-        {LUA_MATHLIBNAME, luaopen_math},
-    };
-    for (const auto& lib : kSafeLibs) {
-        lua_pushcfunction(L, lib.fn);
-        lua_pushstring(L, lib.name);
-        lua_call(L, 1, 0);
-    }
-    // Re-strip the filesystem-exposing globals the LuaVM ctor stripped,
-    // because luaopen_base re-installs them.
-    lua_pushnil(L); lua_setglobal(L, "dofile");
-    lua_pushnil(L); lua_setglobal(L, "loadfile");
+  // Re-open the safe built-in libraries so any sub-table mutation
+  // done by the script (`math.huge = 0`, `string.format = nil`, ...) is
+  // wiped before the next borrow. This is the effective equivalent of
+  // deep-cloning the baseline tables — luaopen_* allocates fresh table
+  // instances on every call and registers fresh C closures into them.
+  // Cheaper than maintaining a cross-state native deep-clone and avoids
+  // the Lua-to-C-state mapping headache (registry refs are per-state).
+  static const struct {
+    const char* name;
+    lua_CFunction fn;
+  } kSafeLibs[] = {
+      {"", luaopen_base},
+      {LUA_TABLIBNAME, luaopen_table},
+      {LUA_STRLIBNAME, luaopen_string},
+      {LUA_MATHLIBNAME, luaopen_math},
+  };
+  for (const auto& lib : kSafeLibs) {
+    lua_pushcfunction(L, lib.fn);
+    lua_pushstring(L, lib.name);
+    lua_call(L, 1, 0);
+  }
+  // Re-strip the filesystem-exposing globals the LuaVM ctor stripped,
+  // because luaopen_base re-installs them.
+  lua_pushnil(L);
+  lua_setglobal(L, "dofile");
+  lua_pushnil(L);
+  lua_setglobal(L, "loadfile");
 
-    // Restore non-builtin baseline globals from the captured snapshot.
-    // The builtin tables (`string`, `table`, `math`, base lib functions on
-    // `_G`) have just been reset above; overwriting them from the snapshot
-    // would restore the *polluted* references the borrow had, defeating
-    // the deep-clone. We free those refs but skip the setglobal.
-    //
-    // Stored as a sorted constexpr array of string_view + std::binary_search:
-    // every release_vm hits this list, and the prior std::set required heap
-    // allocations of every entry the first time the function ran.
-    static constexpr std::string_view kSkipBuiltins[] = {
-        // sorted lexicographically — binary_search relies on this
-        "_G", "_VERSION",
-        "assert", "collectgarbage", "error",
-        "getfenv", "getmetatable",
-        "ipairs",
-        "load", "loadstring",
-        "math",
-        "next",
-        "pairs", "pcall", "print",
-        "rawequal", "rawget", "rawset",
-        "select", "setfenv", "setmetatable", "string",
-        "table", "tonumber", "tostring", "type",
-        "unpack",
-        "xpcall",
-    };
-    for (const auto& [key, ref] : borrow_snap) {
-        if (!std::binary_search(std::begin(kSkipBuiltins), std::end(kSkipBuiltins),
-                                std::string_view(key))) {
-            lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
-            lua_setglobal(L, key.c_str());
-        }
-        luaL_unref(L, LUA_REGISTRYINDEX, ref);
+  // Restore non-builtin baseline globals from the captured snapshot.
+  // The builtin tables (`string`, `table`, `math`, base lib functions on
+  // `_G`) have just been reset above; overwriting them from the snapshot
+  // would restore the *polluted* references the borrow had, defeating
+  // the deep-clone. We free those refs but skip the setglobal.
+  //
+  // Stored as a sorted constexpr array of string_view + std::binary_search:
+  // every release_vm hits this list, and the prior std::set required heap
+  // allocations of every entry the first time the function ran.
+  static constexpr std::string_view kSkipBuiltins[] = {
+      // sorted lexicographically — binary_search relies on this
+      "_G",     "_VERSION", "assert",     "collectgarbage", "error",  "getfenv", "getmetatable",
+      "ipairs", "load",     "loadstring", "math",           "next",   "pairs",   "pcall",
+      "print",  "rawequal", "rawget",     "rawset",         "select", "setfenv", "setmetatable",
+      "string", "table",    "tonumber",   "tostring",       "type",   "unpack",  "xpcall",
+  };
+  for (const auto& [key, ref] : borrow_snap) {
+    if (!std::binary_search(std::begin(kSkipBuiltins), std::end(kSkipBuiltins), std::string_view(key))) {
+      lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+      lua_setglobal(L, key.c_str());
     }
+    luaL_unref(L, LUA_REGISTRYINDEX, ref);
+  }
 }
 
 LuaVM::LuaVM() {
-    L_ = luaL_newstate();
-    if (!L_) throw ExecutionError("failed to create Lua state");
+  L_ = luaL_newstate();
+  if (!L_) {
+    throw ExecutionError("failed to create Lua state");
+  }
 
-    // Sandbox: Only load safe standard libraries: base (including coroutine etc if opened via those, but here base, table, string, math)
-    // To match Go's SkipOpenLibs: true, we open libraries individually using standard luaopen_* functions.
-    lua_pushcfunction(L_, luaopen_base);
-    lua_pushstring(L_, "");
-    lua_call(L_, 1, 0);
+  // Sandbox: Only load safe standard libraries: base (including coroutine etc if opened via those, but here
+  // base, table, string, math) To match Go's SkipOpenLibs: true, we open libraries individually using
+  // standard luaopen_* functions.
+  lua_pushcfunction(L_, luaopen_base);
+  lua_pushstring(L_, "");
+  lua_call(L_, 1, 0);
 
-    lua_pushcfunction(L_, luaopen_table);
-    lua_pushstring(L_, LUA_TABLIBNAME);
-    lua_call(L_, 1, 0);
+  lua_pushcfunction(L_, luaopen_table);
+  lua_pushstring(L_, LUA_TABLIBNAME);
+  lua_call(L_, 1, 0);
 
-    lua_pushcfunction(L_, luaopen_string);
-    lua_pushstring(L_, LUA_STRLIBNAME);
-    lua_call(L_, 1, 0);
+  lua_pushcfunction(L_, luaopen_string);
+  lua_pushstring(L_, LUA_STRLIBNAME);
+  lua_call(L_, 1, 0);
 
-    lua_pushcfunction(L_, luaopen_math);
-    lua_pushstring(L_, LUA_MATHLIBNAME);
-    lua_call(L_, 1, 0);
+  lua_pushcfunction(L_, luaopen_math);
+  lua_pushstring(L_, LUA_MATHLIBNAME);
+  lua_call(L_, 1, 0);
 
-    // Remove potentially filesystem-accessing functions
-    lua_pushnil(L_); lua_setglobal(L_, "dofile");
-    lua_pushnil(L_); lua_setglobal(L_, "loadfile");
+  // Remove potentially filesystem-accessing functions
+  lua_pushnil(L_);
+  lua_setglobal(L_, "dofile");
+  lua_pushnil(L_);
+  lua_setglobal(L_, "loadfile");
 }
 
 LuaVM::~LuaVM() {
-    if (L_) lua_close(L_);
+  if (L_) {
+    lua_close(L_);
+  }
 }
 
 void LuaVM::load_script(const std::string& code, const std::string& op_name) {
-    if (luaL_dostring(L_, code.c_str()) != 0) {
-        std::string err = lua_tostring(L_, -1);
-        lua_pop(L_, 1);
-        throw ExecutionError(op_name, "lua: failed to load script: " + err);
-    }
+  if (luaL_dostring(L_, code.c_str()) != 0) {
+    std::string err = lua_tostring(L_, -1);
+    lua_pop(L_, 1);
+    throw ExecutionError(op_name, "lua: failed to load script: " + err);
+  }
 }
 
 void LuaVM::push_value(const JsonValue& value) {
-    if (value.is_null()) {
-        lua_pushnil(L_);
-    } else if (value.is_bool()) {
-        lua_pushboolean(L_, value.as_bool() ? 1 : 0);
-    } else if (value.is_number()) {
-        lua_pushnumber(L_, value.as_number());
-    } else if (value.is_string()) {
-        const auto& s = value.as_string();
-        lua_pushlstring(L_, s.c_str(), s.size());
-    } else if (value.is_array()) {
-        const auto& arr = value.as_array();
-        lua_createtable(L_, static_cast<int>(arr.size()), 0);
-        for (std::size_t i = 0; i < arr.size(); ++i) {
-            push_value(arr[i]);
-            lua_rawseti(L_, -2, static_cast<int>(i + 1));
-        }
-    } else if (value.is_object()) {
-        const auto& obj = value.as_object();
-        lua_createtable(L_, 0, static_cast<int>(obj.size()));
-        for (const auto& [k, v] : obj) {
-            lua_pushlstring(L_, k.c_str(), k.size());
-            push_value(v);
-            lua_rawset(L_, -3);
-        }
+  if (value.is_null()) {
+    lua_pushnil(L_);
+  } else if (value.is_bool()) {
+    lua_pushboolean(L_, value.as_bool() ? 1 : 0);
+  } else if (value.is_number()) {
+    lua_pushnumber(L_, value.as_number());
+  } else if (value.is_string()) {
+    const auto& s = value.as_string();
+    lua_pushlstring(L_, s.c_str(), s.size());
+  } else if (value.is_array()) {
+    const auto& arr = value.as_array();
+    lua_createtable(L_, static_cast<int>(arr.size()), 0);
+    for (std::size_t i = 0; i < arr.size(); ++i) {
+      push_value(arr[i]);
+      lua_rawseti(L_, -2, static_cast<int>(i + 1));
     }
+  } else if (value.is_object()) {
+    const auto& obj = value.as_object();
+    lua_createtable(L_, 0, static_cast<int>(obj.size()));
+    for (const auto& [k, v] : obj) {
+      lua_pushlstring(L_, k.c_str(), k.size());
+      push_value(v);
+      lua_rawset(L_, -3);
+    }
+  }
 }
 
 JsonValue LuaVM::to_value(int index) {
-    int t = lua_type(L_, index);
-    switch (t) {
+  int t = lua_type(L_, index);
+  switch (t) {
     case LUA_TNIL:
-        return JsonValue();
+      return JsonValue();
     case LUA_TBOOLEAN:
-        return JsonValue(static_cast<bool>(lua_toboolean(L_, index)));
+      return JsonValue(static_cast<bool>(lua_toboolean(L_, index)));
     case LUA_TNUMBER:
-        return JsonValue(lua_tonumber(L_, index));
+      return JsonValue(lua_tonumber(L_, index));
     case LUA_TSTRING: {
-        std::size_t len;
-        const char* s = lua_tolstring(L_, index, &len);
-        return JsonValue(std::string(s, len));
+      std::size_t len;
+      const char* s = lua_tolstring(L_, index, &len);
+      return JsonValue(std::string(s, len));
     }
     default:
-        return JsonValue();
-    }
+      return JsonValue();
+  }
 }
 
 void LuaVM::set_global(const std::string& name, const JsonValue& value) {
-    push_value(value);
-    lua_setglobal(L_, name.c_str());
+  push_value(value);
+  lua_setglobal(L_, name.c_str());
 }
 
 void LuaVM::set_global_table(const std::string& name, const std::vector<JsonValue>& values) {
-    lua_createtable(L_, static_cast<int>(values.size()), 0);
-    for (std::size_t i = 0; i < values.size(); ++i) {
-        push_value(values[i]);
-        lua_rawseti(L_, -2, static_cast<int>(i + 1));
-    }
-    lua_setglobal(L_, name.c_str());
+  lua_createtable(L_, static_cast<int>(values.size()), 0);
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    push_value(values[i]);
+    lua_rawseti(L_, -2, static_cast<int>(i + 1));
+  }
+  lua_setglobal(L_, name.c_str());
 }
 
-std::vector<JsonValue> LuaVM::call_function(const std::string& func_name, int nret, const std::string& op_name) {
-    lua_getglobal(L_, func_name.c_str());
-    if (lua_type(L_, -1) != LUA_TFUNCTION) {
-        lua_pop(L_, 1);
-        throw ExecutionError(op_name, "lua: function \"" + func_name + "\" not defined in script");
+std::vector<JsonValue> LuaVM::call_function(const std::string& func_name, int nret,
+                                            const std::string& op_name) {
+  lua_getglobal(L_, func_name.c_str());
+  if (lua_type(L_, -1) != LUA_TFUNCTION) {
+    lua_pop(L_, 1);
+    throw ExecutionError(op_name, "lua: function \"" + func_name + "\" not defined in script");
+  }
+  if (lua_pcall(L_, 0, nret, 0) != 0) {
+    std::string err = lua_tostring(L_, -1);
+    lua_pop(L_, 1);
+    throw ExecutionError(op_name, "lua: " + err);
+  }
+  std::vector<JsonValue> results;
+  results.reserve(static_cast<std::size_t>(nret));
+  for (int j = 0; j < nret; ++j) {
+    int idx = -(nret - j);
+    if (lua_type(L_, idx) == LUA_TNUMBER) {
+      double d = lua_tonumber(L_, idx);
+      if (std::isnan(d)) {
+        lua_pop(L_, nret);
+        throw ExecutionError(op_name, "lua returned NaN");
+      }
     }
-    if (lua_pcall(L_, 0, nret, 0) != 0) {
-        std::string err = lua_tostring(L_, -1);
-        lua_pop(L_, 1);
-        throw ExecutionError(op_name, "lua: " + err);
-    }
-    std::vector<JsonValue> results;
-    results.reserve(static_cast<std::size_t>(nret));
-    for (int j = 0; j < nret; ++j) {
-        int idx = -(nret - j);
-        if (lua_type(L_, idx) == LUA_TNUMBER) {
-            double d = lua_tonumber(L_, idx);
-            if (std::isnan(d)) {
-                lua_pop(L_, nret);
-                throw ExecutionError(op_name, "lua returned NaN");
-            }
-        }
-        results.push_back(to_value(idx));
-    }
-    lua_pop(L_, nret);
-    return results;
+    results.push_back(to_value(idx));
+  }
+  lua_pop(L_, nret);
+  return results;
 }
 
 }  // namespace lua

--- a/pine-cpp/src/lua/lua_bridge.hpp
+++ b/pine-cpp/src/lua/lua_bridge.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "pine/pine.hpp"
-#include <set>
+
 #include <map>
+#include <set>
 #include <string>
 
 struct lua_State;
@@ -11,36 +12,38 @@ namespace pine {
 namespace lua {
 
 class LuaSnapshot {
-public:
-    LuaSnapshot() = default;
-    explicit LuaSnapshot(lua_State* L);
+ public:
+  LuaSnapshot() = default;
+  explicit LuaSnapshot(lua_State* L);
 
-    std::map<std::string, int> capture_values(lua_State* L) const;
-    void reset_to_baseline(lua_State* L, const std::map<std::string, int>& borrow_snap) const;
+  std::map<std::string, int> capture_values(lua_State* L) const;
+  void reset_to_baseline(lua_State* L, const std::map<std::string, int>& borrow_snap) const;
 
-private:
-    std::set<std::string> globals;
+ private:
+  std::set<std::string> globals;
 };
 
 class LuaVM {
-public:
-    LuaVM();
-    ~LuaVM();
+ public:
+  LuaVM();
+  ~LuaVM();
 
-    LuaVM(const LuaVM&) = delete;
-    LuaVM& operator=(const LuaVM&) = delete;
+  LuaVM(const LuaVM&) = delete;
+  LuaVM& operator=(const LuaVM&) = delete;
 
-    void load_script(const std::string& code, const std::string& op_name);
-    void set_global(const std::string& name, const JsonValue& value);
-    void set_global_table(const std::string& name, const std::vector<JsonValue>& values);
-    std::vector<JsonValue> call_function(const std::string& func_name, int nret, const std::string& op_name);
+  void load_script(const std::string& code, const std::string& op_name);
+  void set_global(const std::string& name, const JsonValue& value);
+  void set_global_table(const std::string& name, const std::vector<JsonValue>& values);
+  std::vector<JsonValue> call_function(const std::string& func_name, int nret, const std::string& op_name);
 
-    lua_State* state() const { return L_; }
+  lua_State* state() const {
+    return L_;
+  }
 
-private:
-    void push_value(const JsonValue& value);
-    JsonValue to_value(int index);
-    lua_State* L_;
+ private:
+  void push_value(const JsonValue& value);
+  JsonValue to_value(int index);
+  lua_State* L_;
 };
 
 }  // namespace lua

--- a/pine-cpp/src/lua/lua_pool.cpp
+++ b/pine-cpp/src/lua/lua_pool.cpp
@@ -5,142 +5,163 @@ namespace lua {
 
 StatePool::StatePool(std::string script, std::string op_name)
     : script_(std::move(script)), op_name_(std::move(op_name)) {
+  // Create the first state to validate the script and capture baseline
+  auto first = std::make_unique<LuaVM>();
+  first->load_script(script_, op_name_);
+  baseline_ = LuaSnapshot(first->state());
+  create_count_.fetch_add(1, std::memory_order_relaxed);
 
-    // Create the first state to validate the script and capture baseline
-    auto first = std::make_unique<LuaVM>();
-    first->load_script(script_, op_name_);
-    baseline_ = LuaSnapshot(first->state());
-    create_count_.fetch_add(1, std::memory_order_relaxed);
-
-    free_vms_.push_back(first.get());
-    all_vms_.push_back(std::move(first));
+  free_vms_.push_back(first.get());
+  all_vms_.push_back(std::move(first));
 }
 
 StatePool::~StatePool() {
-    std::lock_guard<std::mutex> lock(mu_);
-    closed_ = true;
-    // all_vms_ destruction cleans up LuaVMs
+  std::lock_guard<std::mutex> lock(mu_);
+  closed_ = true;
+  // all_vms_ destruction cleans up LuaVMs
 }
 
 void StatePool::Releaser::operator()(LuaVM* vm) const {
-    if (pool && vm) {
-        // Releaser is a unique_ptr deleter — invoked from ~unique_ptr,
-        // which is noexcept. release_vm() can throw if reset_to_baseline
-        // faults on a script-corrupted state; letting that exception cross
-        // the noexcept boundary triggers std::terminate.
-        // Counters and metrics are still updated inside release_vm's catch
-        // block before it rethrows, so swallowing here loses no observability.
-        try {
-            pool->release_vm(vm, snap);
-        } catch (...) {
-            // intentionally swallow: cannot propagate past unique_ptr dtor.
-        }
+  if (pool && vm) {
+    // Releaser is a unique_ptr deleter — invoked from ~unique_ptr,
+    // which is noexcept. release_vm() can throw if reset_to_baseline
+    // faults on a script-corrupted state; letting that exception cross
+    // the noexcept boundary triggers std::terminate.
+    // Counters and metrics are still updated inside release_vm's catch
+    // block before it rethrows, so swallowing here loses no observability.
+    try {
+      pool->release_vm(vm, snap);
+    } catch (...) {
+      // intentionally swallow: cannot propagate past unique_ptr dtor.
     }
+  }
 }
 
 StatePool::BorrowedVM StatePool::borrow() {
-    std::map<std::string, int> snap;
-    LuaVM* vm = acquire_vm(snap);
-    return BorrowedVM(vm, Releaser{this, std::move(snap)});
+  std::map<std::string, int> snap;
+  LuaVM* vm = acquire_vm(snap);
+  return BorrowedVM(vm, Releaser{this, std::move(snap)});
 }
 
 LuaVM* StatePool::acquire_vm(std::map<std::string, int>& out_snap) {
-    // Defer all counter / metric increments until we are certain the
-    // borrow will succeed AND capture_values has returned. The earlier
-    // implementation incremented atomics + Prometheus first, then could
-    // drop out of acquire via the closed path (which dec'd only the
-    // atomics, not the metric) or via a capture_values exception (which
-    // dec'd nothing — pool drift on every script-corrupted state).
-    LuaVM* vm = nullptr;
-    {
-        std::lock_guard<std::mutex> lock(mu_);
-        if (closed_) {
-            throw ExecutionError(op_name_, "lua pool is closed");
-        }
-        if (!free_vms_.empty()) {
-            vm = free_vms_.back();
-            free_vms_.pop_back();
-        } else {
-            auto fresh = std::make_unique<LuaVM>();
-            fresh->load_script(script_, op_name_);
-            vm = fresh.get();
-            all_vms_.push_back(std::move(fresh));
-            create_count_.fetch_add(1, std::memory_order_relaxed);
-            if (m_create_) m_create_->inc();
-        }
+  // Defer all counter / metric increments until we are certain the
+  // borrow will succeed AND capture_values has returned. The earlier
+  // implementation incremented atomics + Prometheus first, then could
+  // drop out of acquire via the closed path (which dec'd only the
+  // atomics, not the metric) or via a capture_values exception (which
+  // dec'd nothing — pool drift on every script-corrupted state).
+  LuaVM* vm = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (closed_) {
+      throw ExecutionError(op_name_, "lua pool is closed");
     }
-
-    // capture_values runs outside the pool mutex (it touches the VM only).
-    // If it throws (script corrupted the Lua state in a way we cannot
-    // snapshot), we must return the vm to free_vms_ — otherwise the vm
-    // gets stuck owned by all_vms_ with no one able to reclaim it, and
-    // pool size grows monotonically.
-    try {
-        out_snap = baseline_.capture_values(vm->state());
-    } catch (...) {
-        std::lock_guard<std::mutex> lock(mu_);
-        if (!closed_) free_vms_.push_back(vm);
-        throw;
+    if (!free_vms_.empty()) {
+      vm = free_vms_.back();
+      free_vms_.pop_back();
+    } else {
+      auto fresh = std::make_unique<LuaVM>();
+      fresh->load_script(script_, op_name_);
+      vm = fresh.get();
+      all_vms_.push_back(std::move(fresh));
+      create_count_.fetch_add(1, std::memory_order_relaxed);
+      if (m_create_) {
+        m_create_->inc();
+      }
     }
+  }
 
-    borrow_count_.fetch_add(1, std::memory_order_relaxed);
-    active_count_.fetch_add(1, std::memory_order_relaxed);
-    if (m_borrow_) m_borrow_->inc();
-    if (m_active_) m_active_->add(1);
+  // capture_values runs outside the pool mutex (it touches the VM only).
+  // If it throws (script corrupted the Lua state in a way we cannot
+  // snapshot), we must return the vm to free_vms_ — otherwise the vm
+  // gets stuck owned by all_vms_ with no one able to reclaim it, and
+  // pool size grows monotonically.
+  try {
+    out_snap = baseline_.capture_values(vm->state());
+  } catch (...) {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (!closed_) {
+      free_vms_.push_back(vm);
+    }
+    throw;
+  }
 
-    return vm;
+  borrow_count_.fetch_add(1, std::memory_order_relaxed);
+  active_count_.fetch_add(1, std::memory_order_relaxed);
+  if (m_borrow_) {
+    m_borrow_->inc();
+  }
+  if (m_active_) {
+    m_active_->add(1);
+  }
+
+  return vm;
 }
 
 void StatePool::release_vm(LuaVM* vm, const std::map<std::string, int>& snap) {
-    bool closed = false;
-    {
-        std::lock_guard<std::mutex> lock(mu_);
-        closed = closed_;
-    }
+  bool closed = false;
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    closed = closed_;
+  }
 
-    if (!closed) {
-        // reset_to_baseline can fault if the script wrecked the Lua state.
-        // If it throws we must NOT swallow — but we also must still update
-        // counters / metrics so they stay symmetric with acquire_vm. The
-        // vm is dropped (not pushed back) so a future borrow recreates it
-        // (create_count_ ticks up next time).
-        try {
-            baseline_.reset_to_baseline(vm->state(), snap);
-            std::lock_guard<std::mutex> lock(mu_);
-            if (!closed_) {
-                free_vms_.push_back(vm);
-            }
-        } catch (...) {
-            return_count_.fetch_add(1, std::memory_order_relaxed);
-            active_count_.fetch_sub(1, std::memory_order_relaxed);
-            if (m_return_) m_return_->inc();
-            if (m_active_) m_active_->add(-1);
-            throw;
-        }
+  if (!closed) {
+    // reset_to_baseline can fault if the script wrecked the Lua state.
+    // If it throws we must NOT swallow — but we also must still update
+    // counters / metrics so they stay symmetric with acquire_vm. The
+    // vm is dropped (not pushed back) so a future borrow recreates it
+    // (create_count_ ticks up next time).
+    try {
+      baseline_.reset_to_baseline(vm->state(), snap);
+      std::lock_guard<std::mutex> lock(mu_);
+      if (!closed_) {
+        free_vms_.push_back(vm);
+      }
+    } catch (...) {
+      return_count_.fetch_add(1, std::memory_order_relaxed);
+      active_count_.fetch_sub(1, std::memory_order_relaxed);
+      if (m_return_) {
+        m_return_->inc();
+      }
+      if (m_active_) {
+        m_active_->add(-1);
+      }
+      throw;
     }
+  }
 
-    return_count_.fetch_add(1, std::memory_order_relaxed);
-    active_count_.fetch_sub(1, std::memory_order_relaxed);
-    if (m_return_) m_return_->inc();
-    if (m_active_) m_active_->add(-1);
+  return_count_.fetch_add(1, std::memory_order_relaxed);
+  active_count_.fetch_sub(1, std::memory_order_relaxed);
+  if (m_return_) {
+    m_return_->inc();
+  }
+  if (m_active_) {
+    m_active_->add(-1);
+  }
 }
 
 std::map<std::string, int64_t> StatePool::stats_snapshot() const {
-    return {
-        {"borrow_count", borrow_count_.load(std::memory_order_relaxed)},
-        {"return_count", return_count_.load(std::memory_order_relaxed)},
-        {"create_count", create_count_.load(std::memory_order_relaxed)},
-        {"active_count", active_count_.load(std::memory_order_relaxed)},
-    };
+  return {
+      {"borrow_count", borrow_count_.load(std::memory_order_relaxed)},
+      {"return_count", return_count_.load(std::memory_order_relaxed)},
+      {"create_count", create_count_.load(std::memory_order_relaxed)},
+      {"active_count", active_count_.load(std::memory_order_relaxed)},
+  };
 }
 
 void StatePool::set_metrics(metrics::Provider* provider, const std::string& op_name) {
-    if (!provider) return;
-    std::vector<std::string> labels = {op_name};
-    m_borrow_ = provider->new_counter({"pine_lua_pool_borrow_total", "Total Lua state borrows.", {"operator"}})->with(labels);
-    m_return_ = provider->new_counter({"pine_lua_pool_return_total", "Total Lua state returns.", {"operator"}})->with(labels);
-    m_create_ = provider->new_counter({"pine_lua_pool_create_total", "Total Lua states created.", {"operator"}})->with(labels);
-    m_active_ = provider->new_gauge({"pine_lua_pool_active", "Lua states currently borrowed.", {"operator"}})->with(labels);
+  if (!provider) {
+    return;
+  }
+  std::vector<std::string> labels = {op_name};
+  m_borrow_ = provider->new_counter({"pine_lua_pool_borrow_total", "Total Lua state borrows.", {"operator"}})
+                  ->with(labels);
+  m_return_ = provider->new_counter({"pine_lua_pool_return_total", "Total Lua state returns.", {"operator"}})
+                  ->with(labels);
+  m_create_ = provider->new_counter({"pine_lua_pool_create_total", "Total Lua states created.", {"operator"}})
+                  ->with(labels);
+  m_active_ = provider->new_gauge({"pine_lua_pool_active", "Lua states currently borrowed.", {"operator"}})
+                  ->with(labels);
 }
 
 }  // namespace lua

--- a/pine-cpp/src/lua/lua_pool.hpp
+++ b/pine-cpp/src/lua/lua_pool.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "pine/pine.hpp"
 #include "pine/metrics.hpp"
-#include "lua/lua_bridge.hpp"
+#include "pine/pine.hpp"
 
 #include <atomic>
 #include <map>
@@ -11,55 +10,57 @@
 #include <string>
 #include <vector>
 
+#include "lua/lua_bridge.hpp"
+
 namespace pine {
 namespace lua {
 
 class StatePool {
-public:
-    explicit StatePool(std::string script, std::string op_name);
-    ~StatePool();
+ public:
+  explicit StatePool(std::string script, std::string op_name);
+  ~StatePool();
 
-    StatePool(const StatePool&) = delete;
-    StatePool& operator=(const StatePool&) = delete;
+  StatePool(const StatePool&) = delete;
+  StatePool& operator=(const StatePool&) = delete;
 
-    // Borrow returns a unique_ptr to a LuaVM that will be returned to the pool on destruction.
-    // The VM is reset to its baseline state automatically.
-    struct Releaser {
-        StatePool* pool;
-        std::map<std::string, int> snap;
-        void operator()(LuaVM* vm) const;
-    };
-    using BorrowedVM = std::unique_ptr<LuaVM, Releaser>;
+  // Borrow returns a unique_ptr to a LuaVM that will be returned to the pool on destruction.
+  // The VM is reset to its baseline state automatically.
+  struct Releaser {
+    StatePool* pool;
+    std::map<std::string, int> snap;
+    void operator()(LuaVM* vm) const;
+  };
+  using BorrowedVM = std::unique_ptr<LuaVM, Releaser>;
 
-    BorrowedVM borrow();
+  BorrowedVM borrow();
 
-    std::map<std::string, int64_t> stats_snapshot() const;
-    void set_metrics(metrics::Provider* provider, const std::string& op_name);
+  std::map<std::string, int64_t> stats_snapshot() const;
+  void set_metrics(metrics::Provider* provider, const std::string& op_name);
 
-private:
-    LuaVM* acquire_vm(std::map<std::string, int>& out_snap);
-    void release_vm(LuaVM* vm, const std::map<std::string, int>& snap);
+ private:
+  LuaVM* acquire_vm(std::map<std::string, int>& out_snap);
+  void release_vm(LuaVM* vm, const std::map<std::string, int>& snap);
 
-    std::string script_;
-    std::string op_name_;
-    LuaSnapshot baseline_;
+  std::string script_;
+  std::string op_name_;
+  LuaSnapshot baseline_;
 
-    std::mutex mu_;
-    std::vector<LuaVM*> free_vms_;
-    std::vector<std::unique_ptr<LuaVM>> all_vms_;
-    bool closed_ = false;
+  std::mutex mu_;
+  std::vector<LuaVM*> free_vms_;
+  std::vector<std::unique_ptr<LuaVM>> all_vms_;
+  bool closed_ = false;
 
-    // Fast atomics
-    std::atomic<int64_t> borrow_count_{0};
-    std::atomic<int64_t> return_count_{0};
-    std::atomic<int64_t> create_count_{0};
-    std::atomic<int64_t> active_count_{0};
+  // Fast atomics
+  std::atomic<int64_t> borrow_count_{0};
+  std::atomic<int64_t> return_count_{0};
+  std::atomic<int64_t> create_count_{0};
+  std::atomic<int64_t> active_count_{0};
 
-    // External metrics
-    metrics::Counter* m_borrow_ = nullptr;
-    metrics::Counter* m_return_ = nullptr;
-    metrics::Counter* m_create_ = nullptr;
-    metrics::Gauge* m_active_ = nullptr;
+  // External metrics
+  metrics::Counter* m_borrow_ = nullptr;
+  metrics::Counter* m_return_ = nullptr;
+  metrics::Counter* m_create_ = nullptr;
+  metrics::Gauge* m_active_ = nullptr;
 };
 
 }  // namespace lua

--- a/pine-cpp/src/redis/connection_pool.cpp
+++ b/pine-cpp/src/redis/connection_pool.cpp
@@ -4,47 +4,50 @@ namespace pine {
 namespace redis {
 
 std::unique_ptr<Client> ConnectionPool::acquire(const std::string& host, int port,
-                                                 const std::string& password, int db) {
-    Key key{host, port, password, db};
-    const auto now = std::chrono::steady_clock::now();
-    {
-        std::lock_guard<std::mutex> lk(mu_);
-        auto it = idle_.find(key);
-        if (it != idle_.end()) {
-            // Pop newest-first (LIFO) and drop anything that has been idle
-            // longer than kIdleTimeout. Stale handles are very likely
-            // closed by the broker side already; surfacing them as errors
-            // on first use defeats the purpose of pooling.
-            while (!it->second.empty()) {
-                auto entry = std::move(it->second.back());
-                it->second.pop_back();
-                if (now - entry.queued_at <= kIdleTimeout && entry.client->connected()) {
-                    return std::move(entry.client);
-                }
-                // entry.client destructs here, closing the stale socket.
-            }
+                                                const std::string& password, int db) {
+  Key key{host, port, password, db};
+  const auto now = std::chrono::steady_clock::now();
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto it = idle_.find(key);
+    if (it != idle_.end()) {
+      // Pop newest-first (LIFO) and drop anything that has been idle
+      // longer than kIdleTimeout. Stale handles are very likely
+      // closed by the broker side already; surfacing them as errors
+      // on first use defeats the purpose of pooling.
+      while (!it->second.empty()) {
+        auto entry = std::move(it->second.back());
+        it->second.pop_back();
+        if (now - entry.queued_at <= kIdleTimeout && entry.client->connected()) {
+          return std::move(entry.client);
         }
+        // entry.client destructs here, closing the stale socket.
+      }
     }
-    return std::make_unique<Client>(host, port, password, db);
+  }
+  return std::make_unique<Client>(host, port, password, db);
 }
 
-void ConnectionPool::release(const std::string& host, int port,
-                              const std::string& password, int db,
-                              std::unique_ptr<Client> c) {
-    if (!c || !c->connected()) return;
-    Key key{host, port, password, db};
-    std::lock_guard<std::mutex> lk(mu_);
-    auto& bucket = idle_[key];
-    // Bound the idle queue: a workload spike can push many handles into
-    // the pool; without the cap they sit there indefinitely, eating fd
-    // budget for a key that may never see traffic again.
-    if (bucket.size() >= kMaxIdlePerKey) return;  // c destructs here
-    bucket.push_back({std::move(c), std::chrono::steady_clock::now()});
+void ConnectionPool::release(const std::string& host, int port, const std::string& password, int db,
+                             std::unique_ptr<Client> c) {
+  if (!c || !c->connected()) {
+    return;
+  }
+  Key key{host, port, password, db};
+  std::lock_guard<std::mutex> lk(mu_);
+  auto& bucket = idle_[key];
+  // Bound the idle queue: a workload spike can push many handles into
+  // the pool; without the cap they sit there indefinitely, eating fd
+  // budget for a key that may never see traffic again.
+  if (bucket.size() >= kMaxIdlePerKey) {
+    return;  // c destructs here
+  }
+  bucket.push_back({std::move(c), std::chrono::steady_clock::now()});
 }
 
 ConnectionPool& shared_pool() {
-    static ConnectionPool pool;
-    return pool;
+  static ConnectionPool pool;
+  return pool;
 }
 
 }  // namespace redis

--- a/pine-cpp/src/redis/connection_pool.hpp
+++ b/pine-cpp/src/redis/connection_pool.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "redis/redis_client.hpp"
-
 #include <chrono>
 #include <map>
 #include <memory>
@@ -9,6 +7,8 @@
 #include <string>
 #include <tuple>
 #include <vector>
+
+#include "redis/redis_client.hpp"
 
 namespace pine {
 namespace redis {
@@ -31,97 +31,118 @@ namespace redis {
 // still a follow-up; the timestamp + connected() check covers most
 // silent-broker-close cases.
 class ConnectionPool {
-public:
-    static constexpr std::size_t kMaxIdlePerKey = 16;
-    static constexpr std::chrono::seconds kIdleTimeout{60};
+ public:
+  static constexpr std::size_t kMaxIdlePerKey = 16;
+  static constexpr std::chrono::seconds kIdleTimeout{60};
 
-    ConnectionPool() = default;
-    ~ConnectionPool() = default;
+  ConnectionPool() = default;
+  ~ConnectionPool() = default;
 
-    ConnectionPool(const ConnectionPool&) = delete;
-    ConnectionPool& operator=(const ConnectionPool&) = delete;
+  ConnectionPool(const ConnectionPool&) = delete;
+  ConnectionPool& operator=(const ConnectionPool&) = delete;
 
-    // Borrow a connection. May construct a new client if none is idle.
-    std::unique_ptr<Client> acquire(const std::string& host, int port,
-                                    const std::string& password, int db);
+  // Borrow a connection. May construct a new client if none is idle.
+  std::unique_ptr<Client> acquire(const std::string& host, int port, const std::string& password, int db);
 
-    // Return a connection to the idle queue. The caller must not reuse
-    // the pointer afterward. If the connection is in a broken state
-    // (`!c->connected()`) it is destroyed instead of returned.
-    void release(const std::string& host, int port,
-                 const std::string& password, int db,
-                 std::unique_ptr<Client> c);
+  // Return a connection to the idle queue. The caller must not reuse
+  // the pointer afterward. If the connection is in a broken state
+  // (`!c->connected()`) it is destroyed instead of returned.
+  void release(const std::string& host, int port, const std::string& password, int db,
+               std::unique_ptr<Client> c);
 
-    // ScopedClient is the RAII handle returned by acquire_scoped. It owns
-    // the Client and bundles the pool + key so the destructor can release
-    // back without the caller wiring up a per-operator guard. Moved-from
-    // instances are inert.
-    class ScopedClient {
-    public:
-        ScopedClient() = default;
-        ScopedClient(ConnectionPool* pool,
-                     std::string host, int port,
-                     std::string password, int db,
-                     std::unique_ptr<Client> client)
-            : pool_(pool), host_(std::move(host)), port_(port),
-              password_(std::move(password)), db_(db),
-              client_(std::move(client)) {}
-
-        ScopedClient(const ScopedClient&) = delete;
-        ScopedClient& operator=(const ScopedClient&) = delete;
-
-        ScopedClient(ScopedClient&& o) noexcept
-            : pool_(o.pool_), host_(std::move(o.host_)), port_(o.port_),
-              password_(std::move(o.password_)), db_(o.db_),
-              client_(std::move(o.client_)) { o.pool_ = nullptr; }
-
-        ScopedClient& operator=(ScopedClient&& o) noexcept {
-            if (this == &o) return *this;
-            release_now();
-            pool_ = o.pool_; o.pool_ = nullptr;
-            host_ = std::move(o.host_); port_ = o.port_;
-            password_ = std::move(o.password_); db_ = o.db_;
-            client_ = std::move(o.client_);
-            return *this;
-        }
-
-        ~ScopedClient() { release_now(); }
-
-        Client* get() const noexcept { return client_.get(); }
-        Client* operator->() const noexcept { return client_.get(); }
-        explicit operator bool() const noexcept { return static_cast<bool>(client_); }
-
-    private:
-        void release_now() {
-            if (pool_ && client_) pool_->release(host_, port_, password_, db_, std::move(client_));
-        }
-
-        ConnectionPool* pool_ = nullptr;
-        std::string host_;
-        int port_ = 0;
-        std::string password_;
-        int db_ = 0;
-        std::unique_ptr<Client> client_;
-    };
-
-    // Convenience: acquire + bundle into a ScopedClient that releases on
-    // scope exit. Returns an empty ScopedClient if the underlying acquire
-    // returned null (connection failure).
-    ScopedClient acquire_scoped(const std::string& host, int port,
-                                const std::string& password, int db) {
-        auto c = acquire(host, port, password, db);
-        if (!c) return ScopedClient{};
-        return ScopedClient{this, host, port, password, db, std::move(c)};
+  // ScopedClient is the RAII handle returned by acquire_scoped. It owns
+  // the Client and bundles the pool + key so the destructor can release
+  // back without the caller wiring up a per-operator guard. Moved-from
+  // instances are inert.
+  class ScopedClient {
+   public:
+    ScopedClient() = default;
+    ScopedClient(ConnectionPool* pool, std::string host, int port, std::string password, int db,
+                 std::unique_ptr<Client> client)
+        : pool_(pool),
+          host_(std::move(host)),
+          port_(port),
+          password_(std::move(password)),
+          db_(db),
+          client_(std::move(client)) {
     }
 
-private:
-    using Key = std::tuple<std::string, int, std::string, int>;
-    struct IdleEntry {
-        std::unique_ptr<Client> client;
-        std::chrono::steady_clock::time_point queued_at;
-    };
-    std::mutex mu_;
-    std::map<Key, std::vector<IdleEntry>> idle_;
+    ScopedClient(const ScopedClient&) = delete;
+    ScopedClient& operator=(const ScopedClient&) = delete;
+
+    ScopedClient(ScopedClient&& o) noexcept
+        : pool_(o.pool_),
+          host_(std::move(o.host_)),
+          port_(o.port_),
+          password_(std::move(o.password_)),
+          db_(o.db_),
+          client_(std::move(o.client_)) {
+      o.pool_ = nullptr;
+    }
+
+    ScopedClient& operator=(ScopedClient&& o) noexcept {
+      if (this == &o) {
+        return *this;
+      }
+      release_now();
+      pool_ = o.pool_;
+      o.pool_ = nullptr;
+      host_ = std::move(o.host_);
+      port_ = o.port_;
+      password_ = std::move(o.password_);
+      db_ = o.db_;
+      client_ = std::move(o.client_);
+      return *this;
+    }
+
+    ~ScopedClient() {
+      release_now();
+    }
+
+    Client* get() const noexcept {
+      return client_.get();
+    }
+    Client* operator->() const noexcept {
+      return client_.get();
+    }
+    explicit operator bool() const noexcept {
+      return static_cast<bool>(client_);
+    }
+
+   private:
+    void release_now() {
+      if (pool_ && client_) {
+        pool_->release(host_, port_, password_, db_, std::move(client_));
+      }
+    }
+
+    ConnectionPool* pool_ = nullptr;
+    std::string host_;
+    int port_ = 0;
+    std::string password_;
+    int db_ = 0;
+    std::unique_ptr<Client> client_;
+  };
+
+  // Convenience: acquire + bundle into a ScopedClient that releases on
+  // scope exit. Returns an empty ScopedClient if the underlying acquire
+  // returned null (connection failure).
+  ScopedClient acquire_scoped(const std::string& host, int port, const std::string& password, int db) {
+    auto c = acquire(host, port, password, db);
+    if (!c) {
+      return ScopedClient{};
+    }
+    return ScopedClient{this, host, port, password, db, std::move(c)};
+  }
+
+ private:
+  using Key = std::tuple<std::string, int, std::string, int>;
+  struct IdleEntry {
+    std::unique_ptr<Client> client;
+    std::chrono::steady_clock::time_point queued_at;
+  };
+  std::mutex mu_;
+  std::map<Key, std::vector<IdleEntry>> idle_;
 };
 
 // Process-wide pool. Lives as long as the binary; suitable for both the

--- a/pine-cpp/src/redis/redis_client.cpp
+++ b/pine-cpp/src/redis/redis_client.cpp
@@ -17,294 +17,394 @@ namespace redis {
 namespace {
 
 std::string encode_bulk(const std::string& s) {
-    return "$" + std::to_string(s.size()) + "\r\n" + s + "\r\n";
+  return "$" + std::to_string(s.size()) + "\r\n" + s + "\r\n";
 }
 
 std::string encode_command(const std::vector<std::string>& args) {
-    std::string out = "*" + std::to_string(args.size()) + "\r\n";
-    for (const auto& arg : args) out += encode_bulk(arg);
-    return out;
+  std::string out = "*" + std::to_string(args.size()) + "\r\n";
+  for (const auto& arg : args) {
+    out += encode_bulk(arg);
+  }
+  return out;
 }
 
 }  // namespace
 
 Client::Client(const std::string& host, int port, const std::string& password, int db) {
-    struct addrinfo hints{}, *result = nullptr;
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
+  struct addrinfo hints{}, *result = nullptr;
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
 
-    std::string port_str = std::to_string(port);
-    int rc = getaddrinfo(host.c_str(), port_str.c_str(), &hints, &result);
-    if (rc != 0) return;
+  std::string port_str = std::to_string(port);
+  int rc = getaddrinfo(host.c_str(), port_str.c_str(), &hints, &result);
+  if (rc != 0) {
+    return;
+  }
 
-    for (auto* rp = result; rp != nullptr; rp = rp->ai_next) {
-        fd_ = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-        if (fd_ < 0) continue;
-
-        struct timeval tv{};
-        tv.tv_sec = 2;
-        setsockopt(fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-        setsockopt(fd_, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
-
-        if (connect(fd_, rp->ai_addr, rp->ai_addrlen) == 0) break;
-        close(fd_);
-        fd_ = -1;
+  for (auto* rp = result; rp != nullptr; rp = rp->ai_next) {
+    fd_ = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    if (fd_ < 0) {
+      continue;
     }
-    freeaddrinfo(result);
 
-    if (fd_ < 0) return;
+    struct timeval tv{};
+    tv.tv_sec = 2;
+    setsockopt(fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(fd_, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 
-    if (!password.empty()) {
-        send_command({"AUTH", password});
-        expect_ok();
+    if (connect(fd_, rp->ai_addr, rp->ai_addrlen) == 0) {
+      break;
     }
-    if (db != 0) {
-        send_command({"SELECT", std::to_string(db)});
-        expect_ok();
-    }
+    close(fd_);
+    fd_ = -1;
+  }
+  freeaddrinfo(result);
+
+  if (fd_ < 0) {
+    return;
+  }
+
+  if (!password.empty()) {
+    send_command({"AUTH", password});
+    expect_ok();
+  }
+  if (db != 0) {
+    send_command({"SELECT", std::to_string(db)});
+    expect_ok();
+  }
 }
 
 Client::~Client() {
-    if (fd_ >= 0) close(fd_);
+  if (fd_ >= 0) {
+    close(fd_);
+  }
 }
 
-bool Client::connected() const { return fd_ >= 0; }
+bool Client::connected() const {
+  return fd_ >= 0;
+}
 
 void Client::send_command(const std::vector<std::string>& args) {
-    std::string data = encode_command(args);
-    const char* ptr = data.c_str();
-    std::size_t remaining = data.size();
-    while (remaining > 0) {
-        ssize_t n = write(fd_, ptr, remaining);
-        if (n <= 0) throw std::runtime_error("redis write failed");
-        ptr += n;
-        remaining -= static_cast<std::size_t>(n);
+  std::string data = encode_command(args);
+  const char* ptr = data.c_str();
+  std::size_t remaining = data.size();
+  while (remaining > 0) {
+    ssize_t n = write(fd_, ptr, remaining);
+    if (n <= 0) {
+      throw std::runtime_error("redis write failed");
     }
+    ptr += n;
+    remaining -= static_cast<std::size_t>(n);
+  }
 }
 
 std::string Client::read_line() {
-    std::string line;
-    for (;;) {
-        char c = read_byte();
-        if (c == '\r') {
-            char lf = read_byte();
-            if (lf != '\n') throw std::runtime_error("redis protocol error");
-            return line;
-        }
-        line.push_back(c);
+  std::string line;
+  for (;;) {
+    char c = read_byte();
+    if (c == '\r') {
+      char lf = read_byte();
+      if (lf != '\n') {
+        throw std::runtime_error("redis protocol error");
+      }
+      return line;
     }
+    line.push_back(c);
+  }
 }
 
-char Client::read_type() { return read_byte(); }
+char Client::read_type() {
+  return read_byte();
+}
 
 void Client::ensure_bytes(std::size_t need) {
-    while (read_buf_.size() - read_pos_ < need) {
-        if (read_pos_ > 0 && read_pos_ == read_buf_.size()) {
-            // Buffer fully drained; reset to avoid unbounded growth.
-            read_buf_.clear();
-            read_pos_ = 0;
-        }
-        char chunk[4096];
-        ssize_t n = read(fd_, chunk, sizeof(chunk));
-        if (n <= 0) throw std::runtime_error("redis read failed");
-        read_buf_.append(chunk, static_cast<std::size_t>(n));
+  while (read_buf_.size() - read_pos_ < need) {
+    if (read_pos_ > 0 && read_pos_ == read_buf_.size()) {
+      // Buffer fully drained; reset to avoid unbounded growth.
+      read_buf_.clear();
+      read_pos_ = 0;
     }
+    char chunk[4096];
+    ssize_t n = read(fd_, chunk, sizeof(chunk));
+    if (n <= 0) {
+      throw std::runtime_error("redis read failed");
+    }
+    read_buf_.append(chunk, static_cast<std::size_t>(n));
+  }
 }
 
 char Client::read_byte() {
-    ensure_bytes(1);
-    return read_buf_[read_pos_++];
+  ensure_bytes(1);
+  return read_buf_[read_pos_++];
 }
 
 void Client::read_into(char* dst, std::size_t n) {
-    while (n > 0) {
-        std::size_t avail = read_buf_.size() - read_pos_;
-        if (avail == 0) {
-            // Drain directly into the caller buffer — no per-syscall 4 KB
-            // staging copy. The previous variant read into a stack chunk
-            // and memcpy'd out, paying 2× memory traffic on every large
-            // bulk read.
-            ssize_t got = read(fd_, dst, n);
-            if (got <= 0) throw std::runtime_error("redis read failed");
-            dst += got;
-            n -= static_cast<std::size_t>(got);
-            continue;
-        }
-        std::size_t take = std::min(avail, n);
-        std::memcpy(dst, read_buf_.data() + read_pos_, take);
-        read_pos_ += take;
-        dst += take;
-        n -= take;
+  while (n > 0) {
+    std::size_t avail = read_buf_.size() - read_pos_;
+    if (avail == 0) {
+      // Drain directly into the caller buffer — no per-syscall 4 KB
+      // staging copy. The previous variant read into a stack chunk
+      // and memcpy'd out, paying 2× memory traffic on every large
+      // bulk read.
+      ssize_t got = read(fd_, dst, n);
+      if (got <= 0) {
+        throw std::runtime_error("redis read failed");
+      }
+      dst += got;
+      n -= static_cast<std::size_t>(got);
+      continue;
     }
+    std::size_t take = std::min(avail, n);
+    std::memcpy(dst, read_buf_.data() + read_pos_, take);
+    read_pos_ += take;
+    dst += take;
+    n -= take;
+  }
 }
 
 std::string Client::read_simple_string() {
-    return read_line();
+  return read_line();
 }
 
 std::string Client::read_error() {
-    return read_line();
+  return read_line();
 }
 
 int64_t Client::read_integer() {
-    std::string line = read_line();
-    return std::stoll(line);
+  std::string line = read_line();
+  return std::stoll(line);
 }
 
 std::optional<std::string> Client::read_bulk_string() {
-    std::string len_str = read_line();
-    int len = std::stoi(len_str);
-    if (len < 0) return std::nullopt;
-    std::string data(static_cast<std::size_t>(len), '\0');
-    if (len > 0) read_into(&data[0], static_cast<std::size_t>(len));
-    char cr = read_byte();
-    char lf = read_byte();
-    if (cr != '\r' || lf != '\n') {
-        throw std::runtime_error("redis protocol error: missing CRLF after bulk");
-    }
-    return data;
+  std::string len_str = read_line();
+  int len = std::stoi(len_str);
+  if (len < 0) {
+    return std::nullopt;
+  }
+  std::string data(static_cast<std::size_t>(len), '\0');
+  if (len > 0) {
+    read_into(&data[0], static_cast<std::size_t>(len));
+  }
+  char cr = read_byte();
+  char lf = read_byte();
+  if (cr != '\r' || lf != '\n') {
+    throw std::runtime_error("redis protocol error: missing CRLF after bulk");
+  }
+  return data;
 }
 
 std::vector<std::optional<std::string>> Client::read_array() {
-    std::string count_str = read_line();
-    int count = std::stoi(count_str);
-    if (count < 0) return {};
-    std::vector<std::optional<std::string>> result;
-    for (int i = 0; i < count; ++i) {
-        char type = read_type();
-        switch (type) {
-            case '$': result.push_back(read_bulk_string()); break;
-            case '+': result.push_back(read_simple_string()); break;
-            case ':': result.push_back(std::to_string(read_integer())); break;
-            case '-': throw std::runtime_error("redis error: " + read_error());
-            default: throw std::runtime_error("redis: unexpected type in array");
-        }
+  std::string count_str = read_line();
+  int count = std::stoi(count_str);
+  if (count < 0) {
+    return {};
+  }
+  std::vector<std::optional<std::string>> result;
+  for (int i = 0; i < count; ++i) {
+    char type = read_type();
+    switch (type) {
+      case '$':
+        result.push_back(read_bulk_string());
+        break;
+      case '+':
+        result.push_back(read_simple_string());
+        break;
+      case ':':
+        result.push_back(std::to_string(read_integer()));
+        break;
+      case '-':
+        throw std::runtime_error("redis error: " + read_error());
+      default:
+        throw std::runtime_error("redis: unexpected type in array");
     }
-    return result;
+  }
+  return result;
 }
 
 void Client::expect_ok() {
-    char type = read_type();
-    switch (type) {
-        case '+': read_line(); break;
-        case '-': throw std::runtime_error("redis error: " + read_error());
-        case '$': read_bulk_string(); break;
-        case ':': read_integer(); break;
-        default: throw std::runtime_error("redis: unexpected response type");
-    }
+  char type = read_type();
+  switch (type) {
+    case '+':
+      read_line();
+      break;
+    case '-':
+      throw std::runtime_error("redis error: " + read_error());
+    case '$':
+      read_bulk_string();
+      break;
+    case ':':
+      read_integer();
+      break;
+    default:
+      throw std::runtime_error("redis: unexpected response type");
+  }
 }
 
 std::optional<std::string> Client::get(const std::string& key) {
-    send_command({"GET", key});
-    char type = read_type();
-    if (type == '$') return read_bulk_string();
-    if (type == '-') throw std::runtime_error("redis error: " + read_error());
-    if (type == '+') return read_simple_string();
-    throw std::runtime_error("redis: unexpected response type for GET");
+  send_command({"GET", key});
+  char type = read_type();
+  if (type == '$') {
+    return read_bulk_string();
+  }
+  if (type == '-') {
+    throw std::runtime_error("redis error: " + read_error());
+  }
+  if (type == '+') {
+    return read_simple_string();
+  }
+  throw std::runtime_error("redis: unexpected response type for GET");
 }
 
 void Client::set(const std::string& key, const std::string& value, int ttl_seconds) {
-    if (ttl_seconds > 0) {
-        send_command({"SET", key, value, "EX", std::to_string(ttl_seconds)});
-    } else {
-        send_command({"SET", key, value});
-    }
-    expect_ok();
+  if (ttl_seconds > 0) {
+    send_command({"SET", key, value, "EX", std::to_string(ttl_seconds)});
+  } else {
+    send_command({"SET", key, value});
+  }
+  expect_ok();
 }
 
 std::vector<std::string> Client::smembers(const std::string& key) {
-    send_command({"SMEMBERS", key});
-    char type = read_type();
-    if (type == '*') {
-        auto arr = read_array();
-        std::vector<std::string> result;
-        for (auto& item : arr) {
-            if (item) result.push_back(std::move(*item));
-        }
-        return result;
+  send_command({"SMEMBERS", key});
+  char type = read_type();
+  if (type == '*') {
+    auto arr = read_array();
+    std::vector<std::string> result;
+    for (auto& item : arr) {
+      if (item) {
+        result.push_back(std::move(*item));
+      }
     }
-    if (type == '-') throw std::runtime_error("redis error: " + read_error());
-    throw std::runtime_error("redis: unexpected response type for SMEMBERS");
+    return result;
+  }
+  if (type == '-') {
+    throw std::runtime_error("redis error: " + read_error());
+  }
+  throw std::runtime_error("redis: unexpected response type for SMEMBERS");
 }
 
 void Client::sadd(const std::string& key, const std::vector<std::string>& members) {
-    std::vector<std::string> args = {"SADD", key};
-    for (const auto& m : members) args.push_back(m);
-    send_command(args);
-    char type = read_type();
-    if (type == ':') { read_integer(); return; }
-    if (type == '-') throw std::runtime_error("redis error: " + read_error());
-    throw std::runtime_error("redis: unexpected response type for SADD");
+  std::vector<std::string> args = {"SADD", key};
+  for (const auto& m : members) {
+    args.push_back(m);
+  }
+  send_command(args);
+  char type = read_type();
+  if (type == ':') {
+    read_integer();
+    return;
+  }
+  if (type == '-') {
+    throw std::runtime_error("redis error: " + read_error());
+  }
+  throw std::runtime_error("redis: unexpected response type for SADD");
 }
 
 std::vector<std::string> Client::lrange(const std::string& key, int start, int stop) {
-    send_command({"LRANGE", key, std::to_string(start), std::to_string(stop)});
-    char type = read_type();
-    if (type == '*') {
-        auto arr = read_array();
-        std::vector<std::string> result;
-        for (auto& item : arr) {
-            if (item) result.push_back(std::move(*item));
-        }
-        return result;
+  send_command({"LRANGE", key, std::to_string(start), std::to_string(stop)});
+  char type = read_type();
+  if (type == '*') {
+    auto arr = read_array();
+    std::vector<std::string> result;
+    for (auto& item : arr) {
+      if (item) {
+        result.push_back(std::move(*item));
+      }
     }
-    if (type == '-') throw std::runtime_error("redis error: " + read_error());
-    throw std::runtime_error("redis: unexpected response type for LRANGE");
+    return result;
+  }
+  if (type == '-') {
+    throw std::runtime_error("redis error: " + read_error());
+  }
+  throw std::runtime_error("redis: unexpected response type for LRANGE");
 }
 
 void Client::rpush(const std::string& key, const std::vector<std::string>& values) {
-    std::vector<std::string> args = {"RPUSH", key};
-    for (const auto& v : values) args.push_back(v);
-    send_command(args);
-    char type = read_type();
-    if (type == ':') { read_integer(); return; }
-    if (type == '-') throw std::runtime_error("redis error: " + read_error());
-    throw std::runtime_error("redis: unexpected response type for RPUSH");
+  std::vector<std::string> args = {"RPUSH", key};
+  for (const auto& v : values) {
+    args.push_back(v);
+  }
+  send_command(args);
+  char type = read_type();
+  if (type == ':') {
+    read_integer();
+    return;
+  }
+  if (type == '-') {
+    throw std::runtime_error("redis error: " + read_error());
+  }
+  throw std::runtime_error("redis: unexpected response type for RPUSH");
 }
 
 void Client::del(const std::string& key) {
-    send_command({"DEL", key});
-    char type = read_type();
-    if (type == ':') { read_integer(); return; }
-    if (type == '-') throw std::runtime_error("redis error: " + read_error());
-    throw std::runtime_error("redis: unexpected response type for DEL");
+  send_command({"DEL", key});
+  char type = read_type();
+  if (type == ':') {
+    read_integer();
+    return;
+  }
+  if (type == '-') {
+    throw std::runtime_error("redis error: " + read_error());
+  }
+  throw std::runtime_error("redis: unexpected response type for DEL");
 }
 
 void Client::expire(const std::string& key, int seconds) {
-    send_command({"EXPIRE", key, std::to_string(seconds)});
-    char type = read_type();
-    if (type == ':') { read_integer(); return; }
-    if (type == '-') throw std::runtime_error("redis error: " + read_error());
-    throw std::runtime_error("redis: unexpected response type for EXPIRE");
+  send_command({"EXPIRE", key, std::to_string(seconds)});
+  char type = read_type();
+  if (type == ':') {
+    read_integer();
+    return;
+  }
+  if (type == '-') {
+    throw std::runtime_error("redis error: " + read_error());
+  }
+  throw std::runtime_error("redis: unexpected response type for EXPIRE");
 }
 
 void Client::write_multiexec(const std::vector<std::vector<std::string>>& command_args_list) {
-    send_command({"MULTI"});
-    char type = read_type();
-    if (type == '-') throw std::runtime_error("redis error: " + read_error());
-    if (type == '+') { read_line(); } else { throw std::runtime_error("redis: unexpected MULTI response"); }
+  send_command({"MULTI"});
+  char type = read_type();
+  if (type == '-') {
+    throw std::runtime_error("redis error: " + read_error());
+  }
+  if (type == '+') {
+    read_line();
+  } else {
+    throw std::runtime_error("redis: unexpected MULTI response");
+  }
 
-    for (const auto& args : command_args_list) {
-        send_command(args);
-        type = read_type();
-        if (type == '-') {
-            std::string err = read_error();
-            // Try to abort transaction if possible
-            try { send_command({"DISCARD"}); read_line(); } catch (...) {}
-            throw std::runtime_error("redis error: " + err);
-        }
-        if (type == '+') { read_line(); } else { throw std::runtime_error("redis: unexpected queued response"); }
-    }
-
-    send_command({"EXEC"});
+  for (const auto& args : command_args_list) {
+    send_command(args);
     type = read_type();
-    if (type == '*') {
-        // Read and discard EXEC results
-        read_array();
-        return;
+    if (type == '-') {
+      std::string err = read_error();
+      // Try to abort transaction if possible
+      try {
+        send_command({"DISCARD"});
+        read_line();
+      } catch (...) {
+      }
+      throw std::runtime_error("redis error: " + err);
     }
-    if (type == '-') throw std::runtime_error("redis error: " + read_error());
-    throw std::runtime_error("redis: unexpected response type for EXEC");
+    if (type == '+') {
+      read_line();
+    } else {
+      throw std::runtime_error("redis: unexpected queued response");
+    }
+  }
+
+  send_command({"EXEC"});
+  type = read_type();
+  if (type == '*') {
+    // Read and discard EXEC results
+    read_array();
+    return;
+  }
+  if (type == '-') {
+    throw std::runtime_error("redis error: " + read_error());
+  }
+  throw std::runtime_error("redis: unexpected response type for EXEC");
 }
 
 }  // namespace redis

--- a/pine-cpp/src/redis/redis_client.hpp
+++ b/pine-cpp/src/redis/redis_client.hpp
@@ -8,51 +8,51 @@ namespace pine {
 namespace redis {
 
 class Client {
-public:
-    Client(const std::string& host, int port, const std::string& password = "", int db = 0);
-    ~Client();
+ public:
+  Client(const std::string& host, int port, const std::string& password = "", int db = 0);
+  ~Client();
 
-    Client(const Client&) = delete;
-    Client& operator=(const Client&) = delete;
+  Client(const Client&) = delete;
+  Client& operator=(const Client&) = delete;
 
-    bool connected() const;
+  bool connected() const;
 
-    std::optional<std::string> get(const std::string& key);
-    void set(const std::string& key, const std::string& value, int ttl_seconds = 0);
+  std::optional<std::string> get(const std::string& key);
+  void set(const std::string& key, const std::string& value, int ttl_seconds = 0);
 
-    std::vector<std::string> smembers(const std::string& key);
-    void sadd(const std::string& key, const std::vector<std::string>& members);
+  std::vector<std::string> smembers(const std::string& key);
+  void sadd(const std::string& key, const std::vector<std::string>& members);
 
-    std::vector<std::string> lrange(const std::string& key, int start, int stop);
-    void rpush(const std::string& key, const std::vector<std::string>& values);
+  std::vector<std::string> lrange(const std::string& key, int start, int stop);
+  void rpush(const std::string& key, const std::vector<std::string>& values);
 
-    void del(const std::string& key);
-    void expire(const std::string& key, int seconds);
+  void del(const std::string& key);
+  void expire(const std::string& key, int seconds);
 
-    // Multi-Exec helper to wrap write operations under an atomic transaction
-    void write_multiexec(const std::vector<std::vector<std::string>>& command_args_list);
+  // Multi-Exec helper to wrap write operations under an atomic transaction
+  void write_multiexec(const std::vector<std::vector<std::string>>& command_args_list);
 
-private:
-    int fd_ = -1;
-    // Read buffer to avoid one syscall per byte on response parsing.
-    // Sized to a single typical Redis read response (8 KB). The buffer is
-    // refilled lazily when the next read needs more bytes than are
-    // currently available.
-    std::string read_buf_;
-    std::size_t read_pos_ = 0;
-    void ensure_bytes(std::size_t need);
-    char read_byte();
-    void read_into(char* dst, std::size_t n);
+ private:
+  int fd_ = -1;
+  // Read buffer to avoid one syscall per byte on response parsing.
+  // Sized to a single typical Redis read response (8 KB). The buffer is
+  // refilled lazily when the next read needs more bytes than are
+  // currently available.
+  std::string read_buf_;
+  std::size_t read_pos_ = 0;
+  void ensure_bytes(std::size_t need);
+  char read_byte();
+  void read_into(char* dst, std::size_t n);
 
-    void send_command(const std::vector<std::string>& args);
-    std::string read_line();
-    char read_type();
-    std::string read_simple_string();
-    std::string read_error();
-    int64_t read_integer();
-    std::optional<std::string> read_bulk_string();
-    std::vector<std::optional<std::string>> read_array();
-    void expect_ok();
+  void send_command(const std::vector<std::string>& args);
+  std::string read_line();
+  char read_type();
+  std::string read_simple_string();
+  std::string read_error();
+  int64_t read_integer();
+  std::optional<std::string> read_bulk_string();
+  std::vector<std::optional<std::string>> read_array();
+  void expect_ok();
 };
 
 }  // namespace redis

--- a/pine-cpp/src/registry/registry.cpp
+++ b/pine-cpp/src/registry/registry.cpp
@@ -1,5 +1,5 @@
-#include "pine/pine.hpp"
 #include "pine/operator.hpp"
+#include "pine/pine.hpp"
 
 #include <algorithm>
 #include <map>
@@ -12,27 +12,39 @@ namespace pine {
 // --- op_type helpers ---
 
 const char* op_type_to_string(OpType t) {
-    switch (t) {
-        case OpType::Recall:    return "recall";
-        case OpType::Transform: return "transform";
-        case OpType::Filter:    return "filter";
-        case OpType::Merge:     return "merge";
-        case OpType::Reorder:   return "reorder";
-        case OpType::Observe:   return "observe";
-    }
-    return "unknown";
+  switch (t) {
+    case OpType::Recall:
+      return "recall";
+    case OpType::Transform:
+      return "transform";
+    case OpType::Filter:
+      return "filter";
+    case OpType::Merge:
+      return "merge";
+    case OpType::Reorder:
+      return "reorder";
+    case OpType::Observe:
+      return "observe";
+  }
+  return "unknown";
 }
 
 const char* op_type_to_schema_string(OpType t) {
-    switch (t) {
-        case OpType::Recall:    return "Recall";
-        case OpType::Transform: return "Transform";
-        case OpType::Filter:    return "Filter";
-        case OpType::Merge:     return "Merge";
-        case OpType::Reorder:   return "Reorder";
-        case OpType::Observe:   return "Observe";
-    }
-    return "Unknown";
+  switch (t) {
+    case OpType::Recall:
+      return "Recall";
+    case OpType::Transform:
+      return "Transform";
+    case OpType::Filter:
+      return "Filter";
+    case OpType::Merge:
+      return "Merge";
+    case OpType::Reorder:
+      return "Reorder";
+    case OpType::Observe:
+      return "Observe";
+  }
+  return "Unknown";
 }
 
 namespace {
@@ -42,116 +54,125 @@ namespace {
 // library may fire before any other translation unit, so we cannot rely on
 // file-scope statics being initialized first.
 std::shared_mutex& registry_mu() {
-    static std::shared_mutex m;
-    return m;
+  static std::shared_mutex m;
+  return m;
 }
 
 std::map<std::string, OperatorEntry>& registry_map() {
-    static std::map<std::string, OperatorEntry> m;
-    return m;
+  static std::map<std::string, OperatorEntry> m;
+  return m;
 }
 
 }  // namespace
 
-void register_operator_with_traits(OperatorSchema schema,
-                                   OperatorFactory factory,
-                                   bool consumes_row_set,
-                                   bool mutates_row_set,
-                                   bool additive_writes_row_set,
-                                   bool concurrent_safe) {
-    if (schema.name.empty()) {
-        throw RegistryError("pine: register_operator_with_traits called with empty name");
+void register_operator_with_traits(OperatorSchema schema, OperatorFactory factory, bool consumes_row_set,
+                                   bool mutates_row_set, bool additive_writes_row_set, bool concurrent_safe) {
+  if (schema.name.empty()) {
+    throw RegistryError("pine: register_operator_with_traits called with empty name");
+  }
+  if (schema.description.empty()) {
+    throw RegistryError("pine: operator \"" + schema.name + "\": description is required");
+  }
+  for (const auto& [pname, pschema] : schema.params) {
+    if (pschema.description.empty()) {
+      throw RegistryError("pine: operator \"" + schema.name + "\" param \"" + pname +
+                          "\": description is required");
     }
-    if (schema.description.empty()) {
-        throw RegistryError("pine: operator \"" + schema.name + "\": description is required");
-    }
-    for (const auto& [pname, pschema] : schema.params) {
-        if (pschema.description.empty()) {
-            throw RegistryError("pine: operator \"" + schema.name + "\" param \"" + pname +
-                                "\": description is required");
-        }
-    }
-    if (!factory) {
-        throw RegistryError("pine: operator \"" + schema.name + "\": factory must not be null");
-    }
+  }
+  if (!factory) {
+    throw RegistryError("pine: operator \"" + schema.name + "\": factory must not be null");
+  }
 
-    OperatorEntry entry;
-    entry.schema = std::move(schema);
-    entry.factory = std::move(factory);
-    entry.consumes_row_set        = consumes_row_set;
-    entry.mutates_row_set         = mutates_row_set;
-    entry.additive_writes_row_set = additive_writes_row_set;
-    entry.concurrent_safe         = concurrent_safe;
+  OperatorEntry entry;
+  entry.schema = std::move(schema);
+  entry.factory = std::move(factory);
+  entry.consumes_row_set = consumes_row_set;
+  entry.mutates_row_set = mutates_row_set;
+  entry.additive_writes_row_set = additive_writes_row_set;
+  entry.concurrent_safe = concurrent_safe;
 
-    const std::string name = entry.schema.name;
+  const std::string name = entry.schema.name;
 
-    std::unique_lock<std::shared_mutex> lk(registry_mu());
-    auto& reg = registry_map();
-    if (reg.count(name)) {
-        throw RegistryError("pine: duplicate operator registration: \"" + name + "\"");
-    }
-    reg.emplace(name, std::move(entry));
+  std::unique_lock<std::shared_mutex> lk(registry_mu());
+  auto& reg = registry_map();
+  if (reg.count(name)) {
+    throw RegistryError("pine: duplicate operator registration: \"" + name + "\"");
+  }
+  reg.emplace(name, std::move(entry));
 }
 
 const OperatorEntry* registry_entry(const std::string& type_name) {
-    std::shared_lock<std::shared_mutex> lk(registry_mu());
-    const auto& reg = registry_map();
-    auto it = reg.find(type_name);
-    return it != reg.end() ? &it->second : nullptr;
+  std::shared_lock<std::shared_mutex> lk(registry_mu());
+  const auto& reg = registry_map();
+  auto it = reg.find(type_name);
+  return it != reg.end() ? &it->second : nullptr;
 }
 
 std::vector<std::string> registered_operator_names() {
-    std::shared_lock<std::shared_mutex> lk(registry_mu());
-    const auto& reg = registry_map();
-    std::vector<std::string> names;
-    names.reserve(reg.size());
-    for (const auto& [name, _] : reg) names.push_back(name);
-    return names;
+  std::shared_lock<std::shared_mutex> lk(registry_mu());
+  const auto& reg = registry_map();
+  std::vector<std::string> names;
+  names.reserve(reg.size());
+  for (const auto& [name, _] : reg) {
+    names.push_back(name);
+  }
+  return names;
 }
 
 void apply_registry_traits(Config& config) {
-    for (auto& [name, op] : config.operators) {
-        const auto* entry = registry_entry(op.type_name);
-        if (!entry) {
-            throw RegistryError("operator \"" + name + "\": operator type not registered: \"" + op.type_name + "\"");
-        }
-        op.operator_type = op_type_to_string(entry->schema.type);
-        if (entry->consumes_row_set)        op.consumes_row_set = true;
-        if (entry->mutates_row_set)         op.mutates_row_set = true;
-        if (entry->additive_writes_row_set) op.additive_writes_row_set = true;
-        if (entry->concurrent_safe)         op.concurrent_safe = true;
+  for (auto& [name, op] : config.operators) {
+    const auto* entry = registry_entry(op.type_name);
+    if (!entry) {
+      throw RegistryError("operator \"" + name + "\": operator type not registered: \"" + op.type_name +
+                          "\"");
     }
+    op.operator_type = op_type_to_string(entry->schema.type);
+    if (entry->consumes_row_set) {
+      op.consumes_row_set = true;
+    }
+    if (entry->mutates_row_set) {
+      op.mutates_row_set = true;
+    }
+    if (entry->additive_writes_row_set) {
+      op.additive_writes_row_set = true;
+    }
+    if (entry->concurrent_safe) {
+      op.concurrent_safe = true;
+    }
+  }
 }
 
 std::string export_schema_json() {
-    auto names = registered_operator_names();
-    std::sort(names.begin(), names.end());
+  auto names = registered_operator_names();
+  std::sort(names.begin(), names.end());
 
-    JsonValue::array_t arr;
-    for (const auto& name : names) {
-        const auto* entry = registry_entry(name);
-        if (!entry) continue;
-        const auto& schema = entry->schema;
-        JsonValue::object_t obj;
-        obj["Name"]        = JsonValue(schema.name);
-        obj["Type"]        = JsonValue(op_type_to_schema_string(schema.type));
-        obj["Description"] = JsonValue(schema.description);
-
-        JsonValue::object_t params_obj;
-        for (const auto& [pname, pschema] : schema.params) {
-            JsonValue::object_t param;
-            param["Type"]        = JsonValue(pschema.type);
-            param["Required"]    = JsonValue(pschema.required);
-            param["Default"]     = pschema.default_value;
-            param["Description"] = JsonValue(pschema.description);
-            params_obj[pname]    = JsonValue(param);
-        }
-        obj["Params"] = JsonValue(params_obj);
-
-        arr.push_back(JsonValue(obj));
+  JsonValue::array_t arr;
+  for (const auto& name : names) {
+    const auto* entry = registry_entry(name);
+    if (!entry) {
+      continue;
     }
+    const auto& schema = entry->schema;
+    JsonValue::object_t obj;
+    obj["Name"] = JsonValue(schema.name);
+    obj["Type"] = JsonValue(op_type_to_schema_string(schema.type));
+    obj["Description"] = JsonValue(schema.description);
 
-    return dump_json(JsonValue(arr));
+    JsonValue::object_t params_obj;
+    for (const auto& [pname, pschema] : schema.params) {
+      JsonValue::object_t param;
+      param["Type"] = JsonValue(pschema.type);
+      param["Required"] = JsonValue(pschema.required);
+      param["Default"] = pschema.default_value;
+      param["Description"] = JsonValue(pschema.description);
+      params_obj[pname] = JsonValue(param);
+    }
+    obj["Params"] = JsonValue(params_obj);
+
+    arr.push_back(JsonValue(obj));
+  }
+
+  return dump_json(JsonValue(arr));
 }
 
 }  // namespace pine

--- a/pine-cpp/src/render/render.cpp
+++ b/pine-cpp/src/render/render.cpp
@@ -7,175 +7,193 @@ namespace pine {
 namespace {
 
 std::string sanitize(const std::string& name) {
-    std::string out;
-    for (char ch : name) out.push_back((std::isalnum(static_cast<unsigned char>(ch)) || ch == '_') ? ch : '_');
-    return out;
+  std::string out;
+  for (char ch : name) {
+    out.push_back((std::isalnum(static_cast<unsigned char>(ch)) || ch == '_') ? ch : '_');
+  }
+  return out;
 }
 
 const std::map<std::string, std::string>& dot_colors_map() {
-    static const std::map<std::string, std::string> m = {
-        {"recall", "#E8F5E9"},
-        {"transform", "#E3F2FD"},
-        {"filter", "#FFF3E0"},
-        {"merge", "#F3E5F5"},
-        {"reorder", "#FFFDE7"},
-        {"observe", "#F5F5F5"},
-    };
-    return m;
+  static const std::map<std::string, std::string> m = {
+      {"recall", "#E8F5E9"}, {"transform", "#E3F2FD"}, {"filter", "#FFF3E0"},
+      {"merge", "#F3E5F5"},  {"reorder", "#FFFDE7"},   {"observe", "#F5F5F5"},
+  };
+  return m;
 }
 
 std::string color_for(const std::string& t) {
-    const auto& m = dot_colors_map();
-    auto it = m.find(t);
-    if (it != m.end()) return it->second;
-    return "#F5F5F5";
+  const auto& m = dot_colors_map();
+  auto it = m.find(t);
+  if (it != m.end()) {
+    return it->second;
+  }
+  return "#F5F5F5";
 }
 
 std::string collapse_key(const std::string& subflow, int level) {
-    if (subflow.empty()) return "";
-    std::vector<std::string> parts;
-    std::size_t start = 0;
-    while (true) {
-        auto pos = subflow.find('/', start);
-        parts.push_back(subflow.substr(start, pos == std::string::npos ? pos : pos - start));
-        if (pos == std::string::npos) break;
-        start = pos + 1;
+  if (subflow.empty()) {
+    return "";
+  }
+  std::vector<std::string> parts;
+  std::size_t start = 0;
+  while (true) {
+    auto pos = subflow.find('/', start);
+    parts.push_back(subflow.substr(start, pos == std::string::npos ? pos : pos - start));
+    if (pos == std::string::npos) {
+      break;
     }
-    if (level >= static_cast<int>(parts.size())) return subflow;
-    std::string out;
-    for (int i = 0; i < level; ++i) {
-        if (i) out += '/';
-        out += parts[i];
+    start = pos + 1;
+  }
+  if (level >= static_cast<int>(parts.size())) {
+    return subflow;
+  }
+  std::string out;
+  for (int i = 0; i < level; ++i) {
+    if (i) {
+      out += '/';
     }
-    return out;
+    out += parts[i];
+  }
+  return out;
 }
 
 struct Group {
-    std::string key;
-    std::string label;
-    bool subflow;
-    std::string operator_type;  // non-empty for standalone nodes (preserves type coloring)
+  std::string key;
+  std::string label;
+  bool subflow;
+  std::string operator_type;  // non-empty for standalone nodes (preserves type coloring)
 };
 
-std::pair<std::vector<Group>, std::vector<std::pair<int, int>>> build_collapsed(const Graph& graph, int level) {
-    std::vector<Group> groups;
-    std::map<std::string, int> key_to_group;
-    std::vector<int> node_to_group(graph.nodes.size());
-    for (std::size_t i = 0; i < graph.nodes.size(); ++i) {
-        const auto& node = graph.nodes[i];
-        const auto key = collapse_key(node.subflow, level);
-        if (key.empty()) {
-            node_to_group[i] = static_cast<int>(groups.size());
-            std::string op_type = node.config ? node.config->operator_type : "";
-            groups.push_back({"standalone_" + std::to_string(i), node.name, false, op_type});
-        } else if (!key_to_group.count(key)) {
-            key_to_group[key] = static_cast<int>(groups.size());
-            node_to_group[i] = static_cast<int>(groups.size());
-            groups.push_back({key, key, true, ""});
-        } else {
-            node_to_group[i] = key_to_group[key];
-        }
+std::pair<std::vector<Group>, std::vector<std::pair<int, int>>> build_collapsed(const Graph& graph,
+                                                                                int level) {
+  std::vector<Group> groups;
+  std::map<std::string, int> key_to_group;
+  std::vector<int> node_to_group(graph.nodes.size());
+  for (std::size_t i = 0; i < graph.nodes.size(); ++i) {
+    const auto& node = graph.nodes[i];
+    const auto key = collapse_key(node.subflow, level);
+    if (key.empty()) {
+      node_to_group[i] = static_cast<int>(groups.size());
+      std::string op_type = node.config ? node.config->operator_type : "";
+      groups.push_back({"standalone_" + std::to_string(i), node.name, false, op_type});
+    } else if (!key_to_group.count(key)) {
+      key_to_group[key] = static_cast<int>(groups.size());
+      node_to_group[i] = static_cast<int>(groups.size());
+      groups.push_back({key, key, true, ""});
+    } else {
+      node_to_group[i] = key_to_group[key];
     }
-    std::set<std::pair<int, int>> edges_seen;
-    std::vector<std::pair<int, int>> edges;
-    for (std::size_t i = 0; i < graph.nodes.size(); ++i) {
-        for (int succ : graph.nodes[i].succs) {
-            int a = node_to_group[i], b = node_to_group[succ];
-            if (a != b && edges_seen.insert({a, b}).second) edges.push_back({a, b});
-        }
+  }
+  std::set<std::pair<int, int>> edges_seen;
+  std::vector<std::pair<int, int>> edges;
+  for (std::size_t i = 0; i < graph.nodes.size(); ++i) {
+    for (int succ : graph.nodes[i].succs) {
+      int a = node_to_group[i], b = node_to_group[succ];
+      if (a != b && edges_seen.insert({a, b}).second) {
+        edges.push_back({a, b});
+      }
     }
-    return {groups, edges};
+  }
+  return {groups, edges};
 }
 
 }  // namespace
 
 std::string render_dot(const Graph& graph) {
-    std::ostringstream oss;
-    oss << "digraph pipeline {\n    rankdir=TB;\n    node [shape=box, style=filled, fontname=\"Helvetica\"];\n\n";
-    for (const auto& node : graph.nodes) {
-        oss << "    \"" << node.name << "\" [label=\"" << node.name << "\", fillcolor=\""
-            << color_for(node.config ? node.config->operator_type : "transform") << "\"];\n";
+  std::ostringstream oss;
+  oss << "digraph pipeline {\n    rankdir=TB;\n    node [shape=box, style=filled, "
+         "fontname=\"Helvetica\"];\n\n";
+  for (const auto& node : graph.nodes) {
+    oss << "    \"" << node.name << "\" [label=\"" << node.name << "\", fillcolor=\""
+        << color_for(node.config ? node.config->operator_type : "transform") << "\"];\n";
+  }
+  oss << "\n";
+  for (const auto& node : graph.nodes) {
+    for (int succ : node.succs) {
+      oss << "    \"" << node.name << "\" -> \"" << graph.nodes[succ].name << "\";\n";
     }
-    oss << "\n";
-    for (const auto& node : graph.nodes) {
-        for (int succ : node.succs) {
-            oss << "    \"" << node.name << "\" -> \"" << graph.nodes[succ].name << "\";\n";
-        }
-    }
-    oss << "}\n";
-    return oss.str();
+  }
+  oss << "}\n";
+  return oss.str();
 }
 
 std::string render_mermaid(const Graph& graph) {
-    std::ostringstream oss;
-    oss << "graph TB\n";
-    for (const auto& node : graph.nodes) {
-        std::string t = node.config ? node.config->operator_type : "transform";
-        oss << "    " << sanitize(node.name) << "[\"" << node.name << "\"]:::" << t << "\n";
+  std::ostringstream oss;
+  oss << "graph TB\n";
+  for (const auto& node : graph.nodes) {
+    std::string t = node.config ? node.config->operator_type : "transform";
+    oss << "    " << sanitize(node.name) << "[\"" << node.name << "\"]:::" << t << "\n";
+  }
+  oss << "\n";
+  for (const auto& node : graph.nodes) {
+    for (int succ : node.succs) {
+      oss << "    " << sanitize(node.name) << " --> " << sanitize(graph.nodes[succ].name) << "\n";
     }
-    oss << "\n";
-    for (const auto& node : graph.nodes) {
-        for (int succ : node.succs) {
-            oss << "    " << sanitize(node.name) << " --> " << sanitize(graph.nodes[succ].name) << "\n";
-        }
-    }
-    oss << "\n"
-        << "    classDef recall fill:#E8F5E9,stroke:#4CAF50\n"
-        << "    classDef transform fill:#E3F2FD,stroke:#2196F3\n"
-        << "    classDef filter fill:#FFF3E0,stroke:#FF9800\n"
-        << "    classDef merge fill:#F3E5F5,stroke:#9C27B0\n"
-        << "    classDef reorder fill:#FFFDE7,stroke:#FFC107\n"
-        << "    classDef observe fill:#F5F5F5,stroke:#9E9E9E\n";
-    return oss.str();
+  }
+  oss << "\n"
+      << "    classDef recall fill:#E8F5E9,stroke:#4CAF50\n"
+      << "    classDef transform fill:#E3F2FD,stroke:#2196F3\n"
+      << "    classDef filter fill:#FFF3E0,stroke:#FF9800\n"
+      << "    classDef merge fill:#F3E5F5,stroke:#9C27B0\n"
+      << "    classDef reorder fill:#FFFDE7,stroke:#FFC107\n"
+      << "    classDef observe fill:#F5F5F5,stroke:#9E9E9E\n";
+  return oss.str();
 }
 
 std::string render_collapsed_dot(const Graph& graph, int level) {
-    auto [groups, edges] = build_collapsed(graph, level);
-    std::ostringstream oss;
-    oss << "digraph pipeline {\n    rankdir=TB;\n    node [shape=box, style=filled, fontname=\"Helvetica\"];\n\n";
-    for (std::size_t i = 0; i < groups.size(); ++i) {
-        std::string color = "#E0E0E0";
-        if (groups[i].subflow) {
-            color = "#BBDEFB";
-        } else if (!groups[i].operator_type.empty()) {
-            const auto& m = dot_colors_map();
-            auto it = m.find(groups[i].operator_type);
-            if (it != m.end()) color = it->second;
-        }
-        oss << "    \"g" << i << "\" [label=\"" << groups[i].label << "\", fillcolor=\"" << color << "\"];\n";
+  auto [groups, edges] = build_collapsed(graph, level);
+  std::ostringstream oss;
+  oss << "digraph pipeline {\n    rankdir=TB;\n    node [shape=box, style=filled, "
+         "fontname=\"Helvetica\"];\n\n";
+  for (std::size_t i = 0; i < groups.size(); ++i) {
+    std::string color = "#E0E0E0";
+    if (groups[i].subflow) {
+      color = "#BBDEFB";
+    } else if (!groups[i].operator_type.empty()) {
+      const auto& m = dot_colors_map();
+      auto it = m.find(groups[i].operator_type);
+      if (it != m.end()) {
+        color = it->second;
+      }
     }
-    oss << "\n";
-    for (auto [a, b] : edges) oss << "    \"g" << a << "\" -> \"g" << b << "\";\n";
-    oss << "}\n";
-    return oss.str();
+    oss << "    \"g" << i << "\" [label=\"" << groups[i].label << "\", fillcolor=\"" << color << "\"];\n";
+  }
+  oss << "\n";
+  for (auto [a, b] : edges) {
+    oss << "    \"g" << a << "\" -> \"g" << b << "\";\n";
+  }
+  oss << "}\n";
+  return oss.str();
 }
 
 std::string render_collapsed_mermaid(const Graph& graph, int level) {
-    auto [groups, edges] = build_collapsed(graph, level);
-    std::ostringstream oss;
-    oss << "graph TB\n";
-    for (std::size_t i = 0; i < groups.size(); ++i) {
-        std::string cls = "standalone";
-        if (groups[i].subflow) {
-            cls = "subflow";
-        } else if (!groups[i].operator_type.empty()) {
-            cls = groups[i].operator_type;
-        }
-        oss << "    g" << i << "[\"" << groups[i].label << "\"]:::"
-            << cls << "\n";
+  auto [groups, edges] = build_collapsed(graph, level);
+  std::ostringstream oss;
+  oss << "graph TB\n";
+  for (std::size_t i = 0; i < groups.size(); ++i) {
+    std::string cls = "standalone";
+    if (groups[i].subflow) {
+      cls = "subflow";
+    } else if (!groups[i].operator_type.empty()) {
+      cls = groups[i].operator_type;
     }
-    oss << "\n";
-    for (auto [a, b] : edges) oss << "    g" << a << " --> g" << b << "\n";
-    oss << "\n"
-        << "    classDef subflow fill:#BBDEFB,stroke:#1976D2\n"
-        << "    classDef standalone fill:#E0E0E0,stroke:#616161\n"
-        << "    classDef recall fill:#E8F5E9,stroke:#4CAF50\n"
-        << "    classDef transform fill:#E3F2FD,stroke:#2196F3\n"
-        << "    classDef filter fill:#FFF3E0,stroke:#FF9800\n"
-        << "    classDef merge fill:#F3E5F5,stroke:#9C27B0\n"
-        << "    classDef reorder fill:#FFFDE7,stroke:#FFC107\n"
-        << "    classDef observe fill:#F5F5F5,stroke:#9E9E9E\n";
-    return oss.str();
+    oss << "    g" << i << "[\"" << groups[i].label << "\"]:::" << cls << "\n";
+  }
+  oss << "\n";
+  for (auto [a, b] : edges) {
+    oss << "    g" << a << " --> g" << b << "\n";
+  }
+  oss << "\n"
+      << "    classDef subflow fill:#BBDEFB,stroke:#1976D2\n"
+      << "    classDef standalone fill:#E0E0E0,stroke:#616161\n"
+      << "    classDef recall fill:#E8F5E9,stroke:#4CAF50\n"
+      << "    classDef transform fill:#E3F2FD,stroke:#2196F3\n"
+      << "    classDef filter fill:#FFF3E0,stroke:#FF9800\n"
+      << "    classDef merge fill:#F3E5F5,stroke:#9C27B0\n"
+      << "    classDef reorder fill:#FFFDE7,stroke:#FFC107\n"
+      << "    classDef observe fill:#F5F5F5,stroke:#9E9E9E\n";
+  return oss.str();
 }
 
 }  // namespace pine

--- a/pine-cpp/src/resource/resource.cpp
+++ b/pine-cpp/src/resource/resource.cpp
@@ -1,4 +1,5 @@
 #include "pine/resource.hpp"
+
 #include "pine/pine.hpp"
 
 #include <chrono>
@@ -13,222 +14,234 @@ namespace resource {
 namespace {
 
 std::mutex& registry_mu() {
-    static std::mutex m;
-    return m;
+  static std::mutex m;
+  return m;
 }
 
 std::map<std::string, FetcherFactory>& factory_registry() {
-    static std::map<std::string, FetcherFactory> r;
-    return r;
+  static std::map<std::string, FetcherFactory> r;
+  return r;
 }
 
 }  // namespace
 
 bool register_fetcher_factory(const std::string& type_name, FetcherFactory factory) {
-    std::lock_guard<std::mutex> lk(registry_mu());
-    auto& reg = factory_registry();
-    if (reg.count(type_name)) {
-        throw std::runtime_error("resource: duplicate fetcher type \"" + type_name + "\"");
-    }
-    reg.emplace(type_name, std::move(factory));
-    return true;
+  std::lock_guard<std::mutex> lk(registry_mu());
+  auto& reg = factory_registry();
+  if (reg.count(type_name)) {
+    throw std::runtime_error("resource: duplicate fetcher type \"" + type_name + "\"");
+  }
+  reg.emplace(type_name, std::move(factory));
+  return true;
 }
 
 // Built-in Static fetcher registration triggered at static initialization time.
-// This allows both server-side mtime config reload and CLI parsing to resolve "type": "static" on resource_config out-of-the-box.
+// This allows both server-side mtime config reload and CLI parsing to resolve "type": "static" on
+// resource_config out-of-the-box.
 const bool _static_fetcher_init = [] {
-    register_fetcher_factory("static", [](const JsonValue& params) {
-        auto val_it = params.as_object().find("value");
-        JsonValue val = (val_it != params.as_object().end()) ? val_it->second : JsonValue();
-        return Fetcher{[val]() { return val; }};
-    });
-    return true;
+  register_fetcher_factory("static", [](const JsonValue& params) {
+    auto val_it = params.as_object().find("value");
+    JsonValue val = (val_it != params.as_object().end()) ? val_it->second : JsonValue();
+    return Fetcher{[val]() { return val; }};
+  });
+  return true;
 }();
 
 const FetcherFactory* lookup_fetcher_factory(const std::string& type_name) {
-    std::lock_guard<std::mutex> lk(registry_mu());
-    auto& reg = factory_registry();
-    auto it = reg.find(type_name);
-    if (it == reg.end()) return nullptr;
-    return &it->second;
+  std::lock_guard<std::mutex> lk(registry_mu());
+  auto& reg = factory_registry();
+  auto it = reg.find(type_name);
+  if (it == reg.end()) {
+    return nullptr;
+  }
+  return &it->second;
 }
 
 std::vector<std::string> registered_fetcher_types() {
-    std::lock_guard<std::mutex> lk(registry_mu());
-    std::vector<std::string> out;
-    for (const auto& kv : factory_registry()) out.push_back(kv.first);
-    return out;  // map iteration is already sorted by key
+  std::lock_guard<std::mutex> lk(registry_mu());
+  std::vector<std::string> out;
+  for (const auto& kv : factory_registry()) {
+    out.push_back(kv.first);
+  }
+  return out;  // map iteration is already sorted by key
 }
 
 void reset_fetcher_registry() {
-    std::lock_guard<std::mutex> lk(registry_mu());
-    factory_registry().clear();
+  std::lock_guard<std::mutex> lk(registry_mu());
+  factory_registry().clear();
 }
 
 Manager::Manager() = default;
 
-Manager::~Manager() { stop(); }
+Manager::~Manager() {
+  stop();
+}
 
-void Manager::register_resource(const std::string& name, Fetcher fetcher,
-                                std::chrono::seconds interval) {
-    std::unique_lock<std::shared_mutex> lk(mu_);
-    if (started_) {
-        throw std::runtime_error("resource: register_resource called after start()");
-    }
-    if (resources_.count(name)) {
-        throw std::runtime_error("resource: duplicate resource name \"" + name + "\"");
-    }
-    if (interval <= std::chrono::seconds(0)) {
-        interval = std::chrono::minutes(10);
-    }
-    auto m = std::make_unique<Managed>();
-    m->name = name;
-    m->fetcher = std::move(fetcher);
-    m->interval = interval;
-    resources_.emplace(name, std::move(m));
+void Manager::register_resource(const std::string& name, Fetcher fetcher, std::chrono::seconds interval) {
+  std::unique_lock<std::shared_mutex> lk(mu_);
+  if (started_) {
+    throw std::runtime_error("resource: register_resource called after start()");
+  }
+  if (resources_.count(name)) {
+    throw std::runtime_error("resource: duplicate resource name \"" + name + "\"");
+  }
+  if (interval <= std::chrono::seconds(0)) {
+    interval = std::chrono::minutes(10);
+  }
+  auto m = std::make_unique<Managed>();
+  m->name = name;
+  m->fetcher = std::move(fetcher);
+  m->interval = interval;
+  resources_.emplace(name, std::move(m));
 }
 
 void Manager::load_from_config(const Config& config) {
-    if (config.resource_config.empty()) return;
-    for (const auto& [name, entry] : config.resource_config) {
-        const auto* factory = lookup_fetcher_factory(entry.type);
-        if (!factory) {
-            throw std::runtime_error("resource: unknown fetcher type \"" + entry.type +
-                                     "\" for resource \"" + name + "\"");
-        }
-        Fetcher fetcher = (*factory)(entry.params);
-        auto interval = entry.interval > 0 ? std::chrono::seconds(entry.interval)
-                                           : std::chrono::seconds(0);
-        register_resource(name, std::move(fetcher), interval);
+  if (config.resource_config.empty()) {
+    return;
+  }
+  for (const auto& [name, entry] : config.resource_config) {
+    const auto* factory = lookup_fetcher_factory(entry.type);
+    if (!factory) {
+      throw std::runtime_error("resource: unknown fetcher type \"" + entry.type + "\" for resource \"" +
+                               name + "\"");
     }
-    // Every load_from_config call now validates resource dependencies
-    // against the operators in the same config. The previous design ran
-    // validate_resource_deps only from server.cpp / pineapple-run; unit
-    // tests, Python bindings, or any future caller that constructed an
-    // Engine + Manager directly silently skipped the check. Closing the
-    // validate-or-die loop here makes the invariant unsurvivable from any
-    // path that loads config.
-    validate_resource_deps(config);
+    Fetcher fetcher = (*factory)(entry.params);
+    auto interval = entry.interval > 0 ? std::chrono::seconds(entry.interval) : std::chrono::seconds(0);
+    register_resource(name, std::move(fetcher), interval);
+  }
+  // Every load_from_config call now validates resource dependencies
+  // against the operators in the same config. The previous design ran
+  // validate_resource_deps only from server.cpp / pineapple-run; unit
+  // tests, Python bindings, or any future caller that constructed an
+  // Engine + Manager directly silently skipped the check. Closing the
+  // validate-or-die loop here makes the invariant unsurvivable from any
+  // path that loads config.
+  validate_resource_deps(config);
 }
 
 void Manager::start() {
-    std::vector<Managed*> to_refresh;
-    {
-        std::unique_lock<std::shared_mutex> lk(mu_);
-        if (started_) {
-            throw std::runtime_error("resource: already started");
-        }
-        // Synchronous initial load — propagate failure so callers see it.
-        // Wrap each fetcher in std::async + wait_for(30s) so a
-        // hung backend (DNS resolution stall, broker dead, etc.) does
-        // NOT hang server startup forever. Fetchers themselves already
-        // honour socket-level SO_RCVTIMEO / SO_SNDTIMEO, so 30 s is an
-        // outer fence; the future's destructor will still block until
-        // the task finishes, but the inner socket timeout bounds that
-        // wait to a few seconds beyond the outer deadline.
-        constexpr auto kInitDeadline = std::chrono::seconds(30);
-        for (auto& [name, r] : resources_) {
-            auto fut = std::async(std::launch::async, [&r] {
-                return r->fetcher();
-            });
-            if (fut.wait_for(kInitDeadline) != std::future_status::ready) {
-                throw std::runtime_error(
-                    "resource: initial fetch of \"" + name +
-                    "\" timed out after " + std::to_string(kInitDeadline.count()) + "s");
-            }
-            r->value = fut.get();
-            r->loaded = true;
-            to_refresh.push_back(r.get());
-        }
-        started_ = true;
+  std::vector<Managed*> to_refresh;
+  {
+    std::unique_lock<std::shared_mutex> lk(mu_);
+    if (started_) {
+      throw std::runtime_error("resource: already started");
     }
-    for (auto* r : to_refresh) {
-        refresh_threads_.emplace_back([this, r]() { refresh_loop(r); });
+    // Synchronous initial load — propagate failure so callers see it.
+    // Wrap each fetcher in std::async + wait_for(30s) so a
+    // hung backend (DNS resolution stall, broker dead, etc.) does
+    // NOT hang server startup forever. Fetchers themselves already
+    // honour socket-level SO_RCVTIMEO / SO_SNDTIMEO, so 30 s is an
+    // outer fence; the future's destructor will still block until
+    // the task finishes, but the inner socket timeout bounds that
+    // wait to a few seconds beyond the outer deadline.
+    constexpr auto kInitDeadline = std::chrono::seconds(30);
+    for (auto& [name, r] : resources_) {
+      auto fut = std::async(std::launch::async, [&r] { return r->fetcher(); });
+      if (fut.wait_for(kInitDeadline) != std::future_status::ready) {
+        throw std::runtime_error("resource: initial fetch of \"" + name + "\" timed out after " +
+                                 std::to_string(kInitDeadline.count()) + "s");
+      }
+      r->value = fut.get();
+      r->loaded = true;
+      to_refresh.push_back(r.get());
     }
+    started_ = true;
+  }
+  for (auto* r : to_refresh) {
+    refresh_threads_.emplace_back([this, r]() { refresh_loop(r); });
+  }
 }
 
 void Manager::stop() {
-    {
-        std::unique_lock<std::shared_mutex> lk(mu_);
-        if (!started_) return;
-    }
-    stopping_.store(true, std::memory_order_release);
-    stop_cv_.notify_all();
-    for (auto& t : refresh_threads_) {
-        if (t.joinable()) t.join();
-    }
-    refresh_threads_.clear();
+  {
     std::unique_lock<std::shared_mutex> lk(mu_);
-    started_ = false;
-    stopping_.store(false, std::memory_order_release);
+    if (!started_) {
+      return;
+    }
+  }
+  stopping_.store(true, std::memory_order_release);
+  stop_cv_.notify_all();
+  for (auto& t : refresh_threads_) {
+    if (t.joinable()) {
+      t.join();
+    }
+  }
+  refresh_threads_.clear();
+  std::unique_lock<std::shared_mutex> lk(mu_);
+  started_ = false;
+  stopping_.store(false, std::memory_order_release);
 }
 
 std::map<std::string, JsonValue> Manager::snapshot() const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    std::map<std::string, JsonValue> out;
-    for (const auto& [name, r] : resources_) {
-        if (r->loaded) out.emplace(name, r->value);
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  std::map<std::string, JsonValue> out;
+  for (const auto& [name, r] : resources_) {
+    if (r->loaded) {
+      out.emplace(name, r->value);
     }
-    return out;
+  }
+  return out;
 }
 
 std::vector<std::string> Manager::names() const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    std::vector<std::string> out;
-    for (const auto& kv : resources_) out.push_back(kv.first);
-    return out;
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  std::vector<std::string> out;
+  for (const auto& kv : resources_) {
+    out.push_back(kv.first);
+  }
+  return out;
 }
 
 void Manager::validate_resource_deps(const Config& config) const {
-    std::shared_lock<std::shared_mutex> lk(mu_);
-    std::vector<std::string> missing;
-    for (const auto& [op_key, params] : config.operators) {
-        auto res_it = params.params.as_object().find("resource_name");
-        if (res_it == params.params.as_object().end()) {
-            continue;
-        }
-        if (!res_it->second.is_string()) {
-            continue;
-        }
-        std::string name = res_it->second.as_string();
-        if (name.empty()) {
-            continue;
-        }
-        if (!resources_.count(name)) {
-            missing.push_back(name + " (operator " + params.type_name + "/" + op_key + ")");
-        }
+  std::shared_lock<std::shared_mutex> lk(mu_);
+  std::vector<std::string> missing;
+  for (const auto& [op_key, params] : config.operators) {
+    auto res_it = params.params.as_object().find("resource_name");
+    if (res_it == params.params.as_object().end()) {
+      continue;
     }
-    if (!missing.empty()) {
-        std::string err_msg = "resource: missing resource definitions: ";
-        for (std::size_t i = 0; i < missing.size(); ++i) {
-            if (i > 0) err_msg += ", ";
-            err_msg += missing[i];
-        }
-        // Raise the canonical ConfigError so callers see the
-        // `pine: config error: ...` prefix and exception type that
-        // matches every other init-time config defect.
-        throw ConfigError(err_msg);
+    if (!res_it->second.is_string()) {
+      continue;
     }
+    std::string name = res_it->second.as_string();
+    if (name.empty()) {
+      continue;
+    }
+    if (!resources_.count(name)) {
+      missing.push_back(name + " (operator " + params.type_name + "/" + op_key + ")");
+    }
+  }
+  if (!missing.empty()) {
+    std::string err_msg = "resource: missing resource definitions: ";
+    for (std::size_t i = 0; i < missing.size(); ++i) {
+      if (i > 0) {
+        err_msg += ", ";
+      }
+      err_msg += missing[i];
+    }
+    // Raise the canonical ConfigError so callers see the
+    // `pine: config error: ...` prefix and exception type that
+    // matches every other init-time config defect.
+    throw ConfigError(err_msg);
+  }
 }
 
 void Manager::refresh_loop(Managed* r) {
-    while (!stopping_.load(std::memory_order_acquire)) {
-        std::unique_lock<std::mutex> lk(stop_mu_);
-        if (stop_cv_.wait_for(lk, r->interval, [this] {
-                return stopping_.load(std::memory_order_acquire);
-            })) {
-            return;  // stopping
-        }
-        lk.unlock();
-        try {
-            JsonValue val = r->fetcher();
-            std::unique_lock<std::shared_mutex> wlk(mu_);
-            r->value = std::move(val);
-        } catch (const std::exception& e) {
-            std::cerr << "[resource] refresh \"" << r->name
-                      << "\" failed: " << e.what() << " (keeping old value)\n";
-        }
+  while (!stopping_.load(std::memory_order_acquire)) {
+    std::unique_lock<std::mutex> lk(stop_mu_);
+    if (stop_cv_.wait_for(lk, r->interval, [this] { return stopping_.load(std::memory_order_acquire); })) {
+      return;  // stopping
     }
+    lk.unlock();
+    try {
+      JsonValue val = r->fetcher();
+      std::unique_lock<std::shared_mutex> wlk(mu_);
+      r->value = std::move(val);
+    } catch (const std::exception& e) {
+      std::cerr << "[resource] refresh \"" << r->name << "\" failed: " << e.what()
+                << " (keeping old value)\n";
+    }
+  }
 }
 
 }  // namespace resource

--- a/pine-cpp/src/runtime/engine.cpp
+++ b/pine-cpp/src/runtime/engine.cpp
@@ -1,8 +1,7 @@
-#include "pine/pine.hpp"
 #include "pine/column_frame.hpp"
 #include "pine/operator.hpp"
 #include "pine/operator_input.hpp"
-#include "runtime/thread_pool.hpp"
+#include "pine/pine.hpp"
 
 #include <algorithm>
 #include <atomic>
@@ -10,47 +9,49 @@
 #include <condition_variable>
 #include <cstdint>
 #include <exception>
+#include <functional>
 #include <future>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <functional>
 #include <set>
 #include <shared_mutex>
 #include <sstream>
 #include <stop_token>
 #include <thread>
 
+#include "runtime/thread_pool.hpp"
+
 namespace pine {
 
 void OperatorOutput::set_common(const std::string& field, JsonValue value) {
-    common_writes_[field] = std::move(value);
+  common_writes_[field] = std::move(value);
 }
 
 void OperatorOutput::set_item(int index, const std::string& field, JsonValue value) {
-    item_writes_.push_back(ItemWrite{index, field, std::move(value)});
+  item_writes_.push_back(ItemWrite{index, field, std::move(value)});
 }
 
 void OperatorOutput::add_item(std::map<std::string, JsonValue> fields) {
-    added_items_.push_back(std::move(fields));
+  added_items_.push_back(std::move(fields));
 }
 
 void OperatorOutput::remove_item(int index) {
-    removed_items_.insert(index);
+  removed_items_.insert(index);
 }
 
 void OperatorOutput::set_item_order(std::vector<int> order) {
-    item_order_ = std::move(order);
-    has_item_order_ = true;
+  item_order_ = std::move(order);
+  has_item_order_ = true;
 }
 
 void OperatorOutput::set_warning(std::string msg) {
-    if (!has_warning_) {
-        warning_ = std::move(msg);
-        has_warning_ = true;
-    }
+  if (!has_warning_) {
+    warning_ = std::move(msg);
+    has_warning_ = true;
+  }
 }
 
 namespace {
@@ -60,22 +61,33 @@ namespace {
 using Frame = ::pine::Frame;
 
 bool should_skip(const Frame& frame, const OperatorConfig& op) {
-    for (const auto& field : op.skip) {
-        JsonValue v = frame.common(field);
-        if (!v.is_null() && v.truthy()) return true;
+  for (const auto& field : op.skip) {
+    JsonValue v = frame.common(field);
+    if (!v.is_null() && v.truthy()) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 Result project_result(const Frame& frame, const FlowContract& contract) {
-    return frame.to_result(contract.common_output, contract.item_output);
+  return frame.to_result(contract.common_output, contract.item_output);
 }
 
 void validate_request(const Request& request, const FlowContract& contract) {
-    for (const auto& field : contract.common_input) if (!request.common.count(field)) throw ValidationError("missing required common input field \"" + field + "\"");
-    for (std::size_t i = 0; i < request.items.size(); ++i) {
-        for (const auto& field : contract.item_input) if (!request.items[i].count(field)) throw ValidationError("item[" + std::to_string(i) + "] missing required item input field \"" + field + "\"");
+  for (const auto& field : contract.common_input) {
+    if (!request.common.count(field)) {
+      throw ValidationError("missing required common input field \"" + field + "\"");
     }
+  }
+  for (std::size_t i = 0; i < request.items.size(); ++i) {
+    for (const auto& field : contract.item_input) {
+      if (!request.items[i].count(field)) {
+        throw ValidationError("item[" + std::to_string(i) + "] missing required item input field \"" + field +
+                              "\"");
+      }
+    }
+  }
 }
 
 // apply_output is now a member of ColumnFrame (frame.apply_output(out, op_name, is_recall)).
@@ -93,99 +105,115 @@ void validate_request(const Request& request, const FlowContract& contract) {
 // earlier C++ version inserted JsonValue() (null) placeholders for those
 // fields, polluting trace output relative to Go.
 JsonValue snapshot_input(const Frame& frame, const OperatorConfig& op) {
-    JsonValue::object_t snap;
-    std::set<std::string> skip_set(op.skip.begin(), op.skip.end());
+  JsonValue::object_t snap;
+  std::set<std::string> skip_set(op.skip.begin(), op.skip.end());
 
-    JsonValue::object_t common;
-    for (const auto& field : op.metadata.common_input) {
-        if (skip_set.count(field)) continue;
-        JsonValue v = frame.common(field);
+  JsonValue::object_t common;
+  for (const auto& field : op.metadata.common_input) {
+    if (skip_set.count(field)) {
+      continue;
+    }
+    JsonValue v = frame.common(field);
+    if (!v.is_null()) {
+      common[field] = v;
+    } else if (auto def = op.common_defaults.find(field); def != op.common_defaults.end()) {
+      common[field] = def->second;
+    }
+    // else: omit — matches Go BuildInput projection semantics.
+  }
+  if (!common.empty()) {
+    snap["common"] = JsonValue(std::move(common));
+  }
+
+  if (frame.item_count() > 0 && !op.metadata.item_input.empty()) {
+    bool has_data = false;
+    JsonValue::array_t items;
+    items.reserve(frame.item_count());
+    for (std::size_t i = 0; i < frame.item_count(); ++i) {
+      JsonValue::object_t row;
+      for (const auto& field : op.metadata.item_input) {
+        JsonValue v = frame.item(i, field);
         if (!v.is_null()) {
-            common[field] = v;
-        } else if (auto def = op.common_defaults.find(field); def != op.common_defaults.end()) {
-            common[field] = def->second;
+          row[field] = v;
+        } else if (auto def = op.item_defaults.find(field); def != op.item_defaults.end()) {
+          row[field] = def->second;
         }
         // else: omit — matches Go BuildInput projection semantics.
+      }
+      if (!row.empty()) {
+        has_data = true;
+      }
+      items.push_back(JsonValue(std::move(row)));
     }
-    if (!common.empty()) snap["common"] = JsonValue(std::move(common));
-
-    if (frame.item_count() > 0 && !op.metadata.item_input.empty()) {
-        bool has_data = false;
-        JsonValue::array_t items;
-        items.reserve(frame.item_count());
-        for (std::size_t i = 0; i < frame.item_count(); ++i) {
-            JsonValue::object_t row;
-            for (const auto& field : op.metadata.item_input) {
-                JsonValue v = frame.item(i, field);
-                if (!v.is_null()) {
-                    row[field] = v;
-                } else if (auto def = op.item_defaults.find(field); def != op.item_defaults.end()) {
-                    row[field] = def->second;
-                }
-                // else: omit — matches Go BuildInput projection semantics.
-            }
-            if (!row.empty()) has_data = true;
-            items.push_back(JsonValue(std::move(row)));
-        }
-        if (has_data) snap["items"] = JsonValue(std::move(items));
+    if (has_data) {
+      snap["items"] = JsonValue(std::move(items));
     }
+  }
 
-    return JsonValue(std::move(snap));
+  return JsonValue(std::move(snap));
 }
 
 // snapshot_output mirrors pine-go's snapshotOutput: serialize the
 // OperatorOutput buffer into a stable JSON-friendly shape.
 JsonValue snapshot_output(const OperatorOutput& out) {
-    JsonValue::object_t snap;
+  JsonValue::object_t snap;
 
-    if (!out.common_writes().empty()) {
-        JsonValue::object_t cw;
-        for (const auto& [field, value] : out.common_writes()) cw[field] = value;
-        snap["common_writes"] = JsonValue(std::move(cw));
+  if (!out.common_writes().empty()) {
+    JsonValue::object_t cw;
+    for (const auto& [field, value] : out.common_writes()) {
+      cw[field] = value;
     }
+    snap["common_writes"] = JsonValue(std::move(cw));
+  }
 
-    if (!out.item_writes().empty()) {
-        // The vector log can hold multiple writes for the same (idx, field);
-        // group by idx and let later writes overwrite earlier ones to
-        // preserve the snapshot's "final state" semantics. apply_output
-        // also replays the vector in order so the on-frame state matches.
-        std::map<int, std::map<std::string, JsonValue>> grouped;
-        for (const auto& w : out.item_writes()) {
-            grouped[w.index][w.field] = w.value;
-        }
-        JsonValue::object_t iw;
-        for (const auto& [idx, fields] : grouped) {
-            JsonValue::object_t row;
-            for (const auto& [field, value] : fields) row[field] = value;
-            iw[std::to_string(idx)] = JsonValue(std::move(row));
-        }
-        snap["item_writes"] = JsonValue(std::move(iw));
+  if (!out.item_writes().empty()) {
+    // The vector log can hold multiple writes for the same (idx, field);
+    // group by idx and let later writes overwrite earlier ones to
+    // preserve the snapshot's "final state" semantics. apply_output
+    // also replays the vector in order so the on-frame state matches.
+    std::map<int, std::map<std::string, JsonValue>> grouped;
+    for (const auto& w : out.item_writes()) {
+      grouped[w.index][w.field] = w.value;
     }
-
-    if (!out.added_items().empty()) {
-        JsonValue::array_t ai;
-        ai.reserve(out.added_items().size());
-        for (const auto& row : out.added_items()) {
-            JsonValue::object_t obj;
-            for (const auto& [field, value] : row) obj[field] = value;
-            ai.push_back(JsonValue(std::move(obj)));
-        }
-        snap["added_items"] = JsonValue(std::move(ai));
+    JsonValue::object_t iw;
+    for (const auto& [idx, fields] : grouped) {
+      JsonValue::object_t row;
+      for (const auto& [field, value] : fields) {
+        row[field] = value;
+      }
+      iw[std::to_string(idx)] = JsonValue(std::move(row));
     }
+    snap["item_writes"] = JsonValue(std::move(iw));
+  }
 
-    if (!out.removed_items().empty()) {
-        JsonValue::array_t ri;
-        ri.reserve(out.removed_items().size());
-        for (int idx : out.removed_items()) ri.push_back(JsonValue(static_cast<double>(idx)));
-        snap["removed_items"] = JsonValue(std::move(ri));
+  if (!out.added_items().empty()) {
+    JsonValue::array_t ai;
+    ai.reserve(out.added_items().size());
+    for (const auto& row : out.added_items()) {
+      JsonValue::object_t obj;
+      for (const auto& [field, value] : row) {
+        obj[field] = value;
+      }
+      ai.push_back(JsonValue(std::move(obj)));
     }
+    snap["added_items"] = JsonValue(std::move(ai));
+  }
 
-    return JsonValue(std::move(snap));
+  if (!out.removed_items().empty()) {
+    JsonValue::array_t ri;
+    ri.reserve(out.removed_items().size());
+    for (int idx : out.removed_items()) {
+      ri.push_back(JsonValue(static_cast<double>(idx)));
+    }
+    snap["removed_items"] = JsonValue(std::move(ri));
+  }
+
+  return JsonValue(std::move(snap));
 }
 
 int64_t now_us() {
-    using namespace std::chrono;
-    return duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+  using namespace std::chrono;
+  return duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
 }
 
 }  // namespace
@@ -193,49 +221,50 @@ int64_t now_us() {
 // Pre-created metrics for the scheduler and per-operator recording.
 // Mirrors pine-go internal/runtime/engine_metrics.go EngineMetrics.
 struct Engine::EngineMetrics {
-    metrics::Counter* scheduler_runs = nullptr;
-    metrics::Gauge* active_ops = nullptr;
-    metrics::Counter* op_exec_total = nullptr;
-    metrics::Histogram* op_exec_duration = nullptr;
-    metrics::Counter* op_skip_total = nullptr;
-    metrics::Counter* op_error_total = nullptr;
-    metrics::Counter* dag_exec_total = nullptr;
-    metrics::Histogram* dag_exec_duration = nullptr;
-    metrics::Histogram* dag_ops_executed = nullptr;
+  metrics::Counter* scheduler_runs = nullptr;
+  metrics::Gauge* active_ops = nullptr;
+  metrics::Counter* op_exec_total = nullptr;
+  metrics::Histogram* op_exec_duration = nullptr;
+  metrics::Counter* op_skip_total = nullptr;
+  metrics::Counter* op_error_total = nullptr;
+  metrics::Counter* dag_exec_total = nullptr;
+  metrics::Histogram* dag_exec_duration = nullptr;
+  metrics::Histogram* dag_ops_executed = nullptr;
 };
 
 namespace {
 
 std::unique_ptr<Engine::EngineMetrics> build_engine_metrics(metrics::Provider* p,
                                                             const std::vector<std::string>& op_names) {
-    auto em = std::make_unique<Engine::EngineMetrics>();
-    em->scheduler_runs = p->new_counter({"pine_scheduler_runs_total", "Total number of DAG scheduler runs.", {}});
-    em->active_ops = p->new_gauge({"pine_operator_active", "Number of operators currently executing.", {}});
-    em->op_exec_total = p->new_counter({"pine_operator_exec_total", "Total successful operator executions.", {"operator"}});
-    em->op_exec_duration = p->new_histogram({
-        {"pine_operator_exec_duration_seconds", "Operator execution duration in seconds.", {"operator"}},
-        {0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0}
-    });
-    em->op_skip_total = p->new_counter({"pine_operator_skip_total", "Total skipped operator executions.", {"operator"}});
-    em->op_error_total = p->new_counter({"pine_operator_error_total", "Total failed operator executions.", {"operator"}});
-    em->dag_exec_total = p->new_counter({"pine_dag_executions_total", "Total DAG executions.", {"status"}});
-    em->dag_exec_duration = p->new_histogram({
-        {"pine_dag_execution_duration_seconds", "DAG execution duration in seconds.", {}},
-        {0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0}
-    });
-    em->dag_ops_executed = p->new_histogram({
-        {"pine_dag_operators_executed", "Number of operators executed per DAG run.", {}},
-        {1, 2, 5, 10, 15, 20, 25, 30, 40, 50, 75, 100, 150, 200, 300, 450}
-    });
-    for (const auto& n : op_names) {
-        em->op_exec_total->with({n});
-        em->op_exec_duration->with({n});
-        em->op_skip_total->with({n});
-        em->op_error_total->with({n});
-    }
-    em->dag_exec_total->with({"success"});
-    em->dag_exec_total->with({"error"});
-    return em;
+  auto em = std::make_unique<Engine::EngineMetrics>();
+  em->scheduler_runs =
+      p->new_counter({"pine_scheduler_runs_total", "Total number of DAG scheduler runs.", {}});
+  em->active_ops = p->new_gauge({"pine_operator_active", "Number of operators currently executing.", {}});
+  em->op_exec_total =
+      p->new_counter({"pine_operator_exec_total", "Total successful operator executions.", {"operator"}});
+  em->op_exec_duration = p->new_histogram(
+      {{"pine_operator_exec_duration_seconds", "Operator execution duration in seconds.", {"operator"}},
+       {0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0}});
+  em->op_skip_total =
+      p->new_counter({"pine_operator_skip_total", "Total skipped operator executions.", {"operator"}});
+  em->op_error_total =
+      p->new_counter({"pine_operator_error_total", "Total failed operator executions.", {"operator"}});
+  em->dag_exec_total = p->new_counter({"pine_dag_executions_total", "Total DAG executions.", {"status"}});
+  em->dag_exec_duration =
+      p->new_histogram({{"pine_dag_execution_duration_seconds", "DAG execution duration in seconds.", {}},
+                        {0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0}});
+  em->dag_ops_executed =
+      p->new_histogram({{"pine_dag_operators_executed", "Number of operators executed per DAG run.", {}},
+                        {1, 2, 5, 10, 15, 20, 25, 30, 40, 50, 75, 100, 150, 200, 300, 450}});
+  for (const auto& n : op_names) {
+    em->op_exec_total->with({n});
+    em->op_exec_duration->with({n});
+    em->op_skip_total->with({n});
+    em->op_error_total->with({n});
+  }
+  em->dag_exec_total->with({"success"});
+  em->dag_exec_total->with({"error"});
+  return em;
 }
 
 }  // namespace
@@ -243,67 +272,74 @@ std::unique_ptr<Engine::EngineMetrics> build_engine_metrics(metrics::Provider* p
 // Engine::PoolHolder wraps the worker pool, hidden from pine.hpp so the
 // public header does not depend on runtime/thread_pool.hpp.
 struct Engine::PoolHolder {
-    runtime::ThreadPool pool;
-    explicit PoolHolder(std::size_t n) : pool(n) {}
+  runtime::ThreadPool pool;
+  explicit PoolHolder(std::size_t n) : pool(n) {
+  }
 };
 
-Engine::Engine(Config config) : Engine(std::move(config), EngineOptions{}) {}
+Engine::Engine(Config config) : Engine(std::move(config), EngineOptions{}) {
+}
 
 Engine::~Engine() = default;
 Engine::Engine(Engine&&) noexcept = default;
 Engine& Engine::operator=(Engine&&) noexcept = default;
 
 Engine::Engine(Config config, EngineOptions options) : config_(std::move(config)) {
-    bool global_debug = options.debug.has_value() ? *options.debug : config_.debug;
-    // Tri-state debug: op-level debug overrides global when explicitly set
-    for (auto& [_, op] : config_.operators) {
-        if (!op.debug.has_value()) {
-            op.debug = global_debug;
-        }
+  bool global_debug = options.debug.has_value() ? *options.debug : config_.debug;
+  // Tri-state debug: op-level debug overrides global when explicitly set
+  for (auto& [_, op] : config_.operators) {
+    if (!op.debug.has_value()) {
+      op.debug = global_debug;
     }
-    log_prefix_ = options.log_prefix.has_value() ? *options.log_prefix : config_.log_prefix;
-    peak_concurrency_ = std::make_unique<std::atomic<int64_t>>(0);
-    metrics_provider_ = options.metrics_provider ? options.metrics_provider : metrics::nop_provider();
-    // Engine-level worker pool reused across data_parallel shards. Sized to
-    // hardware_concurrency (≥1). Avoids the per-request spawn/join cost
-    // that becomes dominant under high QPS.
-    {
-        unsigned hw = std::thread::hardware_concurrency();
-        if (hw == 0) hw = 4;
-        shard_pool_ = std::make_unique<PoolHolder>(static_cast<std::size_t>(hw));
+  }
+  log_prefix_ = options.log_prefix.has_value() ? *options.log_prefix : config_.log_prefix;
+  peak_concurrency_ = std::make_unique<std::atomic<int64_t>>(0);
+  metrics_provider_ = options.metrics_provider ? options.metrics_provider : metrics::nop_provider();
+  // Engine-level worker pool reused across data_parallel shards. Sized to
+  // hardware_concurrency (≥1). Avoids the per-request spawn/join cost
+  // that becomes dominant under high QPS.
+  {
+    unsigned hw = std::thread::hardware_concurrency();
+    if (hw == 0) {
+      hw = 4;
     }
-    expanded_ = expand_operator_sequence_with_subflows(config_);
-    graph_ = build_dag(config_, expanded_);
-    engine_metrics_ = build_engine_metrics(metrics_provider_, expanded_.sequence);
+    shard_pool_ = std::make_unique<PoolHolder>(static_cast<std::size_t>(hw));
+  }
+  expanded_ = expand_operator_sequence_with_subflows(config_);
+  graph_ = build_dag(config_, expanded_);
+  engine_metrics_ = build_engine_metrics(metrics_provider_, expanded_.sequence);
 
-    // Forward-reference validation runs inside build_dag() above
-    // (dag.cpp:155 raises ConfigError("operator \"X\": sources contains
-    // forward reference to \"Y\"")), so by the time we reach this point
-    // every operator's sources are guaranteed to refer to nodes already
-    // visited. A second native-side check would be dead code.
+  // Forward-reference validation runs inside build_dag() above
+  // (dag.cpp:155 raises ConfigError("operator \"X\": sources contains
+  // forward reference to \"Y\"")), so by the time we reach this point
+  // every operator's sources are guaranteed to refer to nodes already
+  // visited. A second native-side check would be dead code.
 
-    // Instantiate and init one Operator per config operator.
-    for (auto& [op_name, op_cfg] : config_.operators) {
-        const auto* entry = registry_entry(op_cfg.type_name);
-        if (!entry || !entry->factory) {
-            throw RegistryError("operator \"" + op_name + "\": operator type not registered: \"" + op_cfg.type_name + "\"");
-        }
-        auto instance = entry->factory();
-        instance->init(op_cfg);
-        // Inject metrics provider for operators that opt-in. Mirrors
-        // pine-go pine.go:170 — init first, then provider injection.
-        if (auto* ma = dynamic_cast<MetricsAware*>(instance.get())) {
-            ma->set_metrics_provider(metrics_provider_);
-        }
-        operators_.emplace(op_name, std::move(instance));
-        // Pre-compute InputFieldSpec for the BuildInput projection layer.
-        input_specs_.emplace(op_name, compute_input_field_spec(op_cfg));
+  // Instantiate and init one Operator per config operator.
+  for (auto& [op_name, op_cfg] : config_.operators) {
+    const auto* entry = registry_entry(op_cfg.type_name);
+    if (!entry || !entry->factory) {
+      throw RegistryError("operator \"" + op_name + "\": operator type not registered: \"" +
+                          op_cfg.type_name + "\"");
     }
+    auto instance = entry->factory();
+    instance->init(op_cfg);
+    // Inject metrics provider for operators that opt-in. Mirrors
+    // pine-go pine.go:170 — init first, then provider injection.
+    if (auto* ma = dynamic_cast<MetricsAware*>(instance.get())) {
+      ma->set_metrics_provider(metrics_provider_);
+    }
+    operators_.emplace(op_name, std::move(instance));
+    // Pre-compute InputFieldSpec for the BuildInput projection layer.
+    input_specs_.emplace(op_name, compute_input_field_spec(op_cfg));
+  }
 }
 
-Engine Engine::from_file(const std::string& path) { return Engine(load_config_from_file(path)); }
+Engine Engine::from_file(const std::string& path) {
+  return Engine(load_config_from_file(path));
+}
 Engine Engine::from_file(const std::string& path, EngineOptions options) {
-    return Engine(load_config_from_file(path), std::move(options));
+  return Engine(load_config_from_file(path), std::move(options));
 }
 
 namespace {
@@ -311,11 +347,12 @@ namespace {
 void dispatch_operator(const OperatorInput& input, const OperatorConfig& op,
                        const std::map<std::string, std::unique_ptr<Operator>>& operators,
                        OperatorOutput& out) {
-    auto it = operators.find(op.name);
-    if (it == operators.end() || !it->second) {
-        throw RegistryError("operator \"" + op.name + "\": operator type not registered: \"" + op.type_name + "\"");
-    }
-    it->second->execute(input, out);
+  auto it = operators.find(op.name);
+  if (it == operators.end() || !it->second) {
+    throw RegistryError("operator \"" + op.name + "\": operator type not registered: \"" + op.type_name +
+                        "\"");
+  }
+  it->second->execute(input, out);
 }
 
 // validate_output_against_type mirrors pine-go types.OperatorType.ValidateOutput
@@ -330,69 +367,117 @@ void dispatch_operator(const OperatorInput& input, const OperatorConfig& op,
 // Error format (Go-compatible byte-exact): `type violation: operator type X
 // must not call [Method1 Method2]`. The bracketed list mimics Go's `%v`
 // formatting of a []string (single space separator, no quotes).
-void validate_output_against_type(const std::string& op_name,
-                                  const std::string& op_type,
+void validate_output_against_type(const std::string& op_name, const std::string& op_type,
                                   const OperatorOutput& out) {
-    const bool has_cw = !out.common_writes().empty();
-    const bool has_iw = !out.item_writes().empty();
-    const bool has_ai = !out.added_items().empty();
-    const bool has_ri = !out.removed_items().empty();
-    const bool has_io = out.has_item_order();
+  const bool has_cw = !out.common_writes().empty();
+  const bool has_iw = !out.item_writes().empty();
+  const bool has_ai = !out.added_items().empty();
+  const bool has_ri = !out.removed_items().empty();
+  const bool has_io = out.has_item_order();
 
-    std::vector<std::string> violations;
-    // Note: op_type comes from OperatorConfig::operator_type which is the
-    // lowercase form ("recall" / "transform" / ...). pine-go's OperatorType
-    // is PascalCase ("Recall") and gets formatted into the error verbatim,
-    // so we need the PascalCase form here for byte-exact parity.
-    std::string display_type;
-    if (op_type == "recall") {
-        display_type = "Recall";
-        if (has_cw) violations.push_back("SetCommon");
-        if (has_iw) violations.push_back("SetItem");
-        if (has_ri) violations.push_back("RemoveItem");
-        if (has_io) violations.push_back("SetItemOrder");
-    } else if (op_type == "transform") {
-        display_type = "Transform";
-        if (has_ai) violations.push_back("AddItem");
-        if (has_ri) violations.push_back("RemoveItem");
-        if (has_io) violations.push_back("SetItemOrder");
-    } else if (op_type == "filter") {
-        display_type = "Filter";
-        if (has_cw) violations.push_back("SetCommon");
-        if (has_iw) violations.push_back("SetItem");
-        if (has_ai) violations.push_back("AddItem");
-        if (has_io) violations.push_back("SetItemOrder");
-    } else if (op_type == "merge") {
-        display_type = "Merge";
-        if (has_cw) violations.push_back("SetCommon");
-        if (has_ai) violations.push_back("AddItem");
-        if (has_io) violations.push_back("SetItemOrder");
-    } else if (op_type == "reorder") {
-        display_type = "Reorder";
-        if (has_cw) violations.push_back("SetCommon");
-        if (has_iw) violations.push_back("SetItem");
-        if (has_ai) violations.push_back("AddItem");
-        if (has_ri) violations.push_back("RemoveItem");
-    } else if (op_type == "observe") {
-        display_type = "Observe";
-        if (has_cw) violations.push_back("SetCommon");
-        if (has_iw) violations.push_back("SetItem");
-        if (has_ai) violations.push_back("AddItem");
-        if (has_ri) violations.push_back("RemoveItem");
-        if (has_io) violations.push_back("SetItemOrder");
-    } else {
-        return;  // unknown type — earlier validation should already have failed
+  std::vector<std::string> violations;
+  // Note: op_type comes from OperatorConfig::operator_type which is the
+  // lowercase form ("recall" / "transform" / ...). pine-go's OperatorType
+  // is PascalCase ("Recall") and gets formatted into the error verbatim,
+  // so we need the PascalCase form here for byte-exact parity.
+  std::string display_type;
+  if (op_type == "recall") {
+    display_type = "Recall";
+    if (has_cw) {
+      violations.push_back("SetCommon");
     }
+    if (has_iw) {
+      violations.push_back("SetItem");
+    }
+    if (has_ri) {
+      violations.push_back("RemoveItem");
+    }
+    if (has_io) {
+      violations.push_back("SetItemOrder");
+    }
+  } else if (op_type == "transform") {
+    display_type = "Transform";
+    if (has_ai) {
+      violations.push_back("AddItem");
+    }
+    if (has_ri) {
+      violations.push_back("RemoveItem");
+    }
+    if (has_io) {
+      violations.push_back("SetItemOrder");
+    }
+  } else if (op_type == "filter") {
+    display_type = "Filter";
+    if (has_cw) {
+      violations.push_back("SetCommon");
+    }
+    if (has_iw) {
+      violations.push_back("SetItem");
+    }
+    if (has_ai) {
+      violations.push_back("AddItem");
+    }
+    if (has_io) {
+      violations.push_back("SetItemOrder");
+    }
+  } else if (op_type == "merge") {
+    display_type = "Merge";
+    if (has_cw) {
+      violations.push_back("SetCommon");
+    }
+    if (has_ai) {
+      violations.push_back("AddItem");
+    }
+    if (has_io) {
+      violations.push_back("SetItemOrder");
+    }
+  } else if (op_type == "reorder") {
+    display_type = "Reorder";
+    if (has_cw) {
+      violations.push_back("SetCommon");
+    }
+    if (has_iw) {
+      violations.push_back("SetItem");
+    }
+    if (has_ai) {
+      violations.push_back("AddItem");
+    }
+    if (has_ri) {
+      violations.push_back("RemoveItem");
+    }
+  } else if (op_type == "observe") {
+    display_type = "Observe";
+    if (has_cw) {
+      violations.push_back("SetCommon");
+    }
+    if (has_iw) {
+      violations.push_back("SetItem");
+    }
+    if (has_ai) {
+      violations.push_back("AddItem");
+    }
+    if (has_ri) {
+      violations.push_back("RemoveItem");
+    }
+    if (has_io) {
+      violations.push_back("SetItemOrder");
+    }
+  } else {
+    return;  // unknown type — earlier validation should already have failed
+  }
 
-    if (violations.empty()) return;
-    std::string list = "[";
-    for (std::size_t i = 0; i < violations.size(); ++i) {
-        if (i > 0) list += " ";
-        list += violations[i];
+  if (violations.empty()) {
+    return;
+  }
+  std::string list = "[";
+  for (std::size_t i = 0; i < violations.size(); ++i) {
+    if (i > 0) {
+      list += " ";
     }
-    list += "]";
-    throw ExecutionError(op_name, "type violation: operator type " + display_type +
-                                  " must not call " + list);
+    list += violations[i];
+  }
+  list += "]";
+  throw ExecutionError(op_name, "type violation: operator type " + display_type + " must not call " + list);
 }
 
 // dispatch_with_recovery runs dispatch_operator and converts any non-pine::Error
@@ -407,27 +492,27 @@ void validate_output_against_type(const std::string& op_name,
 void dispatch_with_recovery(const OperatorInput& input, const OperatorConfig& op,
                             const std::map<std::string, std::unique_ptr<Operator>>& operators,
                             OperatorOutput& out) {
-    try {
-        dispatch_operator(input, op, operators, out);
-    } catch (ExecutionError& e) {
-        // If the execution error was thrown without operator name context or
-        // formatted with raw inner message, ensure it matches:
-        // `pine: execution error in operator "X": <inner>`
-        if (e.operator_name().empty()) {
-            std::throw_with_nested(ExecutionError(op.name, e.inner().empty() ? std::string(e.what()) : e.inner()));
-        }
-        throw;
-    } catch (const Error&) {
-        throw;
-    } catch (const std::exception& e) {
-        std::throw_with_nested(PanicError(op.name, e.what()));
-    } catch (...) {
-        // Non-std::exception payloads (`throw 42;`, `throw "literal";`) are
-        // rare but legal. throw_with_nested still captures them so
-        // pine::error_as<T>() can at least walk the chain even if no frame
-        // dynamic_casts to a useful type.
-        std::throw_with_nested(PanicError(op.name, "unknown exception"));
+  try {
+    dispatch_operator(input, op, operators, out);
+  } catch (ExecutionError& e) {
+    // If the execution error was thrown without operator name context or
+    // formatted with raw inner message, ensure it matches:
+    // `pine: execution error in operator "X": <inner>`
+    if (e.operator_name().empty()) {
+      std::throw_with_nested(ExecutionError(op.name, e.inner().empty() ? std::string(e.what()) : e.inner()));
     }
+    throw;
+  } catch (const Error&) {
+    throw;
+  } catch (const std::exception& e) {
+    std::throw_with_nested(PanicError(op.name, e.what()));
+  } catch (...) {
+    // Non-std::exception payloads (`throw 42;`, `throw "literal";`) are
+    // rare but legal. throw_with_nested still captures them so
+    // pine::error_as<T>() can at least walk the chain even if no frame
+    // dynamic_casts to a useful type.
+    std::throw_with_nested(PanicError(op.name, "unknown exception"));
+  }
 }
 
 // merge_shard_output merges a shard's OperatorOutput into the master output,
@@ -439,27 +524,26 @@ void dispatch_with_recovery(const OperatorInput& input, const OperatorConfig& op
 // writes (which would happen only if config validation or operator schema
 // was bypassed), fail loudly rather than silently dropping data — the
 // reviewer-flagged silent-drop path.
-void merge_shard_output(OperatorOutput& dst, const OperatorOutput& src,
-                        int offset, const std::string& op_name) {
-    if (!src.added_items().empty() || src.has_item_order() ||
-        !src.common_writes().empty()) {
-        // Message body must match pine-go/parallel.go:65, pine-java
-        // ParallelExecutor.java:85, and pine-python parallel.py:86-88
-        // byte-for-byte — PanicError values are part of the cross-runtime
-        // contract (memory: "运行时错误对等需字节级一致").
-        throw PanicError(op_name,
-            "data_parallel shard emitted added_items, item_order, or common "
-            "writes; only item_writes / removed_items / warnings are allowed");
-    }
-    for (const auto& [idx, field, value] : src.item_writes()) {
-        dst.set_item(idx + offset, field, value);
-    }
-    for (int idx : src.removed_items()) {
-        dst.remove_item(idx + offset);
-    }
-    if (src.has_warning()) {
-        dst.set_warning(src.warning());
-    }
+void merge_shard_output(OperatorOutput& dst, const OperatorOutput& src, int offset,
+                        const std::string& op_name) {
+  if (!src.added_items().empty() || src.has_item_order() || !src.common_writes().empty()) {
+    // Message body must match pine-go/parallel.go:65, pine-java
+    // ParallelExecutor.java:85, and pine-python parallel.py:86-88
+    // byte-for-byte — PanicError values are part of the cross-runtime
+    // contract (memory: "运行时错误对等需字节级一致").
+    throw PanicError(op_name,
+                     "data_parallel shard emitted added_items, item_order, or common "
+                     "writes; only item_writes / removed_items / warnings are allowed");
+  }
+  for (const auto& [idx, field, value] : src.item_writes()) {
+    dst.set_item(idx + offset, field, value);
+  }
+  for (int idx : src.removed_items()) {
+    dst.remove_item(idx + offset);
+  }
+  if (src.has_warning()) {
+    dst.set_warning(src.warning());
+  }
 }
 
 // parallel_execute shards frame.items across op.data_parallel workers, executes
@@ -478,91 +562,97 @@ void merge_shard_output(OperatorOutput& dst, const OperatorOutput& src,
 // the legacy per-shard std::thread fallback runs — kept so unit tests and
 // stand-alone callers that construct Frame directly still work.
 void parallel_execute(const Frame& frame, const OperatorConfig& op,
-                      const std::map<std::string, std::unique_ptr<Operator>>& operators,
-                      OperatorOutput& out,
-                      const InputFieldSpec& spec,
-                      runtime::ThreadPool* pool = nullptr) {
-    int total = static_cast<int>(frame.item_count());
-    int n = op.data_parallel;
-    if (n <= 1 || total == 0) {
-        OperatorInput input = build_operator_input(frame, op.name, spec);
-        dispatch_with_recovery(input, op, operators, out);
-        return;
+                      const std::map<std::string, std::unique_ptr<Operator>>& operators, OperatorOutput& out,
+                      const InputFieldSpec& spec, runtime::ThreadPool* pool = nullptr) {
+  int total = static_cast<int>(frame.item_count());
+  int n = op.data_parallel;
+  if (n <= 1 || total == 0) {
+    OperatorInput input = build_operator_input(frame, op.name, spec);
+    dispatch_with_recovery(input, op, operators, out);
+    return;
+  }
+  if (n > total) {
+    n = total;
+  }
+
+  int base = total / n;
+  int rem = total % n;
+
+  // Build shards as zero-copy window views into the parent frame's
+  // ColumnStore. Previously each shard materialised its rows
+  // into a fresh row-major list and then back into a per-shard
+  // ColumnStore — costing 2 × column-cell touches per request just to
+  // set up parallelism. The window view shares parent storage with an
+  // (offset, count) translation; the parent is read-only during the
+  // shard window (no apply_output until merge_shard_output below).
+  std::vector<std::unique_ptr<Frame>> shards;
+  shards.reserve(static_cast<std::size_t>(n));
+  std::vector<OperatorOutput> shard_outs(static_cast<std::size_t>(n));
+  std::vector<int> offsets(static_cast<std::size_t>(n));
+  int cursor = 0;
+  for (int i = 0; i < n; ++i) {
+    int size = base + (i < rem ? 1 : 0);
+    auto shard = frame.make_window_view(static_cast<std::size_t>(cursor), static_cast<std::size_t>(size));
+    shards.push_back(std::move(shard));
+    offsets[static_cast<std::size_t>(i)] = cursor;
+    cursor += size;
+  }
+
+  std::mutex err_mu;
+  std::exception_ptr first_err;
+  // shard-level cancellation: first shard to fail flips this flag so
+  // un-started shards bail out before invoking dispatch_with_recovery.
+  // Mirrors pine-go parallel.go:118 — `cancel()` after errOnce.Do.
+  // Shards already running cannot be interrupted mid-execute (operators
+  // are not designed to be re-entrant against cancel during their own
+  // execute body), so the saving is for shards still queued in the
+  // ThreadPool / awaiting their thread slot.
+  std::atomic<bool> shard_cancel{false};
+
+  auto shard_body = [&](int i) {
+    if (shard_cancel.load(std::memory_order_acquire)) {
+      return;
     }
-    if (n > total) n = total;
+    try {
+      OperatorInput input = build_operator_input(*shards[static_cast<std::size_t>(i)], op.name, spec);
+      dispatch_with_recovery(input, op, operators, shard_outs[static_cast<std::size_t>(i)]);
+    } catch (...) {
+      std::lock_guard<std::mutex> lk(err_mu);
+      if (!first_err) {
+        first_err = std::current_exception();
+        shard_cancel.store(true, std::memory_order_release);
+      }
+    }
+  };
 
-    int base = total / n;
-    int rem = total % n;
-
-    // Build shards as zero-copy window views into the parent frame's
-    // ColumnStore. Previously each shard materialised its rows
-    // into a fresh row-major list and then back into a per-shard
-    // ColumnStore — costing 2 × column-cell touches per request just to
-    // set up parallelism. The window view shares parent storage with an
-    // (offset, count) translation; the parent is read-only during the
-    // shard window (no apply_output until merge_shard_output below).
-    std::vector<std::unique_ptr<Frame>> shards;
-    shards.reserve(static_cast<std::size_t>(n));
-    std::vector<OperatorOutput> shard_outs(static_cast<std::size_t>(n));
-    std::vector<int> offsets(static_cast<std::size_t>(n));
-    int cursor = 0;
+  if (pool != nullptr) {
+    std::vector<std::future<void>> futs;
+    futs.reserve(static_cast<std::size_t>(n));
     for (int i = 0; i < n; ++i) {
-        int size = base + (i < rem ? 1 : 0);
-        auto shard = frame.make_window_view(static_cast<std::size_t>(cursor),
-                                              static_cast<std::size_t>(size));
-        shards.push_back(std::move(shard));
-        offsets[static_cast<std::size_t>(i)] = cursor;
-        cursor += size;
+      futs.push_back(pool->submit([&, i]() { shard_body(i); }));
     }
-
-    std::mutex err_mu;
-    std::exception_ptr first_err;
-    // shard-level cancellation: first shard to fail flips this flag so
-    // un-started shards bail out before invoking dispatch_with_recovery.
-    // Mirrors pine-go parallel.go:118 — `cancel()` after errOnce.Do.
-    // Shards already running cannot be interrupted mid-execute (operators
-    // are not designed to be re-entrant against cancel during their own
-    // execute body), so the saving is for shards still queued in the
-    // ThreadPool / awaiting their thread slot.
-    std::atomic<bool> shard_cancel{false};
-
-    auto shard_body = [&](int i) {
-        if (shard_cancel.load(std::memory_order_acquire)) return;
-        try {
-            OperatorInput input = build_operator_input(*shards[static_cast<std::size_t>(i)], op.name, spec);
-            dispatch_with_recovery(input, op, operators,
-                                   shard_outs[static_cast<std::size_t>(i)]);
-        } catch (...) {
-            std::lock_guard<std::mutex> lk(err_mu);
-            if (!first_err) {
-                first_err = std::current_exception();
-                shard_cancel.store(true, std::memory_order_release);
-            }
-        }
-    };
-
-    if (pool != nullptr) {
-        std::vector<std::future<void>> futs;
-        futs.reserve(static_cast<std::size_t>(n));
-        for (int i = 0; i < n; ++i) {
-            futs.push_back(pool->submit([&, i]() { shard_body(i); }));
-        }
-        for (auto& f : futs) f.wait();
-    } else {
-        std::vector<std::thread> threads;
-        threads.reserve(static_cast<std::size_t>(n));
-        for (int i = 0; i < n; ++i) {
-            threads.emplace_back([&, i]() { shard_body(i); });
-        }
-        for (auto& t : threads) t.join();
+    for (auto& f : futs) {
+      f.wait();
     }
-
-    if (first_err) std::rethrow_exception(first_err);
-
+  } else {
+    std::vector<std::thread> threads;
+    threads.reserve(static_cast<std::size_t>(n));
     for (int i = 0; i < n; ++i) {
-        merge_shard_output(out, shard_outs[static_cast<std::size_t>(i)],
-                           offsets[static_cast<std::size_t>(i)], op.name);
+      threads.emplace_back([&, i]() { shard_body(i); });
     }
+    for (auto& t : threads) {
+      t.join();
+    }
+  }
+
+  if (first_err) {
+    std::rethrow_exception(first_err);
+  }
+
+  for (int i = 0; i < n; ++i) {
+    merge_shard_output(out, shard_outs[static_cast<std::size_t>(i)], offsets[static_cast<std::size_t>(i)],
+                       op.name);
+  }
 }
 
 // run_dag executes the DAG concurrently: each node runs on its own thread,
@@ -572,372 +662,406 @@ void parallel_execute(const Frame& frame, const OperatorConfig& op,
 // bail out; the captured exception is rethrown by the caller.
 // Mirrors pine-go internal/runtime/scheduler.go (per-node goroutines, done
 // channels, fatalOnce + context cancel).
-std::vector<OpTrace> run_dag(const Config& config,
-                             const Graph& graph,
+std::vector<OpTrace> run_dag(const Config& config, const Graph& graph,
                              const std::map<std::string, std::unique_ptr<Operator>>& operators,
-                             const std::map<std::string, InputFieldSpec>& input_specs,
-                             Frame& frame,
-                             bool collect_traces,
-                             std::atomic<int64_t>* peak_concurrency = nullptr,
-                             Engine::EngineMetrics* em = nullptr,
-                             runtime::ThreadPool* shard_pool = nullptr,
+                             const std::map<std::string, InputFieldSpec>& input_specs, Frame& frame,
+                             bool collect_traces, std::atomic<int64_t>* peak_concurrency = nullptr,
+                             Engine::EngineMetrics* em = nullptr, runtime::ThreadPool* shard_pool = nullptr,
                              std::stop_token external_cancel = std::stop_token{}) {
-    const std::size_t n = graph.nodes.size();
+  const std::size_t n = graph.nodes.size();
 
-    if (em && em->scheduler_runs) em->scheduler_runs->inc();
-    auto dag_start = std::chrono::steady_clock::now();
-    std::atomic<int64_t> ops_executed{0};
+  if (em && em->scheduler_runs) {
+    em->scheduler_runs->inc();
+  }
+  auto dag_start = std::chrono::steady_clock::now();
+  std::atomic<int64_t> ops_executed{0};
 
-    // NodeSignal replaces std::promise/shared_future so that a fail() can
-    // interrupt waits on still-pending predecessors through a stop_token,
-    // rather than the old "wait until predecessor self-terminates" pattern
-    // which forced every sibling to block until its own predecessors
-    // finished). condition_variable_any::wait(lock, stop_token,
-    // pred) is C++20 P0660 — it returns immediately when stop is requested.
-    struct NodeSignal {
-        std::mutex mu;
-        std::condition_variable_any cv;
-        bool done = false;
-    };
-    std::vector<std::unique_ptr<NodeSignal>> signals;
-    signals.reserve(n);
-    for (std::size_t i = 0; i < n; ++i) {
-        signals.emplace_back(std::make_unique<NodeSignal>());
+  // NodeSignal replaces std::promise/shared_future so that a fail() can
+  // interrupt waits on still-pending predecessors through a stop_token,
+  // rather than the old "wait until predecessor self-terminates" pattern
+  // which forced every sibling to block until its own predecessors
+  // finished). condition_variable_any::wait(lock, stop_token,
+  // pred) is C++20 P0660 — it returns immediately when stop is requested.
+  struct NodeSignal {
+    std::mutex mu;
+    std::condition_variable_any cv;
+    bool done = false;
+  };
+  std::vector<std::unique_ptr<NodeSignal>> signals;
+  signals.reserve(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    signals.emplace_back(std::make_unique<NodeSignal>());
+  }
+
+  std::vector<OpTrace> traces;
+  if (collect_traces) {
+    traces.assign(n, OpTrace{});
+  }
+
+  // Frame concurrency is managed by ColumnFrame's internal
+  // shared_mutex (column_frame.hpp:79). The DAG topology guarantees
+  // predecessor-successor ordering through NodeSignal, and parallel_execute
+  // shards copy items out before mutating, so siblings on the same DAG
+  // level only ever issue concurrent reads. We removed the redundant
+  // engine-level frame_mu — the inner lock is the source of truth.
+  std::mutex fatal_mu;
+  std::exception_ptr fatal_err;
+  std::atomic<int64_t> active_ops{0};
+
+  // stop_source broadcasts cancellation to every node waiting on a
+  // predecessor via cv.wait(lock, stop_token, pred). Replacing the
+  // old `std::atomic<bool> cancelled` with stop_token lets the cv
+  // implementation interrupt the wait directly — no polling, no
+  // sleep_for.
+  std::stop_source cancel_source;
+  auto stop_token = cancel_source.get_token();
+
+  // Bridge the caller-supplied external cancel token (e.g. client disconnect
+  // signal from server.cpp) into the engine-internal cancel_source. The
+  // callback fires once when external_cancel.request_stop() is called and
+  // forwards it to cancel_source so every cv.wait(lock, stop_token, pred)
+  // currently parked in this DAG returns immediately. Mirrors pine-go's
+  // Execute(ctx, req) flow where the scheduler watches ctx.Done() at
+  // every wait.
+  //
+  // RAII ordering: declared after cancel_source so it destructs first —
+  // the callback is unregistered before cancel_source's stop_state is
+  // destroyed, avoiding any use-after-free across threads.
+  std::optional<std::stop_callback<std::function<void()>>> external_link;
+  if (external_cancel.stop_possible()) {
+    external_link.emplace(external_cancel,
+                          std::function<void()>([&cancel_source] { cancel_source.request_stop(); }));
+  }
+
+  auto fail = [&](std::exception_ptr e) {
+    std::lock_guard<std::mutex> lk(fatal_mu);
+    if (!fatal_err) {
+      fatal_err = e;
+      cancel_source.request_stop();
     }
+  };
 
-    std::vector<OpTrace> traces;
-    if (collect_traces) traces.assign(n, OpTrace{});
-
-    // Frame concurrency is managed by ColumnFrame's internal
-    // shared_mutex (column_frame.hpp:79). The DAG topology guarantees
-    // predecessor-successor ordering through NodeSignal, and parallel_execute
-    // shards copy items out before mutating, so siblings on the same DAG
-    // level only ever issue concurrent reads. We removed the redundant
-    // engine-level frame_mu — the inner lock is the source of truth.
-    std::mutex fatal_mu;
-    std::exception_ptr fatal_err;
-    std::atomic<int64_t> active_ops{0};
-
-    // stop_source broadcasts cancellation to every node waiting on a
-    // predecessor via cv.wait(lock, stop_token, pred). Replacing the
-    // old `std::atomic<bool> cancelled` with stop_token lets the cv
-    // implementation interrupt the wait directly — no polling, no
-    // sleep_for.
-    std::stop_source cancel_source;
-    auto stop_token = cancel_source.get_token();
-
-    // Bridge the caller-supplied external cancel token (e.g. client disconnect
-    // signal from server.cpp) into the engine-internal cancel_source. The
-    // callback fires once when external_cancel.request_stop() is called and
-    // forwards it to cancel_source so every cv.wait(lock, stop_token, pred)
-    // currently parked in this DAG returns immediately. Mirrors pine-go's
-    // Execute(ctx, req) flow where the scheduler watches ctx.Done() at
-    // every wait.
-    //
-    // RAII ordering: declared after cancel_source so it destructs first —
-    // the callback is unregistered before cancel_source's stop_state is
-    // destroyed, avoiding any use-after-free across threads.
-    std::optional<std::stop_callback<std::function<void()>>> external_link;
-    if (external_cancel.stop_possible()) {
-        external_link.emplace(external_cancel,
-            std::function<void()>([&cancel_source] { cancel_source.request_stop(); }));
+  auto mark_done = [&](std::size_t idx) {
+    auto& s = *signals[idx];
+    {
+      std::lock_guard<std::mutex> lk(s.mu);
+      s.done = true;
     }
+    s.cv.notify_all();
+  };
 
-    auto fail = [&](std::exception_ptr e) {
-        std::lock_guard<std::mutex> lk(fatal_mu);
-        if (!fatal_err) {
-            fatal_err = e;
-            cancel_source.request_stop();
-        }
-    };
-
-    auto mark_done = [&](std::size_t idx) {
-        auto& s = *signals[idx];
-        {
-            std::lock_guard<std::mutex> lk(s.mu);
-            s.done = true;
-        }
-        s.cv.notify_all();
-    };
-
-    // CAS-update the cumulative peak to at least n_current.
-    // Mirrors pine-go internal/runtime/stats.go Stats.RecordConcurrency.
-    auto record_peak = [&](int64_t n_current) {
-        if (!peak_concurrency) return;
-        for (;;) {
-            int64_t cur = peak_concurrency->load(std::memory_order_relaxed);
-            if (n_current <= cur) return;
-            if (peak_concurrency->compare_exchange_weak(cur, n_current,
-                                                       std::memory_order_relaxed)) {
-                return;
-            }
-        }
-    };
-
-    std::vector<std::thread> threads;
-    threads.reserve(n);
-    for (std::size_t i = 0; i < n; ++i) {
-        threads.emplace_back([&, i]() {
-            // RAII: always notify successors, even on early return / exception.
-            struct Notifier {
-                std::function<void()> fn;
-                ~Notifier() { try { fn(); } catch (...) {} }
-            } notifier{[&, i] { mark_done(i); }};
-            (void)notifier;
-
-            const auto& node = graph.nodes[i];
-            const auto& op = config.operators.at(node.name);
-
-            // Wait on every predecessor's done flag; cv.wait with stop_token
-            // returns false when fail() requests stop, letting us bail out
-            // without serializing through still-running siblings.
-            for (int pred : node.preds) {
-                auto& s = *signals[static_cast<std::size_t>(pred)];
-                std::unique_lock<std::mutex> lk(s.mu);
-                bool got_pred = s.cv.wait(lk, stop_token, [&] { return s.done; });
-                if (!got_pred) return;  // stop requested
-            }
-            if (stop_token.stop_requested()) return;
-
-            // Track active concurrency (mirrors pine-go scheduler activeOps + RecordConcurrency).
-            // Gauge must be updated on both increment AND decrement.
-            // The earlier guard only fetch_sub'd the atomic without touching
-            // the Prometheus handle, leaving pine_operator_active monotonic-
-            // increasing and meaningless for monitoring.
-            struct ActiveGuard {
-                std::atomic<int64_t>& counter;
-                metrics::Gauge* gauge;
-                ~ActiveGuard() {
-                    int64_t after = counter.fetch_sub(1, std::memory_order_relaxed) - 1;
-                    if (gauge) gauge->set(static_cast<double>(after));
-                }
-            };
-            int64_t cur_active = active_ops.fetch_add(1, std::memory_order_relaxed) + 1;
-            ActiveGuard active_guard{active_ops, em ? em->active_ops : nullptr};
-            record_peak(cur_active);
-            if (em && em->active_ops) em->active_ops->set(static_cast<double>(cur_active));
-
-            OpTrace trace;
-            if (collect_traces) {
-                trace.name = op.name;
-                trace.start_time_us = now_us();
-            }
-            auto start = std::chrono::steady_clock::now();
-
-            // Hoisted so the catch block below can salvage the operator's
-            // pre-failure warning.
-            OperatorOutput out;
-
-            try {
-                bool skip = should_skip(frame, op);
-                if (skip) {
-                    if (em && em->op_skip_total) em->op_skip_total->with({op.name})->inc();
-                    if (collect_traces) {
-                        auto end = std::chrono::steady_clock::now();
-                        trace.duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-                        trace.skipped = true;
-                        traces[i] = std::move(trace);
-                    }
-                    return;
-                }
-
-                if (collect_traces && op.debug.value_or(false)) {
-                    trace.input_snapshot = snapshot_input(frame, op);
-                    trace.has_input_snapshot = true;
-                }
-                parallel_execute(frame, op, operators, out, input_specs.at(op.name), shard_pool);
-                if (collect_traces && op.debug.value_or(false)) {
-                    trace.output_snapshot = snapshot_output(out);
-                    trace.has_output_snapshot = true;
-                }
-                // Type-constraint check (pine-go scheduler.go:171). Run before
-                // apply_output so a violation aborts the operator without
-                // mutating the master frame. The bare-message ExecutionError
-                // here gets the standard `pine: execution error in operator
-                // "X": ...` prefix added by the outer run_dag catch block.
-                validate_output_against_type(op.name, op.operator_type, out);
-
-                // [pine-debug] log line for op.debug operators. Mirrors
-                // pine-go scheduler.go:231 and pine-java Engine.java:448.
-                // Emit on stderr, with Java-style duration formatting
-                // (µs below 1ms, ms above). Done before apply_output so
-                // the snapshot reflects the inputs that produced this
-                // output.
-                if (op.debug.value_or(false)) {
-                    auto dur = std::chrono::steady_clock::now() - start;
-                    auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(dur).count();
-                    std::string dur_str;
-                    if (nanos < 1'000'000) {
-                        dur_str = std::to_string(nanos / 1000.0) + "µs";
-                    } else {
-                        dur_str = std::to_string(nanos / 1'000'000.0) + "ms";
-                    }
-                    std::size_t input_size = frame.item_count();
-                    std::size_t output_size = input_size + out.added_items().size() - out.removed_items().size();
-                    std::string in_json = trace.has_input_snapshot
-                        ? dump_json(trace.input_snapshot, 0) : std::string("{}");
-                    std::string out_json = trace.has_output_snapshot
-                        ? dump_json(trace.output_snapshot, 0) : std::string("{}");
-                    // R13-1: compact mode used above; no trailing newline
-                    // to strip. Old code stripped trailing '\n' from the
-                    // indented form — kept the loop as defensive no-op so
-                    // any future formatting drift still keeps the log line
-                    // single-line.
-                    while (!in_json.empty() && in_json.back() == '\n') in_json.pop_back();
-                    while (!out_json.empty() && out_json.back() == '\n') out_json.pop_back();
-                    std::cerr << "[pine-debug] operator=\"" << op.name
-                              << "\" duration=" << dur_str
-                              << " input_size=" << input_size
-                              << " output_size=" << output_size
-                              << " input=" << in_json
-                              << " output=" << out_json << "\n";
-                }
-                frame.apply_output(out, op.name, op.operator_type == "recall");
-                auto end = std::chrono::steady_clock::now();
-                auto dur_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
-                if (em) {
-                    if (em->op_exec_total) em->op_exec_total->with({op.name})->inc();
-                    if (em->op_exec_duration) em->op_exec_duration->with({op.name})->observe(metrics::duration_seconds(dur_ns));
-                }
-                ops_executed.fetch_add(1, std::memory_order_relaxed);
-                if (collect_traces) {
-                    trace.duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-                    traces[i] = std::move(trace);
-                }
-            } catch (...) {
-                if (em && em->op_error_total) em->op_error_total->with({op.name})->inc();
-                // If the operator managed to attach a warning to its
-                // OperatorOutput before throwing (e.g. "Redis unreachable,
-                // falling back to cache-miss"), surface it via the frame so
-                // the diagnostic survives the failure path. The frame
-                // serializes warnings into the response /execute envelope
-                // even when the request ultimately errors.
-                if (out.has_warning()) {
-                    try {
-                        frame.push_warning(std::string("operator \"") + op.name + "\": " + out.warning());
-                    } catch (...) {
-                        // Ignore — fail() below carries the original error.
-                    }
-                }
-                fail(std::current_exception());
-            }
-        });
+  // CAS-update the cumulative peak to at least n_current.
+  // Mirrors pine-go internal/runtime/stats.go Stats.RecordConcurrency.
+  auto record_peak = [&](int64_t n_current) {
+    if (!peak_concurrency) {
+      return;
     }
-
-    for (auto& t : threads) t.join();
-
-    auto dag_end = std::chrono::steady_clock::now();
-    if (em) {
-        if (em->dag_exec_duration) {
-            em->dag_exec_duration->observe(metrics::duration_seconds(
-                std::chrono::duration_cast<std::chrono::nanoseconds>(dag_end - dag_start)));
-        }
-        if (em->dag_ops_executed) {
-            em->dag_ops_executed->observe(static_cast<double>(ops_executed.load(std::memory_order_relaxed)));
-        }
-        if (em->dag_exec_total) {
-            em->dag_exec_total->with({fatal_err ? "error" : "success"})->inc();
-        }
+    for (;;) {
+      int64_t cur = peak_concurrency->load(std::memory_order_relaxed);
+      if (n_current <= cur) {
+        return;
+      }
+      if (peak_concurrency->compare_exchange_weak(cur, n_current, std::memory_order_relaxed)) {
+        return;
+      }
     }
+  };
 
-    if (fatal_err) std::rethrow_exception(fatal_err);
+  std::vector<std::thread> threads;
+  threads.reserve(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    threads.emplace_back([&, i]() {
+      // RAII: always notify successors, even on early return / exception.
+      struct Notifier {
+        std::function<void()> fn;
+        ~Notifier() {
+          try {
+            fn();
+          } catch (...) {
+          }
+        }
+      } notifier{[&, i] { mark_done(i); }};
+      (void)notifier;
 
-    // Filter out pre-allocated trace slots that never got populated — Go
-    // does the same at scheduler.go:285. Empty .name means the node was
-    // never reached (DAG aborted before reaching this slot).
-    std::vector<OpTrace> filtered;
-    filtered.reserve(traces.size());
-    for (auto& t : traces) {
-        if (!t.name.empty()) filtered.push_back(std::move(t));
+      const auto& node = graph.nodes[i];
+      const auto& op = config.operators.at(node.name);
+
+      // Wait on every predecessor's done flag; cv.wait with stop_token
+      // returns false when fail() requests stop, letting us bail out
+      // without serializing through still-running siblings.
+      for (int pred : node.preds) {
+        auto& s = *signals[static_cast<std::size_t>(pred)];
+        std::unique_lock<std::mutex> lk(s.mu);
+        bool got_pred = s.cv.wait(lk, stop_token, [&] { return s.done; });
+        if (!got_pred) {
+          return;  // stop requested
+        }
+      }
+      if (stop_token.stop_requested()) {
+        return;
+      }
+
+      // Track active concurrency (mirrors pine-go scheduler activeOps + RecordConcurrency).
+      // Gauge must be updated on both increment AND decrement.
+      // The earlier guard only fetch_sub'd the atomic without touching
+      // the Prometheus handle, leaving pine_operator_active monotonic-
+      // increasing and meaningless for monitoring.
+      struct ActiveGuard {
+        std::atomic<int64_t>& counter;
+        metrics::Gauge* gauge;
+        ~ActiveGuard() {
+          int64_t after = counter.fetch_sub(1, std::memory_order_relaxed) - 1;
+          if (gauge) {
+            gauge->set(static_cast<double>(after));
+          }
+        }
+      };
+      int64_t cur_active = active_ops.fetch_add(1, std::memory_order_relaxed) + 1;
+      ActiveGuard active_guard{active_ops, em ? em->active_ops : nullptr};
+      record_peak(cur_active);
+      if (em && em->active_ops) {
+        em->active_ops->set(static_cast<double>(cur_active));
+      }
+
+      OpTrace trace;
+      if (collect_traces) {
+        trace.name = op.name;
+        trace.start_time_us = now_us();
+      }
+      auto start = std::chrono::steady_clock::now();
+
+      // Hoisted so the catch block below can salvage the operator's
+      // pre-failure warning.
+      OperatorOutput out;
+
+      try {
+        bool skip = should_skip(frame, op);
+        if (skip) {
+          if (em && em->op_skip_total) {
+            em->op_skip_total->with({op.name})->inc();
+          }
+          if (collect_traces) {
+            auto end = std::chrono::steady_clock::now();
+            trace.duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+            trace.skipped = true;
+            traces[i] = std::move(trace);
+          }
+          return;
+        }
+
+        if (collect_traces && op.debug.value_or(false)) {
+          trace.input_snapshot = snapshot_input(frame, op);
+          trace.has_input_snapshot = true;
+        }
+        parallel_execute(frame, op, operators, out, input_specs.at(op.name), shard_pool);
+        if (collect_traces && op.debug.value_or(false)) {
+          trace.output_snapshot = snapshot_output(out);
+          trace.has_output_snapshot = true;
+        }
+        // Type-constraint check (pine-go scheduler.go:171). Run before
+        // apply_output so a violation aborts the operator without
+        // mutating the master frame. The bare-message ExecutionError
+        // here gets the standard `pine: execution error in operator
+        // "X": ...` prefix added by the outer run_dag catch block.
+        validate_output_against_type(op.name, op.operator_type, out);
+
+        // [pine-debug] log line for op.debug operators. Mirrors
+        // pine-go scheduler.go:231 and pine-java Engine.java:448.
+        // Emit on stderr, with Java-style duration formatting
+        // (µs below 1ms, ms above). Done before apply_output so
+        // the snapshot reflects the inputs that produced this
+        // output.
+        if (op.debug.value_or(false)) {
+          auto dur = std::chrono::steady_clock::now() - start;
+          auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(dur).count();
+          std::string dur_str;
+          if (nanos < 1'000'000) {
+            dur_str = std::to_string(nanos / 1000.0) + "µs";
+          } else {
+            dur_str = std::to_string(nanos / 1'000'000.0) + "ms";
+          }
+          std::size_t input_size = frame.item_count();
+          std::size_t output_size = input_size + out.added_items().size() - out.removed_items().size();
+          std::string in_json =
+              trace.has_input_snapshot ? dump_json(trace.input_snapshot, 0) : std::string("{}");
+          std::string out_json =
+              trace.has_output_snapshot ? dump_json(trace.output_snapshot, 0) : std::string("{}");
+          // R13-1: compact mode used above; no trailing newline
+          // to strip. Old code stripped trailing '\n' from the
+          // indented form — kept the loop as defensive no-op so
+          // any future formatting drift still keeps the log line
+          // single-line.
+          while (!in_json.empty() && in_json.back() == '\n') {
+            in_json.pop_back();
+          }
+          while (!out_json.empty() && out_json.back() == '\n') {
+            out_json.pop_back();
+          }
+          std::cerr << "[pine-debug] operator=\"" << op.name << "\" duration=" << dur_str
+                    << " input_size=" << input_size << " output_size=" << output_size << " input=" << in_json
+                    << " output=" << out_json << "\n";
+        }
+        frame.apply_output(out, op.name, op.operator_type == "recall");
+        auto end = std::chrono::steady_clock::now();
+        auto dur_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+        if (em) {
+          if (em->op_exec_total) {
+            em->op_exec_total->with({op.name})->inc();
+          }
+          if (em->op_exec_duration) {
+            em->op_exec_duration->with({op.name})->observe(metrics::duration_seconds(dur_ns));
+          }
+        }
+        ops_executed.fetch_add(1, std::memory_order_relaxed);
+        if (collect_traces) {
+          trace.duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+          traces[i] = std::move(trace);
+        }
+      } catch (...) {
+        if (em && em->op_error_total) {
+          em->op_error_total->with({op.name})->inc();
+        }
+        // If the operator managed to attach a warning to its
+        // OperatorOutput before throwing (e.g. "Redis unreachable,
+        // falling back to cache-miss"), surface it via the frame so
+        // the diagnostic survives the failure path. The frame
+        // serializes warnings into the response /execute envelope
+        // even when the request ultimately errors.
+        if (out.has_warning()) {
+          try {
+            frame.push_warning(std::string("operator \"") + op.name + "\": " + out.warning());
+          } catch (...) {
+            // Ignore — fail() below carries the original error.
+          }
+        }
+        fail(std::current_exception());
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  auto dag_end = std::chrono::steady_clock::now();
+  if (em) {
+    if (em->dag_exec_duration) {
+      em->dag_exec_duration->observe(metrics::duration_seconds(
+          std::chrono::duration_cast<std::chrono::nanoseconds>(dag_end - dag_start)));
     }
-    return filtered;
+    if (em->dag_ops_executed) {
+      em->dag_ops_executed->observe(static_cast<double>(ops_executed.load(std::memory_order_relaxed)));
+    }
+    if (em->dag_exec_total) {
+      em->dag_exec_total->with({fatal_err ? "error" : "success"})->inc();
+    }
+  }
+
+  if (fatal_err) {
+    std::rethrow_exception(fatal_err);
+  }
+
+  // Filter out pre-allocated trace slots that never got populated — Go
+  // does the same at scheduler.go:285. Empty .name means the node was
+  // never reached (DAG aborted before reaching this slot).
+  std::vector<OpTrace> filtered;
+  filtered.reserve(traces.size());
+  for (auto& t : traces) {
+    if (!t.name.empty()) {
+      filtered.push_back(std::move(t));
+    }
+  }
+  return filtered;
 }
 
 }  // namespace
 
 Result Engine::execute(const Request& request) const {
-    static const std::map<std::string, JsonValue> empty_resources;
-    return execute(request, empty_resources, std::stop_token{});
+  static const std::map<std::string, JsonValue> empty_resources;
+  return execute(request, empty_resources, std::stop_token{});
 }
 
 Result Engine::execute(const Request& request, const std::map<std::string, JsonValue>& resources) const {
-    return execute(request, resources, std::stop_token{});
+  return execute(request, resources, std::stop_token{});
 }
 
-Result Engine::execute(const Request& request,
-                       const std::map<std::string, JsonValue>& resources,
+Result Engine::execute(const Request& request, const std::map<std::string, JsonValue>& resources,
                        std::stop_token external_cancel) const {
-    // Route through the traced path so partial-result salvage runs even
-    // for callers using the no-trace API. Mirrors pine-go's Execute()
-    // contract: `(*Result, error)` — partial Result survives errors. On
-    // exception the caller still loses access to the partial Result via
-    // this overload (no out-parameter in the signature); to access the
-    // partial Result and warnings, use execute_traced_into.
-    TracedResult traced;
-    execute_traced_into(request, resources, &traced, external_cancel);
-    return std::move(traced.result);
+  // Route through the traced path so partial-result salvage runs even
+  // for callers using the no-trace API. Mirrors pine-go's Execute()
+  // contract: `(*Result, error)` — partial Result survives errors. On
+  // exception the caller still loses access to the partial Result via
+  // this overload (no out-parameter in the signature); to access the
+  // partial Result and warnings, use execute_traced_into.
+  TracedResult traced;
+  execute_traced_into(request, resources, &traced, external_cancel);
+  return std::move(traced.result);
 }
 
-TracedResult Engine::execute_traced(const Request& request, const std::map<std::string, JsonValue>& resources) const {
-    TracedResult traced;
-    execute_traced_into(request, resources, &traced);
-    return traced;
+TracedResult Engine::execute_traced(const Request& request,
+                                    const std::map<std::string, JsonValue>& resources) const {
+  TracedResult traced;
+  execute_traced_into(request, resources, &traced);
+  return traced;
 }
 
-void Engine::execute_traced_into(const Request& request,
-                                  const std::map<std::string, JsonValue>& resources,
-                                  TracedResult* out) const {
-    execute_traced_into(request, resources, out, std::stop_token{});
+void Engine::execute_traced_into(const Request& request, const std::map<std::string, JsonValue>& resources,
+                                 TracedResult* out) const {
+  execute_traced_into(request, resources, out, std::stop_token{});
 }
 
-void Engine::execute_traced_into(const Request& request,
-                                  const std::map<std::string, JsonValue>& resources,
-                                  TracedResult* out,
-                                  std::stop_token external_cancel) const {
-    validate_request(request, config_.flow_contract);
-    // Frame is now the polymorphic base; pick the implementation
-    // requested by storage_mode ("column" / "row"), default "column".
-    std::unique_ptr<Frame> frame_ptr = make_frame(
-        config_.storage_mode, request.common, request.items);
-    Frame& frame = *frame_ptr;
-    frame.set_resources(&resources);
-    std::exception_ptr run_err = nullptr;
-    try {
-        out->trace = run_dag(config_, graph_, operators_, input_specs_, frame, /*collect_traces=*/true, peak_concurrency_.get(), engine_metrics_.get(),
-                             shard_pool_ ? &shard_pool_->pool : nullptr, external_cancel);
-    } catch (...) {
-        run_err = std::current_exception();
-    }
-    // Match Go: even on execution failure we project the partial Result and take warnings
-    out->result = project_result(frame, config_.flow_contract);
-    out->warnings = frame.take_warnings();
-    if (run_err) std::rethrow_exception(run_err);
+void Engine::execute_traced_into(const Request& request, const std::map<std::string, JsonValue>& resources,
+                                 TracedResult* out, std::stop_token external_cancel) const {
+  validate_request(request, config_.flow_contract);
+  // Frame is now the polymorphic base; pick the implementation
+  // requested by storage_mode ("column" / "row"), default "column".
+  std::unique_ptr<Frame> frame_ptr = make_frame(config_.storage_mode, request.common, request.items);
+  Frame& frame = *frame_ptr;
+  frame.set_resources(&resources);
+  std::exception_ptr run_err = nullptr;
+  try {
+    out->trace = run_dag(config_, graph_, operators_, input_specs_, frame, /*collect_traces=*/true,
+                         peak_concurrency_.get(), engine_metrics_.get(),
+                         shard_pool_ ? &shard_pool_->pool : nullptr, external_cancel);
+  } catch (...) {
+    run_err = std::current_exception();
+  }
+  // Match Go: even on execution failure we project the partial Result and take warnings
+  out->result = project_result(frame, config_.flow_contract);
+  out->warnings = frame.take_warnings();
+  if (run_err) {
+    std::rethrow_exception(run_err);
+  }
 }
 
 std::string Engine::render_dag(const std::string& format, int collapse) const {
-    if (format == "dot") return collapse > 0 ? render_collapsed_dot(graph_, collapse) : render_dot(graph_);
-    if (format == "mermaid") return collapse > 0 ? render_collapsed_mermaid(graph_, collapse) : render_mermaid(graph_);
-    throw ValidationError("unsupported DAG format \"" + format + "\" (use \"dot\" or \"mermaid\")");
+  if (format == "dot") {
+    return collapse > 0 ? render_collapsed_dot(graph_, collapse) : render_dot(graph_);
+  }
+  if (format == "mermaid") {
+    return collapse > 0 ? render_collapsed_mermaid(graph_, collapse) : render_mermaid(graph_);
+  }
+  throw ValidationError("unsupported DAG format \"" + format + "\" (use \"dot\" or \"mermaid\")");
 }
 
 int64_t Engine::peak_concurrency() const {
-    return peak_concurrency_ ? peak_concurrency_->load(std::memory_order_relaxed) : 0;
+  return peak_concurrency_ ? peak_concurrency_->load(std::memory_order_relaxed) : 0;
 }
 
 std::map<std::string, std::map<std::string, int64_t>> Engine::operator_custom_stats() const {
-    std::map<std::string, std::map<std::string, int64_t>> result;
-    for (const auto& cop : expanded_.sequence) {
-        auto it = operators_.find(cop); // cop is std::string
-        if (it != operators_.end()) {
-            if (auto* sp = dynamic_cast<const StatsProvider*>(it->second.get())) {
-                auto s = sp->operator_stats();
-                if (!s.empty()) {
-                    result[cop] = std::move(s);
-                }
-            }
+  std::map<std::string, std::map<std::string, int64_t>> result;
+  for (const auto& cop : expanded_.sequence) {
+    auto it = operators_.find(cop);  // cop is std::string
+    if (it != operators_.end()) {
+      if (auto* sp = dynamic_cast<const StatsProvider*>(it->second.get())) {
+        auto s = sp->operator_stats();
+        if (!s.empty()) {
+          result[cop] = std::move(s);
         }
+      }
     }
-    return result;
+  }
+  return result;
 }
 
 }  // namespace pine

--- a/pine-cpp/src/runtime/errors.cpp
+++ b/pine-cpp/src/runtime/errors.cpp
@@ -15,14 +15,14 @@ namespace {
 // inside the recovery deferred function.
 std::string capture_stack() {
 #if defined(PINE_HAS_STACKTRACE)
-    try {
-        auto t = std::stacktrace::current();
-        return std::to_string(t);
-    } catch (...) {
-        return "";  // libbacktrace may fail on stripped binaries
-    }
+  try {
+    auto t = std::stacktrace::current();
+    return std::to_string(t);
+  } catch (...) {
+    return "";  // libbacktrace may fail on stripped binaries
+  }
 #else
-    return "";
+  return "";
 #endif
 }
 }  // namespace
@@ -31,17 +31,20 @@ PanicError::PanicError(std::string operator_name, std::string value)
     : Error(format_msg(operator_name, value)),
       operator_(std::move(operator_name)),
       value_(std::move(value)),
-      stack_(capture_stack()) {}
+      stack_(capture_stack()) {
+}
 
 std::string PanicError::detailed_error() const {
-    // pine-go PanicError.DetailedError() is `pine: panic in operator
-    // "X": Y\nstack trace:\n<frames>` — match the same shape so log
-    // consumers can keyword-grep across runtimes. When no stack was
-    // captured (older toolchain), fall back to just what().
-    if (stack_.empty()) return what();
-    std::ostringstream os;
-    os << what() << "\nstack trace:\n" << stack_;
-    return os.str();
+  // pine-go PanicError.DetailedError() is `pine: panic in operator
+  // "X": Y\nstack trace:\n<frames>` — match the same shape so log
+  // consumers can keyword-grep across runtimes. When no stack was
+  // captured (older toolchain), fall back to just what().
+  if (stack_.empty()) {
+    return what();
+  }
+  std::ostringstream os;
+  os << what() << "\nstack trace:\n" << stack_;
+  return os.str();
 }
 
 }  // namespace pine

--- a/pine-cpp/src/runtime/metrics_nop.cpp
+++ b/pine-cpp/src/runtime/metrics_nop.cpp
@@ -6,41 +6,57 @@ namespace metrics {
 namespace {
 
 class NopCounter : public Counter {
-public:
-    Counter* with(const std::vector<std::string>&) override { return this; }
-    void inc() override {}
+ public:
+  Counter* with(const std::vector<std::string>&) override {
+    return this;
+  }
+  void inc() override {
+  }
 };
 
 class NopGauge : public Gauge {
-public:
-    Gauge* with(const std::vector<std::string>&) override { return this; }
-    void set(double) override {}
-    void add(double) override {}
+ public:
+  Gauge* with(const std::vector<std::string>&) override {
+    return this;
+  }
+  void set(double) override {
+  }
+  void add(double) override {
+  }
 };
 
 class NopHistogram : public Histogram {
-public:
-    Histogram* with(const std::vector<std::string>&) override { return this; }
-    void observe(double) override {}
+ public:
+  Histogram* with(const std::vector<std::string>&) override {
+    return this;
+  }
+  void observe(double) override {
+  }
 };
 
 class NopProvider : public Provider {
-public:
-    Counter* new_counter(const MetricOpts&) override { return &counter_; }
-    Gauge* new_gauge(const MetricOpts&) override { return &gauge_; }
-    Histogram* new_histogram(const HistogramOpts&) override { return &histogram_; }
+ public:
+  Counter* new_counter(const MetricOpts&) override {
+    return &counter_;
+  }
+  Gauge* new_gauge(const MetricOpts&) override {
+    return &gauge_;
+  }
+  Histogram* new_histogram(const HistogramOpts&) override {
+    return &histogram_;
+  }
 
-private:
-    NopCounter counter_;
-    NopGauge gauge_;
-    NopHistogram histogram_;
+ private:
+  NopCounter counter_;
+  NopGauge gauge_;
+  NopHistogram histogram_;
 };
 
 }  // namespace
 
 Provider* nop_provider() {
-    static NopProvider instance;
-    return &instance;
+  static NopProvider instance;
+  return &instance;
 }
 
 }  // namespace metrics

--- a/pine-cpp/src/runtime/thread_pool.cpp
+++ b/pine-cpp/src/runtime/thread_pool.cpp
@@ -4,47 +4,53 @@ namespace pine {
 namespace runtime {
 
 ThreadPool::ThreadPool(std::size_t worker_count) : worker_count_(worker_count) {
-    if (worker_count_ == 0) worker_count_ = 1;
-    workers_.reserve(worker_count_);
-    for (std::size_t i = 0; i < worker_count_; ++i) {
-        workers_.emplace_back([this] { this->worker_loop(); });
-    }
+  if (worker_count_ == 0) {
+    worker_count_ = 1;
+  }
+  workers_.reserve(worker_count_);
+  for (std::size_t i = 0; i < worker_count_; ++i) {
+    workers_.emplace_back([this] { this->worker_loop(); });
+  }
 }
 
 ThreadPool::~ThreadPool() {
-    {
-        std::lock_guard<std::mutex> lk(mu_);
-        stopping_ = true;
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    stopping_ = true;
+  }
+  cv_.notify_all();
+  for (auto& t : workers_) {
+    if (t.joinable()) {
+      t.join();
     }
-    cv_.notify_all();
-    for (auto& t : workers_) {
-        if (t.joinable()) t.join();
-    }
+  }
 }
 
 std::future<void> ThreadPool::submit(std::function<void()> task) {
-    std::packaged_task<void()> pt(std::move(task));
-    std::future<void> fut = pt.get_future();
-    {
-        std::lock_guard<std::mutex> lk(mu_);
-        tasks_.push(std::move(pt));
-    }
-    cv_.notify_one();
-    return fut;
+  std::packaged_task<void()> pt(std::move(task));
+  std::future<void> fut = pt.get_future();
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    tasks_.push(std::move(pt));
+  }
+  cv_.notify_one();
+  return fut;
 }
 
 void ThreadPool::worker_loop() {
-    for (;;) {
-        std::packaged_task<void()> task;
-        {
-            std::unique_lock<std::mutex> lk(mu_);
-            cv_.wait(lk, [this] { return stopping_ || !tasks_.empty(); });
-            if (stopping_ && tasks_.empty()) return;
-            task = std::move(tasks_.front());
-            tasks_.pop();
-        }
-        task();
+  for (;;) {
+    std::packaged_task<void()> task;
+    {
+      std::unique_lock<std::mutex> lk(mu_);
+      cv_.wait(lk, [this] { return stopping_ || !tasks_.empty(); });
+      if (stopping_ && tasks_.empty()) {
+        return;
+      }
+      task = std::move(tasks_.front());
+      tasks_.pop();
     }
+    task();
+  }
 }
 
 }  // namespace runtime

--- a/pine-cpp/src/runtime/thread_pool.hpp
+++ b/pine-cpp/src/runtime/thread_pool.hpp
@@ -22,28 +22,30 @@ namespace runtime {
 // future request-thread reuse fit naturally; DAG node scheduling currently
 // uses per-node std::thread to avoid this hazard.
 class ThreadPool {
-public:
-    explicit ThreadPool(std::size_t worker_count);
-    ~ThreadPool();
+ public:
+  explicit ThreadPool(std::size_t worker_count);
+  ~ThreadPool();
 
-    ThreadPool(const ThreadPool&) = delete;
-    ThreadPool& operator=(const ThreadPool&) = delete;
+  ThreadPool(const ThreadPool&) = delete;
+  ThreadPool& operator=(const ThreadPool&) = delete;
 
-    // Submit a task that will run on one of the pool workers. Returns a
-    // future the caller can wait on.
-    std::future<void> submit(std::function<void()> task);
+  // Submit a task that will run on one of the pool workers. Returns a
+  // future the caller can wait on.
+  std::future<void> submit(std::function<void()> task);
 
-    std::size_t worker_count() const { return worker_count_; }
+  std::size_t worker_count() const {
+    return worker_count_;
+  }
 
-private:
-    void worker_loop();
+ private:
+  void worker_loop();
 
-    std::size_t worker_count_;
-    std::vector<std::thread> workers_;
-    std::queue<std::packaged_task<void()>> tasks_;
-    std::mutex mu_;
-    std::condition_variable cv_;
-    bool stopping_ = false;
+  std::size_t worker_count_;
+  std::vector<std::thread> workers_;
+  std::queue<std::packaged_task<void()>> tasks_;
+  std::mutex mu_;
+  std::condition_variable cv_;
+  bool stopping_ = false;
 };
 
 }  // namespace runtime

--- a/pine-cpp/src/server/http_metrics.cpp
+++ b/pine-cpp/src/server/http_metrics.cpp
@@ -1,8 +1,9 @@
-#include "server.hpp"
-#include "http_stats.hpp"
 #include "pine/metrics.hpp"
 
 #include <chrono>
+
+#include "http_stats.hpp"
+#include "server.hpp"
 
 namespace pine {
 namespace server {
@@ -10,11 +11,19 @@ namespace server {
 namespace {
 
 const char* status_bucket(int code) {
-    if (code >= 500) return "5xx";
-    if (code >= 400) return "4xx";
-    if (code >= 300) return "3xx";
-    if (code >= 200) return "2xx";
-    return "other";
+  if (code >= 500) {
+    return "5xx";
+  }
+  if (code >= 400) {
+    return "4xx";
+  }
+  if (code >= 300) {
+    return "3xx";
+  }
+  if (code >= 200) {
+    return "2xx";
+  }
+  return "other";
 }
 
 }  // namespace
@@ -29,36 +38,32 @@ const char* status_bucket(int code) {
 // the lifetime of the server. http_stats may be nullptr (the middleware then
 // only feeds the external Provider).
 Middleware http_metrics_middleware(metrics::Provider* provider, HttpStats* http_stats) {
-    metrics::Counter* requests_total = provider->new_counter(
-        {"pine_http_requests_total", "Total HTTP requests.",
-         {"method", "path", "status"}});
-    metrics::Histogram* request_duration = provider->new_histogram(
-        {{"pine_http_request_duration_seconds", "HTTP request duration in seconds.",
-          {"method", "path"}},
-         {0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0}});
+  metrics::Counter* requests_total = provider->new_counter(
+      {"pine_http_requests_total", "Total HTTP requests.", {"method", "path", "status"}});
+  metrics::Histogram* request_duration = provider->new_histogram(
+      {{"pine_http_request_duration_seconds", "HTTP request duration in seconds.", {"method", "path"}},
+       {0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0}});
 
-    return [requests_total, request_duration, http_stats](MiddlewareContext& ctx,
-                                                          const std::function<void()>& next) {
-        auto start = std::chrono::steady_clock::now();
-        next();
-        auto dur = std::chrono::steady_clock::now() - start;
-        const char* bucket_name = status_bucket(ctx.status);
-        requests_total->with({ctx.method, ctx.normalized_path, bucket_name})->inc();
-        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(dur);
-        request_duration->with({ctx.method, ctx.normalized_path})
-            ->observe(metrics::duration_seconds(ns));
-        if (http_stats != nullptr) {
-            http_stats->record_request(ctx.method, ctx.normalized_path,
-                                       bucket_name, ns.count());
-        }
-    };
+  return [requests_total, request_duration, http_stats](MiddlewareContext& ctx,
+                                                        const std::function<void()>& next) {
+    auto start = std::chrono::steady_clock::now();
+    next();
+    auto dur = std::chrono::steady_clock::now() - start;
+    const char* bucket_name = status_bucket(ctx.status);
+    requests_total->with({ctx.method, ctx.normalized_path, bucket_name})->inc();
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(dur);
+    request_duration->with({ctx.method, ctx.normalized_path})->observe(metrics::duration_seconds(ns));
+    if (http_stats != nullptr) {
+      http_stats->record_request(ctx.method, ctx.normalized_path, bucket_name, ns.count());
+    }
+  };
 }
 
 // Backwards-compatible overload retaining the original single-arg signature.
 // Callers that constructed the middleware before HttpStats existed continue
 // to compile; their middleware just won't feed /stats.http.
 Middleware http_metrics_middleware(metrics::Provider* provider) {
-    return http_metrics_middleware(provider, nullptr);
+  return http_metrics_middleware(provider, nullptr);
 }
 
 }  // namespace server

--- a/pine-cpp/src/server/http_stats.cpp
+++ b/pine-cpp/src/server/http_stats.cpp
@@ -4,24 +4,24 @@ namespace pine {
 namespace server {
 
 void HttpStats::record_request(const std::string& method, const std::string& path,
-                                const std::string& status_bucket, int64_t duration_ns) {
-    const std::string req_key = method + " " + path + " " + status_bucket;
-    const std::string dur_key = method + " " + path;
-    std::lock_guard<std::mutex> lock(mu_);
-    ++requests_[req_key];
-    auto& bucket = durations_[dur_key];
-    ++bucket.count;
-    bucket.sum_ns += duration_ns;
+                               const std::string& status_bucket, int64_t duration_ns) {
+  const std::string req_key = method + " " + path + " " + status_bucket;
+  const std::string dur_key = method + " " + path;
+  std::lock_guard<std::mutex> lock(mu_);
+  ++requests_[req_key];
+  auto& bucket = durations_[dur_key];
+  ++bucket.count;
+  bucket.sum_ns += duration_ns;
 }
 
 std::map<std::string, int64_t> HttpStats::requests_snapshot() const {
-    std::lock_guard<std::mutex> lock(mu_);
-    return requests_;
+  std::lock_guard<std::mutex> lock(mu_);
+  return requests_;
 }
 
 std::map<std::string, HttpStats::DurationBucket> HttpStats::durations_snapshot() const {
-    std::lock_guard<std::mutex> lock(mu_);
-    return durations_;
+  std::lock_guard<std::mutex> lock(mu_);
+  return durations_;
 }
 
 }  // namespace server

--- a/pine-cpp/src/server/http_stats.hpp
+++ b/pine-cpp/src/server/http_stats.hpp
@@ -18,24 +18,24 @@ namespace server {
 //   requests_total:           "<METHOD> <path> <statusBucket>"
 //   request_duration_seconds: "<METHOD> <path>"
 class HttpStats {
-public:
-    struct DurationBucket {
-        int64_t count = 0;
-        int64_t sum_ns = 0;
-    };
+ public:
+  struct DurationBucket {
+    int64_t count = 0;
+    int64_t sum_ns = 0;
+  };
 
-    void record_request(const std::string& method, const std::string& path,
-                        const std::string& status_bucket, int64_t duration_ns);
+  void record_request(const std::string& method, const std::string& path, const std::string& status_bucket,
+                      int64_t duration_ns);
 
-    // Returns ordered (lexicographic) maps for deterministic JSON output.
-    // Mirrors pine-go's sort.Strings + map serialization.
-    std::map<std::string, int64_t> requests_snapshot() const;
-    std::map<std::string, DurationBucket> durations_snapshot() const;
+  // Returns ordered (lexicographic) maps for deterministic JSON output.
+  // Mirrors pine-go's sort.Strings + map serialization.
+  std::map<std::string, int64_t> requests_snapshot() const;
+  std::map<std::string, DurationBucket> durations_snapshot() const;
 
-private:
-    mutable std::mutex mu_;
-    std::map<std::string, int64_t> requests_;
-    std::map<std::string, DurationBucket> durations_;
+ private:
+  mutable std::mutex mu_;
+  std::map<std::string, int64_t> requests_;
+  std::map<std::string, DurationBucket> durations_;
 };
 
 }  // namespace server

--- a/pine-cpp/src/server/server.cpp
+++ b/pine-cpp/src/server/server.cpp
@@ -1,23 +1,26 @@
 #include "server/server.hpp"
-#include "server/http_stats.hpp"
+
 #include "pine/resource.hpp"
+
+#include <sys/stat.h>
 
 #include <algorithm>
 #include <cerrno>
 #include <chrono>
+#include <csignal>
 #include <cstring>
 #include <iostream>
 #include <sstream>
 #include <thread>
-#include <csignal>
-#include <sys/stat.h>
+
+#include "server/http_stats.hpp"
 
 // POSIX socket headers
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <unistd.h>
-#include <poll.h>
 
 namespace pine {
 namespace server {
@@ -25,75 +28,78 @@ namespace server {
 // ---- Stats implementation ----
 
 void Stats::pre_init(const std::vector<std::string>& names) {
-    std::lock_guard<std::mutex> lock(mu_);
-    for (const auto& name : names) {
-        if (ops_.find(name) == ops_.end()) {
-            ops_[name] = std::make_unique<OpStats>();
-            order_.push_back(name);
-        }
+  std::lock_guard<std::mutex> lock(mu_);
+  for (const auto& name : names) {
+    if (ops_.find(name) == ops_.end()) {
+      ops_[name] = std::make_unique<OpStats>();
+      order_.push_back(name);
     }
+  }
 }
 
 OpStats& Stats::get_or_create(const std::string& name) {
-    std::lock_guard<std::mutex> lock(mu_);
-    auto it = ops_.find(name);
-    if (it != ops_.end()) return *it->second;
-    auto ptr = std::make_unique<OpStats>();
-    auto& ref = *ptr;
-    ops_[name] = std::move(ptr);
-    order_.push_back(name);
-    return ref;
+  std::lock_guard<std::mutex> lock(mu_);
+  auto it = ops_.find(name);
+  if (it != ops_.end()) {
+    return *it->second;
+  }
+  auto ptr = std::make_unique<OpStats>();
+  auto& ref = *ptr;
+  ops_[name] = std::move(ptr);
+  order_.push_back(name);
+  return ref;
 }
 
 void Stats::record_exec(const std::string& name, std::chrono::nanoseconds duration) {
-    auto& st = get_or_create(name);
-    st.exec_count.fetch_add(1, std::memory_order_relaxed);
-    int64_t ns = duration.count();
-    st.total_duration_ns.fetch_add(ns, std::memory_order_relaxed);
-    // CAS loop for max
-    int64_t cur = st.max_duration_ns.load(std::memory_order_relaxed);
-    while (ns > cur) {
-        if (st.max_duration_ns.compare_exchange_weak(cur, ns, std::memory_order_relaxed)) break;
+  auto& st = get_or_create(name);
+  st.exec_count.fetch_add(1, std::memory_order_relaxed);
+  int64_t ns = duration.count();
+  st.total_duration_ns.fetch_add(ns, std::memory_order_relaxed);
+  // CAS loop for max
+  int64_t cur = st.max_duration_ns.load(std::memory_order_relaxed);
+  while (ns > cur) {
+    if (st.max_duration_ns.compare_exchange_weak(cur, ns, std::memory_order_relaxed)) {
+      break;
     }
+  }
 }
 
 void Stats::record_skip(const std::string& name) {
-    auto& st = get_or_create(name);
-    st.skip_count.fetch_add(1, std::memory_order_relaxed);
+  auto& st = get_or_create(name);
+  st.skip_count.fetch_add(1, std::memory_order_relaxed);
 }
 
 void Stats::record_error(const std::string& name, std::chrono::nanoseconds duration) {
-    auto& st = get_or_create(name);
-    st.error_count.fetch_add(1, std::memory_order_relaxed);
-    int64_t ns = duration.count();
-    st.total_duration_ns.fetch_add(ns, std::memory_order_relaxed);
-    int64_t cur = st.max_duration_ns.load(std::memory_order_relaxed);
-    while (ns > cur) {
-        if (st.max_duration_ns.compare_exchange_weak(cur, ns, std::memory_order_relaxed)) break;
+  auto& st = get_or_create(name);
+  st.error_count.fetch_add(1, std::memory_order_relaxed);
+  int64_t ns = duration.count();
+  st.total_duration_ns.fetch_add(ns, std::memory_order_relaxed);
+  int64_t cur = st.max_duration_ns.load(std::memory_order_relaxed);
+  while (ns > cur) {
+    if (st.max_duration_ns.compare_exchange_weak(cur, ns, std::memory_order_relaxed)) {
+      break;
     }
+  }
 }
 
 std::vector<std::pair<std::string, OpStatsSnapshot>> Stats::snapshot() const {
-    std::lock_guard<std::mutex> lock(mu_);
-    std::vector<std::pair<std::string, OpStatsSnapshot>> result;
-    result.reserve(order_.size());
-    for (const auto& name : order_) {
-        auto it = ops_.find(name);
-        if (it == ops_.end()) continue;
-        const auto& st = *it->second;
-        int64_t exec = st.exec_count.load(std::memory_order_relaxed);
-        int64_t total = st.total_duration_ns.load(std::memory_order_relaxed);
-        int64_t avg = exec > 0 ? total / exec : 0;
-        result.push_back({name, OpStatsSnapshot{
-            exec,
-            st.skip_count.load(std::memory_order_relaxed),
-            st.error_count.load(std::memory_order_relaxed),
-            total,
-            st.max_duration_ns.load(std::memory_order_relaxed),
-            avg
-        }});
+  std::lock_guard<std::mutex> lock(mu_);
+  std::vector<std::pair<std::string, OpStatsSnapshot>> result;
+  result.reserve(order_.size());
+  for (const auto& name : order_) {
+    auto it = ops_.find(name);
+    if (it == ops_.end()) {
+      continue;
     }
-    return result;
+    const auto& st = *it->second;
+    int64_t exec = st.exec_count.load(std::memory_order_relaxed);
+    int64_t total = st.total_duration_ns.load(std::memory_order_relaxed);
+    int64_t avg = exec > 0 ? total / exec : 0;
+    result.push_back({name, OpStatsSnapshot{exec, st.skip_count.load(std::memory_order_relaxed),
+                                            st.error_count.load(std::memory_order_relaxed), total,
+                                            st.max_duration_ns.load(std::memory_order_relaxed), avg}});
+  }
+  return result;
 }
 
 // ---- HTTP parsing helpers ----
@@ -101,278 +107,336 @@ std::vector<std::pair<std::string, OpStatsSnapshot>> Stats::snapshot() const {
 namespace {
 
 struct HttpRequest {
-    std::string method;
-    std::string path;
-    std::string query_string;
-    std::string body;
-    int64_t content_length = -1;
-    bool connection_close = false;
-    // Track HTTP/1.0 vs HTTP/1.1 to choose default keep-alive policy.
-    // HTTP/1.1 defaults to keep-alive unless `Connection: close`; HTTP/1.0
-    // defaults to close unless `Connection: keep-alive`.
-    std::string http_version = "HTTP/1.1";
-    bool connection_keep_alive = false;  // explicit `Connection: keep-alive` header
+  std::string method;
+  std::string path;
+  std::string query_string;
+  std::string body;
+  int64_t content_length = -1;
+  bool connection_close = false;
+  // Track HTTP/1.0 vs HTTP/1.1 to choose default keep-alive policy.
+  // HTTP/1.1 defaults to keep-alive unless `Connection: close`; HTTP/1.0
+  // defaults to close unless `Connection: keep-alive`.
+  std::string http_version = "HTTP/1.1";
+  bool connection_keep_alive = false;  // explicit `Connection: keep-alive` header
 };
 
 // Read all available data from socket until headers are complete, then read body.
-bool read_http_request(int fd, HttpRequest& req, int64_t max_body_size,
-                       int header_timeout_seconds, int body_timeout_seconds) {
-    // pine-go's http.Server ReadHeaderTimeout caps the duration
-    // for header reading independently of ReadTimeout. Raw sockets cannot
-    // model two timeouts at once, but we can swap SO_RCVTIMEO at the
-    // header boundary — short window for headers (Slowloris defense),
-    // wider window for body once we know how much to expect. Both default
-    // to 0 (caller passed unset) → leave timeout as caller set.
-    auto apply_rcv_timeout = [fd](int seconds) {
-        if (seconds <= 0) return;
-        struct timeval to{seconds, 0};
-        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &to, sizeof(to));
-    };
-    apply_rcv_timeout(header_timeout_seconds);
-
-    std::string buffer;
-    char chunk[4096];
-
-    // Read until we get full headers, hard cap headers size at 1MB to prevent OOM.
-    // Check the cap *after* append rather than before, so a single
-    // chunk that overflows the limit is reliably caught instead of letting
-    // the buffer grow to `max_header_size + chunk_size` before we notice.
-    const std::size_t max_header_size = 1024 * 1024;
-    std::string::size_type header_end = std::string::npos;
-    while (header_end == std::string::npos) {
-        ssize_t n = recv(fd, chunk, sizeof(chunk), 0);
-        if (n <= 0) return false;
-        buffer.append(chunk, static_cast<size_t>(n));
-        if (buffer.size() > max_header_size) return false;
-        header_end = buffer.find("\r\n\r\n");
+bool read_http_request(int fd, HttpRequest& req, int64_t max_body_size, int header_timeout_seconds,
+                       int body_timeout_seconds) {
+  // pine-go's http.Server ReadHeaderTimeout caps the duration
+  // for header reading independently of ReadTimeout. Raw sockets cannot
+  // model two timeouts at once, but we can swap SO_RCVTIMEO at the
+  // header boundary — short window for headers (Slowloris defense),
+  // wider window for body once we know how much to expect. Both default
+  // to 0 (caller passed unset) → leave timeout as caller set.
+  auto apply_rcv_timeout = [fd](int seconds) {
+    if (seconds <= 0) {
+      return;
     }
+    struct timeval to{seconds, 0};
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &to, sizeof(to));
+  };
+  apply_rcv_timeout(header_timeout_seconds);
 
-    // Header phase complete — relax timeout to the body window before
-    // reading the (possibly large) body.
-    apply_rcv_timeout(body_timeout_seconds);
+  std::string buffer;
+  char chunk[4096];
 
-    // Parse request line
-    auto first_line_end = buffer.find("\r\n");
-    if (first_line_end == std::string::npos) return false;
-    std::string request_line = buffer.substr(0, first_line_end);
-
-    // "METHOD /path HTTP/1.1"
-    auto space1 = request_line.find(' ');
-    if (space1 == std::string::npos) return false;
-    req.method = request_line.substr(0, space1);
-
-    auto space2 = request_line.find(' ', space1 + 1);
-    if (space2 == std::string::npos) return false;
-    std::string uri = request_line.substr(space1 + 1, space2 - space1 - 1);
-    // Capture HTTP version so handle_connection can decide
-    // the default keep-alive policy (1.1 keep-alive by default, 1.0 close).
-    req.http_version = request_line.substr(space2 + 1);
-
-    auto q = uri.find('?');
-    if (q != std::string::npos) {
-        req.path = uri.substr(0, q);
-        req.query_string = uri.substr(q + 1);
-    } else {
-        req.path = uri;
+  // Read until we get full headers, hard cap headers size at 1MB to prevent OOM.
+  // Check the cap *after* append rather than before, so a single
+  // chunk that overflows the limit is reliably caught instead of letting
+  // the buffer grow to `max_header_size + chunk_size` before we notice.
+  const std::size_t max_header_size = 1024 * 1024;
+  std::string::size_type header_end = std::string::npos;
+  while (header_end == std::string::npos) {
+    ssize_t n = recv(fd, chunk, sizeof(chunk), 0);
+    if (n <= 0) {
+      return false;
     }
+    buffer.append(chunk, static_cast<size_t>(n));
+    if (buffer.size() > max_header_size) {
+      return false;
+    }
+    header_end = buffer.find("\r\n\r\n");
+  }
 
-    // Parse headers
-    std::string headers_str = buffer.substr(first_line_end + 2, header_end - first_line_end - 2);
-    req.content_length = 0;
-    bool has_content_length = false;
-    bool invalid_content_length = false;
-    std::istringstream header_stream(headers_str);
-    std::string line;
-    while (std::getline(header_stream, line)) {
-        if (!line.empty() && line.back() == '\r') line.pop_back();
-        if (line.empty()) continue;
-        auto colon = line.find(':');
-        if (colon == std::string::npos) continue;
-        std::string key = line.substr(0, colon);
-        std::string val = line.substr(colon + 1);
-        // Trim leading whitespace from val
-        while (!val.empty() && val.front() == ' ') val.erase(val.begin());
-        // Case-insensitive header comparison
-        std::string lower_key = key;
-        std::transform(lower_key.begin(), lower_key.end(), lower_key.begin(), ::tolower);
-        if (lower_key == "content-length") {
-            has_content_length = true;
-            try {
-                size_t consumed = 0;
-                long long parsed = std::stoll(val, &consumed);
-                if (consumed != val.size() || parsed < 0) {
-                    invalid_content_length = true;
-                } else {
-                    req.content_length = parsed;
-                }
-            } catch (...) {
-                invalid_content_length = true;
-            }
-        } else if (lower_key == "connection") {
-            std::string lower_val = val;
-            std::transform(lower_val.begin(), lower_val.end(), lower_val.begin(), ::tolower);
-            if (lower_val == "close") req.connection_close = true;
-            else if (lower_val == "keep-alive") req.connection_keep_alive = true;
+  // Header phase complete — relax timeout to the body window before
+  // reading the (possibly large) body.
+  apply_rcv_timeout(body_timeout_seconds);
+
+  // Parse request line
+  auto first_line_end = buffer.find("\r\n");
+  if (first_line_end == std::string::npos) {
+    return false;
+  }
+  std::string request_line = buffer.substr(0, first_line_end);
+
+  // "METHOD /path HTTP/1.1"
+  auto space1 = request_line.find(' ');
+  if (space1 == std::string::npos) {
+    return false;
+  }
+  req.method = request_line.substr(0, space1);
+
+  auto space2 = request_line.find(' ', space1 + 1);
+  if (space2 == std::string::npos) {
+    return false;
+  }
+  std::string uri = request_line.substr(space1 + 1, space2 - space1 - 1);
+  // Capture HTTP version so handle_connection can decide
+  // the default keep-alive policy (1.1 keep-alive by default, 1.0 close).
+  req.http_version = request_line.substr(space2 + 1);
+
+  auto q = uri.find('?');
+  if (q != std::string::npos) {
+    req.path = uri.substr(0, q);
+    req.query_string = uri.substr(q + 1);
+  } else {
+    req.path = uri;
+  }
+
+  // Parse headers
+  std::string headers_str = buffer.substr(first_line_end + 2, header_end - first_line_end - 2);
+  req.content_length = 0;
+  bool has_content_length = false;
+  bool invalid_content_length = false;
+  std::istringstream header_stream(headers_str);
+  std::string line;
+  while (std::getline(header_stream, line)) {
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+    if (line.empty()) {
+      continue;
+    }
+    auto colon = line.find(':');
+    if (colon == std::string::npos) {
+      continue;
+    }
+    std::string key = line.substr(0, colon);
+    std::string val = line.substr(colon + 1);
+    // Trim leading whitespace from val
+    while (!val.empty() && val.front() == ' ') {
+      val.erase(val.begin());
+    }
+    // Case-insensitive header comparison
+    std::string lower_key = key;
+    std::transform(lower_key.begin(), lower_key.end(), lower_key.begin(), ::tolower);
+    if (lower_key == "content-length") {
+      has_content_length = true;
+      try {
+        size_t consumed = 0;
+        long long parsed = std::stoll(val, &consumed);
+        if (consumed != val.size() || parsed < 0) {
+          invalid_content_length = true;
+        } else {
+          req.content_length = parsed;
         }
+      } catch (...) {
+        invalid_content_length = true;
+      }
+    } else if (lower_key == "connection") {
+      std::string lower_val = val;
+      std::transform(lower_val.begin(), lower_val.end(), lower_val.begin(), ::tolower);
+      if (lower_val == "close") {
+        req.connection_close = true;
+      } else if (lower_val == "keep-alive") {
+        req.connection_keep_alive = true;
+      }
     }
+  }
 
-    if (invalid_content_length) {
-        // Signal malformed request to caller.
-        req.content_length = -2;
-        req.body = "";
-        return true;
-    }
-    (void)has_content_length;  // POST bodies without Content-Length read 0 bytes (matches existing behavior).
-
-    // Check declared body size against the hard cap BEFORE reading.
-    if (req.content_length > max_body_size) {
-        req.content_length = max_body_size + 1;  // signal "too large"
-        req.body = "";
-        return true;
-    }
-
-    // Read body — bounded by both Content-Length and max_body_size + 1 so a
-    // misbehaving client cannot stream past the cap even if its header lied.
-    size_t body_start = header_end + 4;
-    std::string body_so_far = buffer.substr(body_start);
-    const int64_t hard_cap = max_body_size + 1;
-    int64_t need = req.content_length - static_cast<int64_t>(body_so_far.size());
-    while (need > 0 && static_cast<int64_t>(body_so_far.size()) < hard_cap) {
-        size_t want = std::min(sizeof(chunk), static_cast<size_t>(need));
-        // Never read past the hard cap.
-        if (static_cast<int64_t>(body_so_far.size()) + static_cast<int64_t>(want) > hard_cap) {
-            want = static_cast<size_t>(hard_cap - static_cast<int64_t>(body_so_far.size()));
-        }
-        ssize_t n = recv(fd, chunk, want, 0);
-        if (n <= 0) break;
-        body_so_far.append(chunk, static_cast<size_t>(n));
-        need -= n;
-    }
-    if (static_cast<int64_t>(body_so_far.size()) > max_body_size) {
-        req.content_length = max_body_size + 1;  // signal "too large"
-        req.body = "";
-        return true;
-    }
-    req.body = std::move(body_so_far);
+  if (invalid_content_length) {
+    // Signal malformed request to caller.
+    req.content_length = -2;
+    req.body = "";
     return true;
+  }
+  (void)has_content_length;  // POST bodies without Content-Length read 0 bytes (matches existing behavior).
+
+  // Check declared body size against the hard cap BEFORE reading.
+  if (req.content_length > max_body_size) {
+    req.content_length = max_body_size + 1;  // signal "too large"
+    req.body = "";
+    return true;
+  }
+
+  // Read body — bounded by both Content-Length and max_body_size + 1 so a
+  // misbehaving client cannot stream past the cap even if its header lied.
+  size_t body_start = header_end + 4;
+  std::string body_so_far = buffer.substr(body_start);
+  const int64_t hard_cap = max_body_size + 1;
+  int64_t need = req.content_length - static_cast<int64_t>(body_so_far.size());
+  while (need > 0 && static_cast<int64_t>(body_so_far.size()) < hard_cap) {
+    size_t want = std::min(sizeof(chunk), static_cast<size_t>(need));
+    // Never read past the hard cap.
+    if (static_cast<int64_t>(body_so_far.size()) + static_cast<int64_t>(want) > hard_cap) {
+      want = static_cast<size_t>(hard_cap - static_cast<int64_t>(body_so_far.size()));
+    }
+    ssize_t n = recv(fd, chunk, want, 0);
+    if (n <= 0) {
+      break;
+    }
+    body_so_far.append(chunk, static_cast<size_t>(n));
+    need -= n;
+  }
+  if (static_cast<int64_t>(body_so_far.size()) > max_body_size) {
+    req.content_length = max_body_size + 1;  // signal "too large"
+    req.body = "";
+    return true;
+  }
+  req.body = std::move(body_so_far);
+  return true;
 }
 
 std::string url_decode_query_param(const std::string& qs, const std::string& key) {
-    std::string search = key + "=";
-    std::string::size_type pos = 0;
-    while (pos < qs.size()) {
-        auto amp = qs.find('&', pos);
-        std::string param = (amp == std::string::npos) ? qs.substr(pos) : qs.substr(pos, amp - pos);
-        if (param.size() >= search.size() && param.substr(0, search.size()) == search) {
-            return param.substr(search.size());
-        }
-        if (amp == std::string::npos) break;
-        pos = amp + 1;
+  std::string search = key + "=";
+  std::string::size_type pos = 0;
+  while (pos < qs.size()) {
+    auto amp = qs.find('&', pos);
+    std::string param = (amp == std::string::npos) ? qs.substr(pos) : qs.substr(pos, amp - pos);
+    if (param.size() >= search.size() && param.substr(0, search.size()) == search) {
+      return param.substr(search.size());
     }
-    return "";
+    if (amp == std::string::npos) {
+      break;
+    }
+    pos = amp + 1;
+  }
+  return "";
 }
 
 std::string status_text(int code) {
-    switch (code) {
-        case 200: return "OK";
-        case 400: return "Bad Request";
-        case 405: return "Method Not Allowed";
-        case 413: return "Request Entity Too Large";
-        case 404: return "Not Found";
-        case 500: return "Internal Server Error";
-        case 503: return "Service Unavailable";
-        default: return "Unknown";
-    }
+  switch (code) {
+    case 200:
+      return "OK";
+    case 400:
+      return "Bad Request";
+    case 405:
+      return "Method Not Allowed";
+    case 413:
+      return "Request Entity Too Large";
+    case 404:
+      return "Not Found";
+    case 500:
+      return "Internal Server Error";
+    case 503:
+      return "Service Unavailable";
+    default:
+      return "Unknown";
+  }
 }
 
 // JSON helpers — build JSON strings without depending on nlohmann
 std::string json_escape(const std::string& s) {
-    std::string out;
-    out.reserve(s.size() + 8);
-    for (char c : s) {
-        switch (c) {
-            case '"': out += "\\\""; break;
-            case '\\': out += "\\\\"; break;
-            case '\n': out += "\\n"; break;
-            case '\r': out += "\\r"; break;
-            case '\t': out += "\\t"; break;
-            default:
-                if (static_cast<unsigned char>(c) < 0x20) {
-                    char buf[8];
-                    snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned char>(c));
-                    out += buf;
-                } else {
-                    out += c;
-                }
+  std::string out;
+  out.reserve(s.size() + 8);
+  for (char c : s) {
+    switch (c) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          char buf[8];
+          snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned char>(c));
+          out += buf;
+        } else {
+          out += c;
         }
     }
-    return out;
+  }
+  return out;
 }
 
 // Convert a JsonValue to its JSON string representation.
 std::string jsonvalue_to_string(const JsonValue& v) {
-    if (v.is_null()) return "null";
-    if (v.is_bool()) return v.as_bool() ? "true" : "false";
-    if (v.is_number()) {
-        double d = v.as_number();
-        // Match Go's json.Encoder behavior for numbers
-        if (d == static_cast<double>(static_cast<int64_t>(d)) &&
-            d >= -1e15 && d <= 1e15) {
-            // Integer-like
-            return std::to_string(static_cast<int64_t>(d));
-        }
-        char buf[64];
-        int n = snprintf(buf, sizeof(buf), "%.17g", d);
-        return std::string(buf, static_cast<size_t>(n));
-    }
-    if (v.is_string()) return "\"" + json_escape(v.as_string()) + "\"";
-    if (v.is_array()) {
-        std::string out = "[";
-        bool first = true;
-        for (const auto& item : v.as_array()) {
-            if (!first) out += ",";
-            first = false;
-            out += jsonvalue_to_string(item);
-        }
-        out += "]";
-        return out;
-    }
-    if (v.is_object()) {
-        std::string out = "{";
-        bool first = true;
-        for (const auto& [k, val] : v.as_object()) {
-            if (!first) out += ",";
-            first = false;
-            out += "\"" + json_escape(k) + "\":" + jsonvalue_to_string(val);
-        }
-        out += "}";
-        return out;
-    }
+  if (v.is_null()) {
     return "null";
+  }
+  if (v.is_bool()) {
+    return v.as_bool() ? "true" : "false";
+  }
+  if (v.is_number()) {
+    double d = v.as_number();
+    // Match Go's json.Encoder behavior for numbers
+    if (d == static_cast<double>(static_cast<int64_t>(d)) && d >= -1e15 && d <= 1e15) {
+      // Integer-like
+      return std::to_string(static_cast<int64_t>(d));
+    }
+    char buf[64];
+    int n = snprintf(buf, sizeof(buf), "%.17g", d);
+    return std::string(buf, static_cast<size_t>(n));
+  }
+  if (v.is_string()) {
+    return "\"" + json_escape(v.as_string()) + "\"";
+  }
+  if (v.is_array()) {
+    std::string out = "[";
+    bool first = true;
+    for (const auto& item : v.as_array()) {
+      if (!first) {
+        out += ",";
+      }
+      first = false;
+      out += jsonvalue_to_string(item);
+    }
+    out += "]";
+    return out;
+  }
+  if (v.is_object()) {
+    std::string out = "{";
+    bool first = true;
+    for (const auto& [k, val] : v.as_object()) {
+      if (!first) {
+        out += ",";
+      }
+      first = false;
+      out += "\"" + json_escape(k) + "\":" + jsonvalue_to_string(val);
+    }
+    out += "}";
+    return out;
+  }
+  return "null";
 }
 
 // Build a JSON object string from a map<string, JsonValue>
 std::string map_to_json(const std::map<std::string, JsonValue>& m) {
-    std::string out = "{";
-    bool first = true;
-    for (const auto& [k, v] : m) {
-        if (!first) out += ",";
-        first = false;
-        out += "\"" + json_escape(k) + "\":" + jsonvalue_to_string(v);
+  std::string out = "{";
+  bool first = true;
+  for (const auto& [k, v] : m) {
+    if (!first) {
+      out += ",";
     }
-    out += "}";
-    return out;
+    first = false;
+    out += "\"" + json_escape(k) + "\":" + jsonvalue_to_string(v);
+  }
+  out += "}";
+  return out;
 }
 
 // Build items JSON array
 std::string items_to_json(const std::vector<std::map<std::string, JsonValue>>& items) {
-    std::string out = "[";
-    for (size_t i = 0; i < items.size(); ++i) {
-        if (i > 0) out += ",";
-        out += map_to_json(items[i]);
+  std::string out = "[";
+  for (size_t i = 0; i < items.size(); ++i) {
+    if (i > 0) {
+      out += ",";
     }
-    out += "]";
-    return out;
+    out += map_to_json(items[i]);
+  }
+  out += "]";
+  return out;
 }
 
 }  // anonymous namespace
@@ -381,10 +445,10 @@ std::string items_to_json(const std::vector<std::map<std::string, JsonValue>>& i
 // so per-path metric label cardinality stays bounded. Mirrors pine-go
 // http_metrics.go normalizePath.
 static std::string normalize_path(const std::string& path) {
-    if (path == "/execute" || path == "/health" || path == "/stats" || path == "/dag") {
-        return path;
-    }
-    return "_other";
+  if (path == "/execute" || path == "/health" || path == "/stats" || path == "/dag") {
+    return path;
+  }
+  return "_other";
 }
 
 // ---- Server implementation ----
@@ -397,865 +461,907 @@ thread_local MiddlewareContext* t_mw_ctx = nullptr;
 
 Server::Server() = default;
 Server::~Server() {
-    stop();
+  stop();
 }
 
-void Server::send_response(int fd, int status, const std::string& content_type,
-                           const std::string& body) {
-    if (t_mw_ctx) t_mw_ctx->status = status;
-    // Choose Connection header from the middleware context's
-    // keep_alive flag, set by handle_connection's keep-alive loop. When
-    // the flag is false (HTTP/1.0 by default, or `Connection: close`
-    // header was present, or the keep-alive loop is on its way to close
-    // anyway), emit Connection: close as before.
-    const bool keep_alive = (t_mw_ctx && t_mw_ctx->keep_alive);
-    std::string response = "HTTP/1.1 " + std::to_string(status) + " " + status_text(status) + "\r\n";
-    response += "Content-Type: " + content_type + "\r\n";
-    response += "Content-Length: " + std::to_string(body.size()) + "\r\n";
-    response += keep_alive ? "Connection: keep-alive\r\n" : "Connection: close\r\n";
-    response += "\r\n";
-    response += body;
+void Server::send_response(int fd, int status, const std::string& content_type, const std::string& body) {
+  if (t_mw_ctx) {
+    t_mw_ctx->status = status;
+  }
+  // Choose Connection header from the middleware context's
+  // keep_alive flag, set by handle_connection's keep-alive loop. When
+  // the flag is false (HTTP/1.0 by default, or `Connection: close`
+  // header was present, or the keep-alive loop is on its way to close
+  // anyway), emit Connection: close as before.
+  const bool keep_alive = (t_mw_ctx && t_mw_ctx->keep_alive);
+  std::string response = "HTTP/1.1 " + std::to_string(status) + " " + status_text(status) + "\r\n";
+  response += "Content-Type: " + content_type + "\r\n";
+  response += "Content-Length: " + std::to_string(body.size()) + "\r\n";
+  response += keep_alive ? "Connection: keep-alive\r\n" : "Connection: close\r\n";
+  response += "\r\n";
+  response += body;
 
-    size_t total = response.size();
-    size_t sent = 0;
-    while (sent < total) {
-        ssize_t n = ::send(fd, response.data() + sent, total - sent, MSG_NOSIGNAL);
-        if (n <= 0) break;
-        sent += static_cast<size_t>(n);
+  size_t total = response.size();
+  size_t sent = 0;
+  while (sent < total) {
+    ssize_t n = ::send(fd, response.data() + sent, total - sent, MSG_NOSIGNAL);
+    if (n <= 0) {
+      break;
     }
+    sent += static_cast<size_t>(n);
+  }
 }
 
 void Server::send_json(int fd, int status, const std::string& json_body) {
-    send_response(fd, status, "application/json", json_body);
+  send_response(fd, status, "application/json", json_body);
 }
 
 void Server::send_error(int fd, int status, const std::string& message) {
-    std::string body = "{\"error\":\"" + json_escape(message) + "\"}\n";
-    send_json(fd, status, body);
+  std::string body = "{\"error\":\"" + json_escape(message) + "\"}\n";
+  send_json(fd, status, body);
 }
 
 void Server::handle_health(int client_fd, const std::string& method) {
-    if (method != "GET") {
-        send_error(client_fd, 405, "method not allowed");
-        return;
-    }
-    send_json(client_fd, 200, "{\"status\":\"ok\"}\n");
+  if (method != "GET") {
+    send_error(client_fd, 405, "method not allowed");
+    return;
+  }
+  send_json(client_fd, 200, "{\"status\":\"ok\"}\n");
 }
 
-void Server::handle_execute(int client_fd, const std::string& method,
-                            const std::string& body, int64_t content_length) {
-    if (method != "POST") {
-        send_error(client_fd, 405, "method not allowed");
-        return;
+void Server::handle_execute(int client_fd, const std::string& method, const std::string& body,
+                            int64_t content_length) {
+  if (method != "POST") {
+    send_error(client_fd, 405, "method not allowed");
+    return;
+  }
+
+  if (!engine_) {
+    send_error(client_fd, 503, "engine not loaded");
+    return;
+  }
+
+  // Check body size
+  if (content_length > config_.max_request_body_size) {
+    send_error(client_fd, 413, "request body too large");
+    return;
+  }
+
+  // Parse JSON
+  JsonValue json;
+  try {
+    json = parse_json(body);
+  } catch (const std::exception& e) {
+    std::string msg = "invalid request: " + std::string(e.what());
+    send_error(client_fd, 400, msg);
+    return;
+  }
+
+  if (!json.is_object()) {
+    send_error(client_fd, 400, "invalid request: expected JSON object");
+    return;
+  }
+
+  // Build Request
+  Request req;
+  const auto& obj = json.as_object();
+  bool has_common = false;
+
+  // Parse common
+  auto common_it = obj.find("common");
+  if (common_it != obj.end()) {
+    has_common = true;
+    if (common_it->second.is_object()) {
+      req.common = common_it->second.as_object();
     }
-
-    if (!engine_) {
-        send_error(client_fd, 503, "engine not loaded");
-        return;
+    // null common is treated as nil → validation error below
+    if (common_it->second.is_null()) {
+      has_common = false;
     }
+  }
 
-    // Check body size
-    if (content_length > config_.max_request_body_size) {
-        send_error(client_fd, 413, "request body too large");
-        return;
+  // Parse items
+  auto items_it = obj.find("items");
+  if (items_it != obj.end() && items_it->second.is_array()) {
+    for (const auto& item : items_it->second.as_array()) {
+      if (item.is_object()) {
+        req.items.push_back(item.as_object());
+      } else {
+        req.items.push_back({});
+      }
     }
+  }
 
-    // Parse JSON
-    JsonValue json;
-    try {
-        json = parse_json(body);
-    } catch (const std::exception& e) {
-        std::string msg = "invalid request: " + std::string(e.what());
-        send_error(client_fd, 400, msg);
-        return;
+  // Match Go validation: common must not be nil
+  if (!has_common) {
+    // Return error matching Go behavior
+    // Go: resp.Error = err.Error() where err is ValidationError with "request.Common must not be nil"
+    // Go: errors.As(err, &ve) → true → 400
+    // Go: resp.Common is nil, resp.Items is nil → JSON null
+    std::string response =
+        "{\"common\":null,\"items\":null,\"error\":\"pine: validation error: request.Common must not be "
+        "nil\"}\n";
+    send_json(client_fd, 400, response);
+    return;
+  }
+
+  // Check if trace is requested
+  bool return_trace = false;
+  auto trace_it = req.common.find("_return_trace");
+  if (trace_it != req.common.end() && trace_it->second.is_bool()) {
+    return_trace = trace_it->second.as_bool();
+  }
+
+  // Execute (R10-2: pass client_fd so engine sees client-disconnect cancel)
+  auto exec_result = execute_with_trace(req, return_trace, client_fd);
+
+  // Build response JSON — match Go's executeResponse structure.
+  // Go writes resp.Common/Items from result only when result != nil; an
+  // engine-level error leaves them as nil maps → JSON `null`. A successful
+  // run that produces an empty common/items still serializes as `{}`/`[]`.
+  std::string response = "{";
+
+  if (!exec_result.has_result) {
+    response += "\"common\":null";
+    response += ",\"items\":null";
+  } else {
+    response += "\"common\":" + map_to_json(exec_result.result.common);
+    response += ",\"items\":" + items_to_json(exec_result.result.items);
+  }
+
+  // Warnings
+  if (!exec_result.warnings.empty()) {
+    response += ",\"warnings\":[";
+    for (size_t i = 0; i < exec_result.warnings.size(); ++i) {
+      if (i > 0) {
+        response += ",";
+      }
+      response += "\"" + json_escape(exec_result.warnings[i]) + "\"";
     }
+    response += "]";
+  }
 
-    if (!json.is_object()) {
-        send_error(client_fd, 400, "invalid request: expected JSON object");
-        return;
+  // Trace
+  if (!exec_result.trace.empty()) {
+    response += ",\"trace\":[";
+    for (size_t i = 0; i < exec_result.trace.size(); ++i) {
+      if (i > 0) {
+        response += ",";
+      }
+      const auto& t = exec_result.trace[i];
+      response += "{\"name\":\"" + json_escape(t.name) + "\"";
+      response += ",\"duration_ms\":";
+      // Format duration_ms to match Go's encoding:
+      // Go uses float64 → json.Encoder which outputs minimal representation.
+      char dur_buf[64];
+      if (t.duration_ms == 0.0) {
+        response += "0";
+      } else {
+        int n = snprintf(dur_buf, sizeof(dur_buf), "%g", t.duration_ms);
+        response.append(dur_buf, static_cast<size_t>(n));
+      }
+      if (t.skipped) {
+        response += ",\"skipped\":true";
+      }
+      if (t.has_input_snapshot) {
+        response += ",\"input_snapshot\":" + dump_json(t.input_snapshot, 0);
+      }
+      if (t.has_output_snapshot) {
+        response += ",\"output_snapshot\":" + dump_json(t.output_snapshot, 0);
+      }
+      response += "}";
     }
+    response += "]";
+  }
 
-    // Build Request
-    Request req;
-    const auto& obj = json.as_object();
-    bool has_common = false;
+  // Error
+  if (exec_result.has_error) {
+    response += ",\"error\":\"" + json_escape(exec_result.error) + "\"";
+  }
 
-    // Parse common
-    auto common_it = obj.find("common");
-    if (common_it != obj.end()) {
-        has_common = true;
-        if (common_it->second.is_object()) {
-            req.common = common_it->second.as_object();
-        }
-        // null common is treated as nil → validation error below
-        if (common_it->second.is_null()) {
-            has_common = false;
-        }
-    }
+  response += "}\n";
 
-    // Parse items
-    auto items_it = obj.find("items");
-    if (items_it != obj.end() && items_it->second.is_array()) {
-        for (const auto& item : items_it->second.as_array()) {
-            if (item.is_object()) {
-                req.items.push_back(item.as_object());
-            } else {
-                req.items.push_back({});
-            }
-        }
-    }
+  int status = 200;
+  if (exec_result.has_error) {
+    status = exec_result.is_validation_error ? 400 : 500;
+  }
 
-    // Match Go validation: common must not be nil
-    if (!has_common) {
-        // Return error matching Go behavior
-        // Go: resp.Error = err.Error() where err is ValidationError with "request.Common must not be nil"
-        // Go: errors.As(err, &ve) → true → 400
-        // Go: resp.Common is nil, resp.Items is nil → JSON null
-        std::string response = "{\"common\":null,\"items\":null,\"error\":\"pine: validation error: request.Common must not be nil\"}\n";
-        send_json(client_fd, 400, response);
-        return;
-    }
-
-    // Check if trace is requested
-    bool return_trace = false;
-    auto trace_it = req.common.find("_return_trace");
-    if (trace_it != req.common.end() && trace_it->second.is_bool()) {
-        return_trace = trace_it->second.as_bool();
-    }
-
-    // Execute (R10-2: pass client_fd so engine sees client-disconnect cancel)
-    auto exec_result = execute_with_trace(req, return_trace, client_fd);
-
-    // Build response JSON — match Go's executeResponse structure.
-    // Go writes resp.Common/Items from result only when result != nil; an
-    // engine-level error leaves them as nil maps → JSON `null`. A successful
-    // run that produces an empty common/items still serializes as `{}`/`[]`.
-    std::string response = "{";
-
-    if (!exec_result.has_result) {
-        response += "\"common\":null";
-        response += ",\"items\":null";
-    } else {
-        response += "\"common\":" + map_to_json(exec_result.result.common);
-        response += ",\"items\":" + items_to_json(exec_result.result.items);
-    }
-
-    // Warnings
-    if (!exec_result.warnings.empty()) {
-        response += ",\"warnings\":[";
-        for (size_t i = 0; i < exec_result.warnings.size(); ++i) {
-            if (i > 0) response += ",";
-            response += "\"" + json_escape(exec_result.warnings[i]) + "\"";
-        }
-        response += "]";
-    }
-
-    // Trace
-    if (!exec_result.trace.empty()) {
-        response += ",\"trace\":[";
-        for (size_t i = 0; i < exec_result.trace.size(); ++i) {
-            if (i > 0) response += ",";
-            const auto& t = exec_result.trace[i];
-            response += "{\"name\":\"" + json_escape(t.name) + "\"";
-            response += ",\"duration_ms\":" ;
-            // Format duration_ms to match Go's encoding:
-            // Go uses float64 → json.Encoder which outputs minimal representation.
-            char dur_buf[64];
-            if (t.duration_ms == 0.0) {
-                response += "0";
-            } else {
-                int n = snprintf(dur_buf, sizeof(dur_buf), "%g", t.duration_ms);
-                response.append(dur_buf, static_cast<size_t>(n));
-            }
-            if (t.skipped) {
-                response += ",\"skipped\":true";
-            }
-            if (t.has_input_snapshot) {
-                response += ",\"input_snapshot\":" + dump_json(t.input_snapshot, 0);
-            }
-            if (t.has_output_snapshot) {
-                response += ",\"output_snapshot\":" + dump_json(t.output_snapshot, 0);
-            }
-            response += "}";
-        }
-        response += "]";
-    }
-
-    // Error
-    if (exec_result.has_error) {
-        response += ",\"error\":\"" + json_escape(exec_result.error) + "\"";
-    }
-
-    response += "}\n";
-
-    int status = 200;
-    if (exec_result.has_error) {
-        status = exec_result.is_validation_error ? 400 : 500;
-    }
-
-    send_json(client_fd, status, response);
+  send_json(client_fd, status, response);
 }
 
 void Server::handle_stats(int client_fd, const std::string& method) {
-    if (method != "GET") {
-        send_error(client_fd, 405, "method not allowed");
-        return;
-    }
+  if (method != "GET") {
+    send_error(client_fd, 405, "method not allowed");
+    return;
+  }
 
-    if (!stats_) {
-        send_error(client_fd, 503, "engine not loaded");
-        return;
-    }
+  if (!stats_) {
+    send_error(client_fd, 503, "engine not loaded");
+    return;
+  }
 
-    auto ops_snapshot = stats_->snapshot();
+  auto ops_snapshot = stats_->snapshot();
 
-    // Build operators JSON, preserving pipeline order
-    std::string ops_json = "{";
-    for (size_t i = 0; i < ops_snapshot.size(); ++i) {
-        if (i > 0) ops_json += ",";
-        const auto& [name, st] = ops_snapshot[i];
-        ops_json += "\"" + json_escape(name) + "\":{";
-        ops_json += "\"exec_count\":" + std::to_string(st.exec_count);
-        ops_json += ",\"skip_count\":" + std::to_string(st.skip_count);
-        ops_json += ",\"error_count\":" + std::to_string(st.error_count);
-        ops_json += ",\"total_duration_ns\":" + std::to_string(st.total_duration_ns);
-        ops_json += ",\"max_duration_ns\":" + std::to_string(st.max_duration_ns);
-        ops_json += ",\"avg_duration_ns\":" + std::to_string(st.avg_duration_ns);
-        ops_json += "}";
+  // Build operators JSON, preserving pipeline order
+  std::string ops_json = "{";
+  for (size_t i = 0; i < ops_snapshot.size(); ++i) {
+    if (i > 0) {
+      ops_json += ",";
     }
+    const auto& [name, st] = ops_snapshot[i];
+    ops_json += "\"" + json_escape(name) + "\":{";
+    ops_json += "\"exec_count\":" + std::to_string(st.exec_count);
+    ops_json += ",\"skip_count\":" + std::to_string(st.skip_count);
+    ops_json += ",\"error_count\":" + std::to_string(st.error_count);
+    ops_json += ",\"total_duration_ns\":" + std::to_string(st.total_duration_ns);
+    ops_json += ",\"max_duration_ns\":" + std::to_string(st.max_duration_ns);
+    ops_json += ",\"avg_duration_ns\":" + std::to_string(st.avg_duration_ns);
     ops_json += "}";
+  }
+  ops_json += "}";
 
-    // Build scheduler JSON
-    std::string sched_json = "{";
-    sched_json += "\"run_count\":" + std::to_string(run_count_.load(std::memory_order_relaxed));
-    int64_t peak = 0;
-    {
-        std::shared_lock<std::shared_mutex> lock(engine_mu_);
-        if (engine_) peak = engine_->peak_concurrency();
+  // Build scheduler JSON
+  std::string sched_json = "{";
+  sched_json += "\"run_count\":" + std::to_string(run_count_.load(std::memory_order_relaxed));
+  int64_t peak = 0;
+  {
+    std::shared_lock<std::shared_mutex> lock(engine_mu_);
+    if (engine_) {
+      peak = engine_->peak_concurrency();
     }
-    sched_json += ",\"peak_concurrency\":" + std::to_string(peak);
-    sched_json += "}";
+  }
+  sched_json += ",\"peak_concurrency\":" + std::to_string(peak);
+  sched_json += "}";
 
-    // Build server JSON
-    std::string server_json = "{";
-    server_json += "\"reload_count\":" + std::to_string(reload_count_.load(std::memory_order_relaxed));
-    server_json += ",\"reload_error_count\":" + std::to_string(reload_error_count_.load(std::memory_order_relaxed));
-    server_json += ",\"last_reload_duration_ns\":" + std::to_string(last_reload_duration_ns_.load(std::memory_order_relaxed));
-    server_json += "}";
+  // Build server JSON
+  std::string server_json = "{";
+  server_json += "\"reload_count\":" + std::to_string(reload_count_.load(std::memory_order_relaxed));
+  server_json +=
+      ",\"reload_error_count\":" + std::to_string(reload_error_count_.load(std::memory_order_relaxed));
+  server_json += ",\"last_reload_duration_ns\":" +
+                 std::to_string(last_reload_duration_ns_.load(std::memory_order_relaxed));
+  server_json += "}";
 
-    std::string body = "{\"operators\":" + ops_json +
-                       ",\"scheduler\":" + sched_json +
-                       ",\"server\":" + server_json;
+  std::string body =
+      "{\"operators\":" + ops_json + ",\"scheduler\":" + sched_json + ",\"server\":" + server_json;
 
-    // Build http JSON (mirrors pine-go /stats.http subtree). Maps from
-    // HttpStats are already lexicographically ordered (std::map) so iteration
-    // order produces byte-exact JSON to match Go's encoding/json.
-    if (http_stats_) {
-        auto duration_snap = http_stats_->durations_snapshot();
-        auto requests_snap = http_stats_->requests_snapshot();
+  // Build http JSON (mirrors pine-go /stats.http subtree). Maps from
+  // HttpStats are already lexicographically ordered (std::map) so iteration
+  // order produces byte-exact JSON to match Go's encoding/json.
+  if (http_stats_) {
+    auto duration_snap = http_stats_->durations_snapshot();
+    auto requests_snap = http_stats_->requests_snapshot();
 
-        std::string http_json = "{\"request_duration_seconds\":{";
-        bool first_dur = true;
-        for (const auto& [key, bucket] : duration_snap) {
-            if (!first_dur) http_json += ",";
-            first_dur = false;
-            http_json += "\"" + json_escape(key) + "\":{";
-            http_json += "\"count\":" + std::to_string(bucket.count);
-            http_json += ",\"sum_ns\":" + std::to_string(bucket.sum_ns);
-            http_json += "}";
-        }
-        http_json += "},\"requests_total\":{";
-        bool first_req = true;
-        for (const auto& [key, count] : requests_snap) {
-            if (!first_req) http_json += ",";
-            first_req = false;
-            http_json += "\"" + json_escape(key) + "\":" + std::to_string(count);
-        }
-        http_json += "}}";
-        body += ",\"http\":" + http_json;
+    std::string http_json = "{\"request_duration_seconds\":{";
+    bool first_dur = true;
+    for (const auto& [key, bucket] : duration_snap) {
+      if (!first_dur) {
+        http_json += ",";
+      }
+      first_dur = false;
+      http_json += "\"" + json_escape(key) + "\":{";
+      http_json += "\"count\":" + std::to_string(bucket.count);
+      http_json += ",\"sum_ns\":" + std::to_string(bucket.sum_ns);
+      http_json += "}";
     }
+    http_json += "},\"requests_total\":{";
+    bool first_req = true;
+    for (const auto& [key, count] : requests_snap) {
+      if (!first_req) {
+        http_json += ",";
+      }
+      first_req = false;
+      http_json += "\"" + json_escape(key) + "\":" + std::to_string(count);
+    }
+    http_json += "}}";
+    body += ",\"http\":" + http_json;
+  }
 
-    {
-        std::shared_lock<std::shared_mutex> lock(engine_mu_);
-        if (engine_) {
-            auto custom_stats = engine_->operator_custom_stats();
-            if (!custom_stats.empty()) {
-                body += ",\"operator_detail\":{";
-                bool first_op = true;
-                for (const auto& [op_name, stats] : custom_stats) {
-                    if (!first_op) body += ",";
-                    first_op = false;
-                    body += "\"" + json_escape(op_name) + "\":{";
-                    bool first_stat = true;
-                    for (const auto& [stat_key, stat_val] : stats) {
-                        if (!first_stat) body += ",";
-                        first_stat = false;
-                        body += "\"" + json_escape(stat_key) + "\":" + std::to_string(stat_val);
-                    }
-                    body += "}";
-                }
-                body += "}";
+  {
+    std::shared_lock<std::shared_mutex> lock(engine_mu_);
+    if (engine_) {
+      auto custom_stats = engine_->operator_custom_stats();
+      if (!custom_stats.empty()) {
+        body += ",\"operator_detail\":{";
+        bool first_op = true;
+        for (const auto& [op_name, stats] : custom_stats) {
+          if (!first_op) {
+            body += ",";
+          }
+          first_op = false;
+          body += "\"" + json_escape(op_name) + "\":{";
+          bool first_stat = true;
+          for (const auto& [stat_key, stat_val] : stats) {
+            if (!first_stat) {
+              body += ",";
             }
+            first_stat = false;
+            body += "\"" + json_escape(stat_key) + "\":" + std::to_string(stat_val);
+          }
+          body += "}";
         }
+        body += "}";
+      }
     }
+  }
 
-    body += "}\n";
+  body += "}\n";
 
-    send_json(client_fd, 200, body);
+  send_json(client_fd, 200, body);
 }
 
-void Server::handle_dag(int client_fd, const std::string& method,
-                        const std::string& query_string) {
-    if (method != "GET") {
-        send_error(client_fd, 405, "method not allowed");
-        return;
-    }
+void Server::handle_dag(int client_fd, const std::string& method, const std::string& query_string) {
+  if (method != "GET") {
+    send_error(client_fd, 405, "method not allowed");
+    return;
+  }
 
-    if (!engine_) {
-        send_error(client_fd, 503, "engine not loaded");
-        return;
-    }
+  if (!engine_) {
+    send_error(client_fd, 503, "engine not loaded");
+    return;
+  }
 
-    std::string format = url_decode_query_param(query_string, "format");
-    if (format.empty()) format = "dot";
+  std::string format = url_decode_query_param(query_string, "format");
+  if (format.empty()) {
+    format = "dot";
+  }
 
-    int collapse = 0;
-    std::string collapse_str = url_decode_query_param(query_string, "collapse");
-    if (!collapse_str.empty()) {
-        try {
-            collapse = std::stoi(collapse_str);
-            if (collapse < 0) {
-                send_error(client_fd, 400, "collapse must be a non-negative integer");
-                return;
-            }
-        } catch (...) {
-            send_error(client_fd, 400, "collapse must be a non-negative integer");
-            return;
-        }
-    }
-
-    std::string output;
+  int collapse = 0;
+  std::string collapse_str = url_decode_query_param(query_string, "collapse");
+  if (!collapse_str.empty()) {
     try {
-        std::shared_lock<std::shared_mutex> lock(engine_mu_);
-        output = engine_->render_dag(format, collapse);
-    } catch (const ValidationError& e) {
-        send_error(client_fd, 400, e.what());
+      collapse = std::stoi(collapse_str);
+      if (collapse < 0) {
+        send_error(client_fd, 400, "collapse must be a non-negative integer");
         return;
-    } catch (const std::exception& e) {
-        send_error(client_fd, 400, e.what());
-        return;
+      }
+    } catch (...) {
+      send_error(client_fd, 400, "collapse must be a non-negative integer");
+      return;
     }
+  }
 
-    std::string content_type;
-    if (format == "dot") {
-        content_type = "text/vnd.graphviz; charset=utf-8";
-    } else {
-        content_type = "text/plain; charset=utf-8";
-    }
+  std::string output;
+  try {
+    std::shared_lock<std::shared_mutex> lock(engine_mu_);
+    output = engine_->render_dag(format, collapse);
+  } catch (const ValidationError& e) {
+    send_error(client_fd, 400, e.what());
+    return;
+  } catch (const std::exception& e) {
+    send_error(client_fd, 400, e.what());
+    return;
+  }
 
-    send_response(client_fd, 200, content_type, output);
+  std::string content_type;
+  if (format == "dot") {
+    content_type = "text/vnd.graphviz; charset=utf-8";
+  } else {
+    content_type = "text/plain; charset=utf-8";
+  }
+
+  send_response(client_fd, 200, content_type, output);
 }
 
 void Server::handle_not_found(int client_fd) {
-    send_error(client_fd, 404, "not found");
+  send_error(client_fd, 404, "not found");
 }
 
-ExecuteResult Server::execute_with_trace(const Request& request, bool return_trace,
-                                          int client_fd) {
-    ExecuteResult exec_result;
-    run_count_.fetch_add(1, std::memory_order_relaxed);
+ExecuteResult Server::execute_with_trace(const Request& request, bool return_trace, int client_fd) {
+  ExecuteResult exec_result;
+  run_count_.fetch_add(1, std::memory_order_relaxed);
 
-    try {
-        TracedResult traced;
-        std::map<std::string, JsonValue> res_snap;
-        if (resource_manager_) res_snap = resource_manager_->snapshot();
-        std::exception_ptr exec_err = nullptr;
+  try {
+    TracedResult traced;
+    std::map<std::string, JsonValue> res_snap;
+    if (resource_manager_) {
+      res_snap = resource_manager_->snapshot();
+    }
+    std::exception_ptr exec_err = nullptr;
 
-        // R10-2: poll the client socket for disconnect and forward the
-        // cancel into the engine. Without this, /execute keeps running
-        // even after the client closed (waste + slow shutdown).
-        // poll(POLLRDHUP|POLLHUP|POLLERR) does NOT consume bytes, so
-        // it is safe to use mid-keep-alive — a queued follow-up request
-        // looks like POLLIN, which we don't react to.
-        std::stop_source cancel_src;
-        std::atomic<bool> exec_done{false};
-        std::thread watcher;
-        if (client_fd >= 0) {
-            watcher = std::thread([client_fd, &cancel_src, &exec_done]() {
-                while (!exec_done.load(std::memory_order_acquire)) {
-                    struct pollfd pfd{};
-                    pfd.fd = client_fd;
+    // R10-2: poll the client socket for disconnect and forward the
+    // cancel into the engine. Without this, /execute keeps running
+    // even after the client closed (waste + slow shutdown).
+    // poll(POLLRDHUP|POLLHUP|POLLERR) does NOT consume bytes, so
+    // it is safe to use mid-keep-alive — a queued follow-up request
+    // looks like POLLIN, which we don't react to.
+    std::stop_source cancel_src;
+    std::atomic<bool> exec_done{false};
+    std::thread watcher;
+    if (client_fd >= 0) {
+      watcher = std::thread([client_fd, &cancel_src, &exec_done]() {
+        while (!exec_done.load(std::memory_order_acquire)) {
+          struct pollfd pfd{};
+          pfd.fd = client_fd;
 #ifdef POLLRDHUP
-                    pfd.events = POLLRDHUP;
+          pfd.events = POLLRDHUP;
 #else
-                    pfd.events = 0;
+          pfd.events = 0;
 #endif
-                    int rc = ::poll(&pfd, 1, 100 /*ms*/);
-                    if (rc > 0) {
-                        if (pfd.revents & (POLLERR | POLLHUP
+          int rc = ::poll(&pfd, 1, 100 /*ms*/);
+          if (rc > 0) {
+            if (pfd.revents & (POLLERR | POLLHUP
 #ifdef POLLRDHUP
-                                            | POLLRDHUP
+                               | POLLRDHUP
 #endif
-                                            | POLLNVAL)) {
-                            cancel_src.request_stop();
-                            return;
-                        }
-                    }
-                    // rc == 0 (timeout) or rc < 0 (interrupted) — loop.
-                }
-            });
-        }
-        {
-            std::shared_lock<std::shared_mutex> lock(engine_mu_);
-            try {
-                engine_->execute_traced_into(request, res_snap, &traced,
-                                              cancel_src.get_token());
-            } catch (...) {
-                exec_err = std::current_exception();
+                               | POLLNVAL)) {
+              cancel_src.request_stop();
+              return;
             }
+          }
+          // rc == 0 (timeout) or rc < 0 (interrupted) — loop.
         }
-        exec_done.store(true, std::memory_order_release);
-        if (watcher.joinable()) {
-            // Force the watcher poll() to return early so we don't wait
-            // up to 100 ms after a fast request. request_stop is
-            // idempotent and harmless when the engine already returned.
-            cancel_src.request_stop();
-            watcher.join();
+      });
+    }
+    {
+      std::shared_lock<std::shared_mutex> lock(engine_mu_);
+      try {
+        engine_->execute_traced_into(request, res_snap, &traced, cancel_src.get_token());
+      } catch (...) {
+        exec_err = std::current_exception();
+      }
+    }
+    exec_done.store(true, std::memory_order_release);
+    if (watcher.joinable()) {
+      // Force the watcher poll() to return early so we don't wait
+      // up to 100 ms after a fast request. request_stop is
+      // idempotent and harmless when the engine already returned.
+      cancel_src.request_stop();
+      watcher.join();
+    }
+    // Match Go: even on partial execution errors, we capture the Projected
+    // result (items and common containing fields up to failure point) as well
+    // as traces/warnings compiled up to the failure point.
+    exec_result.result = std::move(traced.result);
+    exec_result.warnings = std::move(traced.warnings);
+    exec_result.has_result = true;
+
+    for (const auto& t : traced.trace) {
+      auto dur_ns = std::chrono::nanoseconds(t.duration_us * 1000);
+      if (t.skipped) {
+        stats_->record_skip(t.name);
+      } else {
+        stats_->record_exec(t.name, dur_ns);
+      }
+
+      if (return_trace) {
+        TraceEntry te;
+        te.name = t.name;
+        te.duration_ms = static_cast<double>(t.duration_us) / 1000.0;
+        te.skipped = t.skipped;
+        if (t.has_input_snapshot) {
+          te.has_input_snapshot = true;
+          te.input_snapshot = t.input_snapshot;
         }
-        // Match Go: even on partial execution errors, we capture the Projected
-        // result (items and common containing fields up to failure point) as well
-        // as traces/warnings compiled up to the failure point.
-        exec_result.result = std::move(traced.result);
-        exec_result.warnings = std::move(traced.warnings);
-        exec_result.has_result = true;
-
-        for (const auto& t : traced.trace) {
-            auto dur_ns = std::chrono::nanoseconds(t.duration_us * 1000);
-            if (t.skipped) {
-                stats_->record_skip(t.name);
-            } else {
-                stats_->record_exec(t.name, dur_ns);
-            }
-
-            if (return_trace) {
-                TraceEntry te;
-                te.name = t.name;
-                te.duration_ms = static_cast<double>(t.duration_us) / 1000.0;
-                te.skipped = t.skipped;
-                if (t.has_input_snapshot) {
-                    te.has_input_snapshot = true;
-                    te.input_snapshot = t.input_snapshot;
-                }
-                if (t.has_output_snapshot) {
-                    te.has_output_snapshot = true;
-                    te.output_snapshot = t.output_snapshot;
-                }
-                exec_result.trace.push_back(std::move(te));
-            }
+        if (t.has_output_snapshot) {
+          te.has_output_snapshot = true;
+          te.output_snapshot = t.output_snapshot;
         }
-
-        if (exec_err) std::rethrow_exception(exec_err);
-
-    } catch (const ValidationError& e) {
-        exec_result.has_error = true;
-        exec_result.is_validation_error = true;
-        exec_result.error = e.what();
-    } catch (const ExecutionError& e) {
-        exec_result.has_error = true;
-        exec_result.error = e.what();
-    } catch (const RegistryError& e) {
-        exec_result.has_error = true;
-        exec_result.error = e.what();
-    } catch (const std::exception& e) {
-        exec_result.has_error = true;
-        exec_result.error = e.what();
+        exec_result.trace.push_back(std::move(te));
+      }
     }
 
-    return exec_result;
+    if (exec_err) {
+      std::rethrow_exception(exec_err);
+    }
+
+  } catch (const ValidationError& e) {
+    exec_result.has_error = true;
+    exec_result.is_validation_error = true;
+    exec_result.error = e.what();
+  } catch (const ExecutionError& e) {
+    exec_result.has_error = true;
+    exec_result.error = e.what();
+  } catch (const RegistryError& e) {
+    exec_result.has_error = true;
+    exec_result.error = e.what();
+  } catch (const std::exception& e) {
+    exec_result.has_error = true;
+    exec_result.error = e.what();
+  }
+
+  return exec_result;
 }
 
 // Global pointer for signal handler
 static std::atomic<Server*> g_server{nullptr};
 
 static void signal_handler(int) {
-    auto* s = g_server.load(std::memory_order_relaxed);
-    if (s) s->stop();
+  auto* s = g_server.load(std::memory_order_relaxed);
+  if (s) {
+    s->stop();
+  }
 }
 
 void Server::stop() {
-    running_.store(false, std::memory_order_release);
-    if (listen_fd_ >= 0) {
-        ::shutdown(listen_fd_, SHUT_RDWR);
-        ::close(listen_fd_);
-        listen_fd_ = -1;
-    }
+  running_.store(false, std::memory_order_release);
+  if (listen_fd_ >= 0) {
+    ::shutdown(listen_fd_, SHUT_RDWR);
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+  }
 }
 
 bool Server::reload_config() {
-    try {
-        auto new_config = load_config_from_file(config_.config_path);
-        // Forward resolved Provider during hot-reload too, so metrics keep
-        // flowing through the same sink after config swap.
-        metrics::Provider* provider = config_.metrics_provider ? config_.metrics_provider : metrics::nop_provider();
-        EngineOptions engine_opts;
-        engine_opts.metrics_provider = provider;
-        if (!new_config.log_prefix.empty()) engine_opts.log_prefix = new_config.log_prefix;
-        auto new_engine = std::make_unique<Engine>(new_config, std::move(engine_opts));
-        auto new_expanded = expand_operator_sequence_with_subflows(new_config);
-
-        auto new_resource_manager = std::make_unique<resource::Manager>();
-        new_resource_manager->load_from_config(new_config);
-        new_resource_manager->validate_resource_deps(new_config);
-        new_resource_manager->start();
-
-        {
-            std::unique_lock lock(engine_mu_);
-            engine_ = std::move(new_engine);
-            if (resource_manager_) resource_manager_->stop();
-            resource_manager_ = std::move(new_resource_manager);
-        }
-
-        stats_->pre_init(new_expanded.sequence);
-        return true;
-    } catch (const std::exception& e) {
-        std::cerr << "config reload failed: " << e.what() << "\n";
-        return false;
+  try {
+    auto new_config = load_config_from_file(config_.config_path);
+    // Forward resolved Provider during hot-reload too, so metrics keep
+    // flowing through the same sink after config swap.
+    metrics::Provider* provider =
+        config_.metrics_provider ? config_.metrics_provider : metrics::nop_provider();
+    EngineOptions engine_opts;
+    engine_opts.metrics_provider = provider;
+    if (!new_config.log_prefix.empty()) {
+      engine_opts.log_prefix = new_config.log_prefix;
     }
+    auto new_engine = std::make_unique<Engine>(new_config, std::move(engine_opts));
+    auto new_expanded = expand_operator_sequence_with_subflows(new_config);
+
+    auto new_resource_manager = std::make_unique<resource::Manager>();
+    new_resource_manager->load_from_config(new_config);
+    new_resource_manager->validate_resource_deps(new_config);
+    new_resource_manager->start();
+
+    {
+      std::unique_lock lock(engine_mu_);
+      engine_ = std::move(new_engine);
+      if (resource_manager_) {
+        resource_manager_->stop();
+      }
+      resource_manager_ = std::move(new_resource_manager);
+    }
+
+    stats_->pre_init(new_expanded.sequence);
+    return true;
+  } catch (const std::exception& e) {
+    std::cerr << "config reload failed: " << e.what() << "\n";
+    return false;
+  }
 }
 
 void Server::watch_config() {
-    struct stat st{};
-    time_t last_mod = 0;
-    if (::stat(config_.config_path.c_str(), &st) == 0) {
-        last_mod = st.st_mtime;
+  struct stat st{};
+  time_t last_mod = 0;
+  if (::stat(config_.config_path.c_str(), &st) == 0) {
+    last_mod = st.st_mtime;
+  }
+
+  while (running_.load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    if (!running_.load(std::memory_order_acquire)) {
+      break;
     }
 
-    while (running_.load(std::memory_order_acquire)) {
-        std::this_thread::sleep_for(std::chrono::seconds(2));
-        if (!running_.load(std::memory_order_acquire)) break;
-
-        if (::stat(config_.config_path.c_str(), &st) != 0) continue;
-        if (st.st_mtime <= last_mod) continue;
-
-        last_mod = st.st_mtime;
-        auto start = std::chrono::steady_clock::now();
-        if (reload_config()) {
-            auto dur = std::chrono::steady_clock::now() - start;
-            reload_count_.fetch_add(1, std::memory_order_relaxed);
-            last_reload_duration_ns_.store(
-                std::chrono::duration_cast<std::chrono::nanoseconds>(dur).count(),
-                std::memory_order_relaxed);
-            if (m_reload_total_) m_reload_total_->inc();
-            if (m_reload_duration_) {
-                m_reload_duration_->observe(metrics::duration_seconds(
-                    std::chrono::duration_cast<std::chrono::nanoseconds>(dur)));
-            }
-            std::cerr << "config reloaded from " << config_.config_path << "\n";
-        } else {
-            reload_error_count_.fetch_add(1, std::memory_order_relaxed);
-            if (m_reload_errors_) m_reload_errors_->inc();
-        }
+    if (::stat(config_.config_path.c_str(), &st) != 0) {
+      continue;
     }
+    if (st.st_mtime <= last_mod) {
+      continue;
+    }
+
+    last_mod = st.st_mtime;
+    auto start = std::chrono::steady_clock::now();
+    if (reload_config()) {
+      auto dur = std::chrono::steady_clock::now() - start;
+      reload_count_.fetch_add(1, std::memory_order_relaxed);
+      last_reload_duration_ns_.store(std::chrono::duration_cast<std::chrono::nanoseconds>(dur).count(),
+                                     std::memory_order_relaxed);
+      if (m_reload_total_) {
+        m_reload_total_->inc();
+      }
+      if (m_reload_duration_) {
+        m_reload_duration_->observe(
+            metrics::duration_seconds(std::chrono::duration_cast<std::chrono::nanoseconds>(dur)));
+      }
+      std::cerr << "config reloaded from " << config_.config_path << "\n";
+    } else {
+      reload_error_count_.fetch_add(1, std::memory_order_relaxed);
+      if (m_reload_errors_) {
+        m_reload_errors_->inc();
+      }
+    }
+  }
 }
 
 int Server::run(const ServerConfig& cfg) {
-    config_ = cfg;
+  config_ = cfg;
 
-    if (cfg.config_path.empty()) {
-        std::cerr << "usage: pineapple-server -config <path-to-config.json>\n";
-        return 1;
+  if (cfg.config_path.empty()) {
+    std::cerr << "usage: pineapple-server -config <path-to-config.json>\n";
+    return 1;
+  }
+
+  // Apply HTTP metrics as innermost middleware. Standard behavior: we use
+  // the configured metrics_provider, or fall back to nop_provider() so the
+  // middleware chain is ALWAYS configured identically to Go/Java/Python.
+  // The middleware also feeds an in-process HttpStats that surfaces through
+  // GET /stats.http; timing excludes user middleware overhead.
+  metrics::Provider* provider = config_.metrics_provider ? config_.metrics_provider : metrics::nop_provider();
+  http_stats_ = std::make_unique<HttpStats>();
+  config_.middlewares.push_back(http_metrics_middleware(provider, http_stats_.get()));
+
+  // Hot-reload Provider metrics. Mirrors pine-go pkg/server/server.go:100-114
+  // — same metric names, help text, and bucket schedule so downstream
+  // Prometheus dashboards work unchanged. NopProvider returns no-op
+  // pointers so the call sites stay branchless.
+  m_reload_total_ =
+      provider->new_counter({"pine_config_reload_total", "Total successful config reloads.", {}});
+  m_reload_errors_ =
+      provider->new_counter({"pine_config_reload_errors_total", "Total failed config reloads.", {}});
+  m_reload_duration_ = provider->new_histogram(
+      {{"pine_config_reload_duration_seconds", "Config reload duration in seconds.", {}},
+       {0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0}});
+
+  // Load engine and start resource manager if configured
+  try {
+    auto config = load_config_from_file(cfg.config_path);
+    // Forward the resolved Provider (caller-configured or NopProvider
+    // fallback) into the Engine via EngineOptions so per-operator,
+    // scheduler, and DAG-level metrics reach the same Provider as the
+    // http_metrics middleware. Mirrors pine-go's
+    // `pine.NewEngine(cfg, pine.WithMetrics(mp))`.
+    EngineOptions engine_opts;
+    engine_opts.metrics_provider = provider;
+    if (!config.log_prefix.empty()) {
+      engine_opts.log_prefix = config.log_prefix;
+    }
+    engine_ = std::make_unique<Engine>(config, std::move(engine_opts));
+
+    resource_manager_ = std::make_unique<resource::Manager>();
+    resource_manager_->load_from_config(config);
+    resource_manager_->validate_resource_deps(config);
+    resource_manager_->start();
+  } catch (const std::exception& e) {
+    std::cerr << "failed to load engine/resources: " << e.what() << "\n";
+    return 1;
+  }
+
+  // Initialize stats with operator names
+  stats_ = std::make_unique<Stats>();
+  // We need the expanded sequence for pre-init.
+  // Re-load config to get the sequence (Engine doesn't expose it directly).
+  try {
+    auto config = load_config_from_file(cfg.config_path);
+    auto expanded = expand_operator_sequence_with_subflows(config);
+    stats_->pre_init(expanded.sequence);
+  } catch (...) {
+    // If we can't get the sequence, stats will still work dynamically
+  }
+
+  std::cerr << "engine loaded from " << cfg.config_path << "\n";
+
+  // Parse address
+  int port = 8080;
+  std::string addr = cfg.addr;
+  if (addr.empty()) {
+    addr = ":8080";
+  }
+  auto colon = addr.rfind(':');
+  if (colon != std::string::npos) {
+    port = std::stoi(addr.substr(colon + 1));
+  }
+
+  // Create socket
+  listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+  if (listen_fd_ < 0) {
+    std::cerr << "socket() failed: " << strerror(errno) << "\n";
+    return 1;
+  }
+
+  int optval = 1;
+  setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+  setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
+
+  struct sockaddr_in server_addr{};
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_addr.s_addr = INADDR_ANY;
+  server_addr.sin_port = htons(static_cast<uint16_t>(port));
+
+  if (bind(listen_fd_, reinterpret_cast<struct sockaddr*>(&server_addr), sizeof(server_addr)) < 0) {
+    std::cerr << "bind() failed on port " << port << ": " << strerror(errno) << "\n";
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+    return 1;
+  }
+
+  if (listen(listen_fd_, 128) < 0) {
+    std::cerr << "listen() failed: " << strerror(errno) << "\n";
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+    return 1;
+  }
+
+  running_.store(true, std::memory_order_release);
+
+  // Set up signal handling
+  g_server.store(this, std::memory_order_release);
+  struct sigaction sa{};
+  sa.sa_handler = signal_handler;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  sigaction(SIGINT, &sa, nullptr);
+  sigaction(SIGTERM, &sa, nullptr);
+
+  std::cerr << "listening on " << addr << "\n";
+
+  // Start config file watcher thread
+  std::thread watcher_thread([this]() { watch_config(); });
+
+  // Accept loop
+  while (running_.load(std::memory_order_acquire)) {
+    struct pollfd pfd{};
+    pfd.fd = listen_fd_;
+    pfd.events = POLLIN;
+    int ret = poll(&pfd, 1, 500);  // 500ms timeout for shutdown check
+    if (ret <= 0) {
+      continue;
     }
 
-    // Apply HTTP metrics as innermost middleware. Standard behavior: we use
-    // the configured metrics_provider, or fall back to nop_provider() so the
-    // middleware chain is ALWAYS configured identically to Go/Java/Python.
-    // The middleware also feeds an in-process HttpStats that surfaces through
-    // GET /stats.http; timing excludes user middleware overhead.
-    metrics::Provider* provider = config_.metrics_provider ? config_.metrics_provider : metrics::nop_provider();
-    http_stats_ = std::make_unique<HttpStats>();
-    config_.middlewares.push_back(http_metrics_middleware(provider, http_stats_.get()));
-
-    // Hot-reload Provider metrics. Mirrors pine-go pkg/server/server.go:100-114
-    // — same metric names, help text, and bucket schedule so downstream
-    // Prometheus dashboards work unchanged. NopProvider returns no-op
-    // pointers so the call sites stay branchless.
-    m_reload_total_ = provider->new_counter(
-        {"pine_config_reload_total", "Total successful config reloads.", {}});
-    m_reload_errors_ = provider->new_counter(
-        {"pine_config_reload_errors_total", "Total failed config reloads.", {}});
-    m_reload_duration_ = provider->new_histogram(
-        {{"pine_config_reload_duration_seconds", "Config reload duration in seconds.", {}},
-         {0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0}});
-
-    // Load engine and start resource manager if configured
-    try {
-        auto config = load_config_from_file(cfg.config_path);
-        // Forward the resolved Provider (caller-configured or NopProvider
-        // fallback) into the Engine via EngineOptions so per-operator,
-        // scheduler, and DAG-level metrics reach the same Provider as the
-        // http_metrics middleware. Mirrors pine-go's
-        // `pine.NewEngine(cfg, pine.WithMetrics(mp))`.
-        EngineOptions engine_opts;
-        engine_opts.metrics_provider = provider;
-        if (!config.log_prefix.empty()) engine_opts.log_prefix = config.log_prefix;
-        engine_ = std::make_unique<Engine>(config, std::move(engine_opts));
-
-        resource_manager_ = std::make_unique<resource::Manager>();
-        resource_manager_->load_from_config(config);
-        resource_manager_->validate_resource_deps(config);
-        resource_manager_->start();
-    } catch (const std::exception& e) {
-        std::cerr << "failed to load engine/resources: " << e.what() << "\n";
-        return 1;
+    struct sockaddr_in client_addr{};
+    socklen_t client_len = sizeof(client_addr);
+    int client_fd = accept(listen_fd_, reinterpret_cast<struct sockaddr*>(&client_addr), &client_len);
+    if (client_fd < 0) {
+      if (running_.load(std::memory_order_acquire)) {
+        // Real error, not shutdown
+      }
+      continue;
     }
 
-    // Initialize stats with operator names
-    stats_ = std::make_unique<Stats>();
-    // We need the expanded sequence for pre-init.
-    // Re-load config to get the sequence (Engine doesn't expose it directly).
-    try {
-        auto config = load_config_from_file(cfg.config_path);
-        auto expanded = expand_operator_sequence_with_subflows(config);
-        stats_->pre_init(expanded.sequence);
-    } catch (...) {
-        // If we can't get the sequence, stats will still work dynamically
-    }
+    // Apply per-connection socket timeouts. Mirrors pine-go's
+    // http.Server ReadTimeout / WriteTimeout. ReadHeaderTimeout is
+    // now wired — read_http_request swaps SO_RCVTIMEO at
+    // the header boundary, so the short window applies to headers
+    // and the long window applies to body reads. IdleTimeout is
+    // handled by the keep-alive loop.
+    int rcv_secs = config_.read_timeout_seconds > 0 ? config_.read_timeout_seconds : 30;
+    int snd_secs = config_.write_timeout_seconds > 0 ? config_.write_timeout_seconds : 60;
+    int header_secs = config_.read_header_timeout_seconds > 0 ? config_.read_header_timeout_seconds
+                                                              : rcv_secs;  // default: same as read_timeout
+    int idle_secs = config_.idle_timeout_seconds > 0 ? config_.idle_timeout_seconds
+                                                     : rcv_secs;  // default: same as read_timeout
+    // Initial socket timeout: write side and a wide read fallback;
+    // read_http_request below installs the precise header→body
+    // schedule via SO_RCVTIMEO swap.
+    struct timeval rcv_to{rcv_secs, 0};
+    struct timeval snd_to{snd_secs, 0};
+    setsockopt(client_fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_to, sizeof(rcv_to));
+    setsockopt(client_fd, SOL_SOCKET, SO_SNDTIMEO, &snd_to, sizeof(snd_to));
 
-    std::cerr << "engine loaded from " << cfg.config_path << "\n";
+    // Handle request in a detached thread for concurrency
+    in_flight_.fetch_add(1, std::memory_order_relaxed);
+    std::thread([this, client_fd, header_secs, rcv_secs, idle_secs]() {
+      // RAII decrement so detached threads always release the counter.
+      // Wakes stop()'s drain loop via drain_cv_ so it does not have
+      // to poll on a 50 ms sleep_for.
+      struct InFlightGuard {
+        std::atomic<int64_t>& c;
+        std::mutex& mu;
+        std::condition_variable& cv;
+        ~InFlightGuard() {
+          c.fetch_sub(1, std::memory_order_relaxed);
+          std::lock_guard<std::mutex> lk(mu);
+          cv.notify_all();
+        }
+      } guard{in_flight_, drain_mu_, drain_cv_};
+      (void)guard;
 
-    // Parse address
-    int port = 8080;
-    std::string addr = cfg.addr;
-    if (addr.empty()) addr = ":8080";
-    auto colon = addr.rfind(':');
-    if (colon != std::string::npos) {
-        port = std::stoi(addr.substr(colon + 1));
-    }
+      // HTTP/1.1 keep-alive loop. The first request uses
+      // header_secs as the header-phase timeout; subsequent
+      // requests on the same connection use idle_secs as the
+      // header-phase timeout (the idle window between requests).
+      // Body timeouts always use rcv_secs.
+      bool first_request = true;
+      while (true) {
+        int hdr_to = first_request ? header_secs : idle_secs;
+        first_request = false;
 
-    // Create socket
-    listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
-    if (listen_fd_ < 0) {
-        std::cerr << "socket() failed: " << strerror(errno) << "\n";
-        return 1;
-    }
-
-    int optval = 1;
-    setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
-    setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
-
-    struct sockaddr_in server_addr{};
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_addr.s_addr = INADDR_ANY;
-    server_addr.sin_port = htons(static_cast<uint16_t>(port));
-
-    if (bind(listen_fd_, reinterpret_cast<struct sockaddr*>(&server_addr), sizeof(server_addr)) < 0) {
-        std::cerr << "bind() failed on port " << port << ": " << strerror(errno) << "\n";
-        ::close(listen_fd_);
-        listen_fd_ = -1;
-        return 1;
-    }
-
-    if (listen(listen_fd_, 128) < 0) {
-        std::cerr << "listen() failed: " << strerror(errno) << "\n";
-        ::close(listen_fd_);
-        listen_fd_ = -1;
-        return 1;
-    }
-
-    running_.store(true, std::memory_order_release);
-
-    // Set up signal handling
-    g_server.store(this, std::memory_order_release);
-    struct sigaction sa{};
-    sa.sa_handler = signal_handler;
-    sigemptyset(&sa.sa_mask);
-    sa.sa_flags = 0;
-    sigaction(SIGINT, &sa, nullptr);
-    sigaction(SIGTERM, &sa, nullptr);
-
-    std::cerr << "listening on " << addr << "\n";
-
-    // Start config file watcher thread
-    std::thread watcher_thread([this]() { watch_config(); });
-
-    // Accept loop
-    while (running_.load(std::memory_order_acquire)) {
-        struct pollfd pfd{};
-        pfd.fd = listen_fd_;
-        pfd.events = POLLIN;
-        int ret = poll(&pfd, 1, 500);  // 500ms timeout for shutdown check
-        if (ret <= 0) continue;
-
-        struct sockaddr_in client_addr{};
-        socklen_t client_len = sizeof(client_addr);
-        int client_fd = accept(listen_fd_, reinterpret_cast<struct sockaddr*>(&client_addr), &client_len);
-        if (client_fd < 0) {
-            if (running_.load(std::memory_order_acquire)) {
-                // Real error, not shutdown
-            }
-            continue;
+        HttpRequest req;
+        if (!read_http_request(client_fd, req, config_.max_request_body_size, hdr_to, rcv_secs)) {
+          // Either EOF, timeout, or malformed — close the connection.
+          ::close(client_fd);
+          return;
         }
 
-        // Apply per-connection socket timeouts. Mirrors pine-go's
-        // http.Server ReadTimeout / WriteTimeout. ReadHeaderTimeout is
-        // now wired — read_http_request swaps SO_RCVTIMEO at
-        // the header boundary, so the short window applies to headers
-        // and the long window applies to body reads. IdleTimeout is
-        // handled by the keep-alive loop.
-        int rcv_secs = config_.read_timeout_seconds > 0 ? config_.read_timeout_seconds : 30;
-        int snd_secs = config_.write_timeout_seconds > 0 ? config_.write_timeout_seconds : 60;
-        int header_secs = config_.read_header_timeout_seconds > 0
-                          ? config_.read_header_timeout_seconds
-                          : rcv_secs;  // default: same as read_timeout
-        int idle_secs = config_.idle_timeout_seconds > 0
-                        ? config_.idle_timeout_seconds
-                        : rcv_secs;  // default: same as read_timeout
-        // Initial socket timeout: write side and a wide read fallback;
-        // read_http_request below installs the precise header→body
-        // schedule via SO_RCVTIMEO swap.
-        struct timeval rcv_to{rcv_secs, 0};
-        struct timeval snd_to{snd_secs, 0};
-        setsockopt(client_fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_to, sizeof(rcv_to));
-        setsockopt(client_fd, SOL_SOCKET, SO_SNDTIMEO, &snd_to, sizeof(snd_to));
+        // Check parse status: malformed Content-Length → 400
+        if (req.content_length == -2) {
+          send_error(client_fd, 400, "invalid Content-Length header");
+          ::close(client_fd);
+          return;
+        }
 
-        // Handle request in a detached thread for concurrency
-        in_flight_.fetch_add(1, std::memory_order_relaxed);
-        std::thread([this, client_fd, header_secs, rcv_secs, idle_secs]() {
-            // RAII decrement so detached threads always release the counter.
-            // Wakes stop()'s drain loop via drain_cv_ so it does not have
-            // to poll on a 50 ms sleep_for.
-            struct InFlightGuard {
-                std::atomic<int64_t>& c;
-                std::mutex& mu;
-                std::condition_variable& cv;
-                ~InFlightGuard() {
-                    c.fetch_sub(1, std::memory_order_relaxed);
-                    std::lock_guard<std::mutex> lk(mu);
-                    cv.notify_all();
-                }
-            } guard{in_flight_, drain_mu_, drain_cv_};
-            (void)guard;
+        // Check if content_length exceeded max
+        if (req.content_length > config_.max_request_body_size) {
+          send_error(client_fd, 413, "request body too large");
+          ::close(client_fd);
+          return;
+        }
 
-            // HTTP/1.1 keep-alive loop. The first request uses
-            // header_secs as the header-phase timeout; subsequent
-            // requests on the same connection use idle_secs as the
-            // header-phase timeout (the idle window between requests).
-            // Body timeouts always use rcv_secs.
-            bool first_request = true;
-            while (true) {
-                int hdr_to = first_request ? header_secs : idle_secs;
-                first_request = false;
+        // Decide keep-alive policy for this request. HTTP/1.1
+        // defaults to keep-alive unless `Connection: close` is
+        // set; HTTP/1.0 defaults to close unless
+        // `Connection: keep-alive` is set. Matches pine-go's
+        // http.Server semantics.
+        bool keep_alive;
+        if (req.http_version == "HTTP/1.0") {
+          keep_alive = req.connection_keep_alive && !req.connection_close;
+        } else {
+          keep_alive = !req.connection_close;
+        }
 
-                HttpRequest req;
-                if (!read_http_request(client_fd, req, config_.max_request_body_size,
-                                        hdr_to, rcv_secs)) {
-                    // Either EOF, timeout, or malformed — close the connection.
-                    ::close(client_fd);
-                    return;
-                }
+        // Set up middleware context + dispatch chain.
+        MiddlewareContext mw_ctx;
+        mw_ctx.method = req.method;
+        mw_ctx.path = req.path;
+        mw_ctx.normalized_path = normalize_path(req.path);
+        mw_ctx.request_bytes = req.content_length > 0 ? req.content_length : 0;
+        mw_ctx.status = 200;
+        mw_ctx.keep_alive = keep_alive;
 
-                // Check parse status: malformed Content-Length → 400
-                if (req.content_length == -2) {
-                    send_error(client_fd, 400, "invalid Content-Length header");
-                    ::close(client_fd);
-                    return;
-                }
+        // Innermost handler: actual route dispatch.
+        std::function<void()> dispatch = [&]() {
+          if (req.path == "/health") {
+            handle_health(client_fd, req.method);
+          } else if (req.path == "/execute") {
+            handle_execute(client_fd, req.method, req.body, req.content_length);
+          } else if (req.path == "/stats") {
+            handle_stats(client_fd, req.method);
+          } else if (req.path == "/dag") {
+            handle_dag(client_fd, req.method, req.query_string);
+          } else {
+            handle_not_found(client_fd);
+          }
+        };
 
-                // Check if content_length exceeded max
-                if (req.content_length > config_.max_request_body_size) {
-                    send_error(client_fd, 413, "request body too large");
-                    ::close(client_fd);
-                    return;
-                }
+        // Apply user middlewares outer-to-inner: the first middleware
+        // sees the request first, matching pine-go's loop direction.
+        std::function<void()> chain = dispatch;
+        const auto& mws = config_.middlewares;
+        for (auto it = mws.rbegin(); it != mws.rend(); ++it) {
+          Middleware mw = *it;
+          std::function<void()> next = chain;
+          chain = [&mw_ctx, mw, next]() { mw(mw_ctx, next); };
+        }
 
-                // Decide keep-alive policy for this request. HTTP/1.1
-                // defaults to keep-alive unless `Connection: close` is
-                // set; HTTP/1.0 defaults to close unless
-                // `Connection: keep-alive` is set. Matches pine-go's
-                // http.Server semantics.
-                bool keep_alive;
-                if (req.http_version == "HTTP/1.0") {
-                    keep_alive = req.connection_keep_alive && !req.connection_close;
-                } else {
-                    keep_alive = !req.connection_close;
-                }
+        t_mw_ctx = &mw_ctx;
+        chain();
+        t_mw_ctx = nullptr;
 
-                // Set up middleware context + dispatch chain.
-                MiddlewareContext mw_ctx;
-                mw_ctx.method = req.method;
-                mw_ctx.path = req.path;
-                mw_ctx.normalized_path = normalize_path(req.path);
-                mw_ctx.request_bytes = req.content_length > 0 ? req.content_length : 0;
-                mw_ctx.status = 200;
-                mw_ctx.keep_alive = keep_alive;
+        if (!keep_alive) {
+          ::close(client_fd);
+          return;
+        }
+        // Loop back to read the next request — read_http_request
+        // will install idle_secs as the header timeout on the
+        // next iteration so a permanently-idle keep-alive
+        // connection is reaped.
+      }
+    }).detach();
+  }
 
-                // Innermost handler: actual route dispatch.
-                std::function<void()> dispatch = [&]() {
-                    if (req.path == "/health") {
-                        handle_health(client_fd, req.method);
-                    } else if (req.path == "/execute") {
-                        handle_execute(client_fd, req.method, req.body, req.content_length);
-                    } else if (req.path == "/stats") {
-                        handle_stats(client_fd, req.method);
-                    } else if (req.path == "/dag") {
-                        handle_dag(client_fd, req.method, req.query_string);
-                    } else {
-                        handle_not_found(client_fd);
-                    }
-                };
-
-                // Apply user middlewares outer-to-inner: the first middleware
-                // sees the request first, matching pine-go's loop direction.
-                std::function<void()> chain = dispatch;
-                const auto& mws = config_.middlewares;
-                for (auto it = mws.rbegin(); it != mws.rend(); ++it) {
-                    Middleware mw = *it;
-                    std::function<void()> next = chain;
-                    chain = [&mw_ctx, mw, next]() { mw(mw_ctx, next); };
-                }
-
-                t_mw_ctx = &mw_ctx;
-                chain();
-                t_mw_ctx = nullptr;
-
-                if (!keep_alive) {
-                    ::close(client_fd);
-                    return;
-                }
-                // Loop back to read the next request — read_http_request
-                // will install idle_secs as the header timeout on the
-                // next iteration so a permanently-idle keep-alive
-                // connection is reaped.
-            }
-        }).detach();
-    }
-
-    g_server.store(nullptr, std::memory_order_release);
-    watcher_thread.join();
-    if (listen_fd_ >= 0) {
-        ::close(listen_fd_);
-        listen_fd_ = -1;
-    }
-    // Graceful drain: wait for all in-flight handler threads to finish.
-    // No deadline — abandoning still-running threads is a use-after-free
-    // hazard once Server members (engine_, config_, engine_mu_, stats_)
-    // get torn down by ~Server(). Detached threads hold raw `this` and
-    // raw references into those members; outliving the destructor would
-    // touch freed storage.
-    //
-    // Socket read/write timeouts (config_.read_timeout_seconds etc.) bound
-    // the runtime of each individual request, so this loop terminates as
-    // long as no handler is genuinely stuck. If a future regression makes
-    // a handler unbounded, we will deadlock here — that is louder and
-    // safer than the UAF it replaces.
-    std::cerr << "shutting down...\n";
-    {
-        std::unique_lock<std::mutex> lk(drain_mu_);
-        drain_cv_.wait(lk, [this] {
-            return in_flight_.load(std::memory_order_relaxed) == 0;
-        });
-    }
-    return 0;
+  g_server.store(nullptr, std::memory_order_release);
+  watcher_thread.join();
+  if (listen_fd_ >= 0) {
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+  }
+  // Graceful drain: wait for all in-flight handler threads to finish.
+  // No deadline — abandoning still-running threads is a use-after-free
+  // hazard once Server members (engine_, config_, engine_mu_, stats_)
+  // get torn down by ~Server(). Detached threads hold raw `this` and
+  // raw references into those members; outliving the destructor would
+  // touch freed storage.
+  //
+  // Socket read/write timeouts (config_.read_timeout_seconds etc.) bound
+  // the runtime of each individual request, so this loop terminates as
+  // long as no handler is genuinely stuck. If a future regression makes
+  // a handler unbounded, we will deadlock here — that is louder and
+  // safer than the UAF it replaces.
+  std::cerr << "shutting down...\n";
+  {
+    std::unique_lock<std::mutex> lk(drain_mu_);
+    drain_cv_.wait(lk, [this] { return in_flight_.load(std::memory_order_relaxed) == 0; });
+  }
+  return 0;
 }
 
 }  // namespace server

--- a/pine-cpp/src/server/server.hpp
+++ b/pine-cpp/src/server/server.hpp
@@ -5,11 +5,11 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <map>
 #include <mutex>
 #include <shared_mutex>
-#include <condition_variable>
 #include <string>
 #include <vector>
 
@@ -18,88 +18,88 @@ namespace server {
 
 // Per-operator stats, thread-safe via atomics.
 struct OpStats {
-    std::atomic<int64_t> exec_count{0};
-    std::atomic<int64_t> skip_count{0};
-    std::atomic<int64_t> error_count{0};
-    std::atomic<int64_t> total_duration_ns{0};
-    std::atomic<int64_t> max_duration_ns{0};
+  std::atomic<int64_t> exec_count{0};
+  std::atomic<int64_t> skip_count{0};
+  std::atomic<int64_t> error_count{0};
+  std::atomic<int64_t> total_duration_ns{0};
+  std::atomic<int64_t> max_duration_ns{0};
 };
 
 // Snapshot of per-operator stats for serialization.
 struct OpStatsSnapshot {
-    int64_t exec_count = 0;
-    int64_t skip_count = 0;
-    int64_t error_count = 0;
-    int64_t total_duration_ns = 0;
-    int64_t max_duration_ns = 0;
-    int64_t avg_duration_ns = 0;
+  int64_t exec_count = 0;
+  int64_t skip_count = 0;
+  int64_t error_count = 0;
+  int64_t total_duration_ns = 0;
+  int64_t max_duration_ns = 0;
+  int64_t avg_duration_ns = 0;
 };
 
 // Trace entry for a single operator execution.
 struct TraceEntry {
-    std::string name;
-    double duration_ms = 0.0;
-    bool skipped = false;
-    bool has_input_snapshot = false;
-    JsonValue input_snapshot;
-    bool has_output_snapshot = false;
-    JsonValue output_snapshot;
+  std::string name;
+  double duration_ms = 0.0;
+  bool skipped = false;
+  bool has_input_snapshot = false;
+  JsonValue input_snapshot;
+  bool has_output_snapshot = false;
+  JsonValue output_snapshot;
 };
 
 // Result of an engine execution, including trace and warnings.
 struct ExecuteResult {
-    Result result;
-    std::vector<std::string> warnings;
-    std::vector<TraceEntry> trace;
-    std::string error;
-    bool is_validation_error = false;
-    bool has_error = false;
-    // Whether `result` was populated by the engine. Mirrors pine-go's
-    // `result != nil` check: on engine-level errors the result is "nil",
-    // and the response must serialize common/items as JSON `null` (not `{}`/`[]`).
-    bool has_result = false;
+  Result result;
+  std::vector<std::string> warnings;
+  std::vector<TraceEntry> trace;
+  std::string error;
+  bool is_validation_error = false;
+  bool has_error = false;
+  // Whether `result` was populated by the engine. Mirrors pine-go's
+  // `result != nil` check: on engine-level errors the result is "nil",
+  // and the response must serialize common/items as JSON `null` (not `{}`/`[]`).
+  bool has_result = false;
 };
 
 // Stats accumulator for per-operator metrics.
 class Stats {
-public:
-    // Pre-register operator names so they appear from startup.
-    void pre_init(const std::vector<std::string>& names);
+ public:
+  // Pre-register operator names so they appear from startup.
+  void pre_init(const std::vector<std::string>& names);
 
-    void record_exec(const std::string& name, std::chrono::nanoseconds duration);
-    void record_skip(const std::string& name);
-    void record_error(const std::string& name, std::chrono::nanoseconds duration);
+  void record_exec(const std::string& name, std::chrono::nanoseconds duration);
+  void record_skip(const std::string& name);
+  void record_error(const std::string& name, std::chrono::nanoseconds duration);
 
-    // Returns a snapshot ordered by the pre-init sequence.
-    std::vector<std::pair<std::string, OpStatsSnapshot>> snapshot() const;
+  // Returns a snapshot ordered by the pre-init sequence.
+  std::vector<std::pair<std::string, OpStatsSnapshot>> snapshot() const;
 
-private:
-    OpStats& get_or_create(const std::string& name);
+ private:
+  OpStats& get_or_create(const std::string& name);
 
-    mutable std::mutex mu_;
-    std::map<std::string, std::unique_ptr<OpStats>> ops_;
-    std::vector<std::string> order_;  // insertion order
+  mutable std::mutex mu_;
+  std::map<std::string, std::unique_ptr<OpStats>> ops_;
+  std::vector<std::string> order_;  // insertion order
 };
 
 // Scheduler-level stats.
 struct SchedulerStatsSnapshot {
-    int64_t run_count = 0;
-    int64_t peak_concurrency = 0;
+  int64_t run_count = 0;
+  int64_t peak_concurrency = 0;
 };
 
 // Per-request context passed through the middleware chain. `status` is set by
 // `send_response` (via thread-local capture) and visible to middleware after
 // `next()` returns. Mirrors pine-go's `statusRecorder`.
 struct MiddlewareContext {
-    std::string method;
-    std::string path;          // raw request path
-    std::string normalized_path; // /execute, /health, /stats, /dag, or "_other"
-    int64_t request_bytes = 0;
-    int status = 200;          // populated by inner handler
-    // Whether the outer connection loop will reuse this socket
-    // for a follow-up request. send_response reads this to choose
-    // `Connection: keep-alive` vs `Connection: close`.
-    bool keep_alive = false;
+  std::string method;
+  std::string path;             // raw request path
+  std::string normalized_path;  // /execute, /health, /stats, /dag, or "_other"
+  int64_t request_bytes = 0;
+  int status = 200;  // populated by inner handler
+  // Whether the outer connection loop will reuse this socket
+  // for a follow-up request. send_response reads this to choose
+  // `Connection: keep-alive` vs `Connection: close`.
+  bool keep_alive = false;
 };
 
 // User-supplied middleware. Middleware MUST call `next()` exactly once unless
@@ -120,97 +120,94 @@ Middleware http_metrics_middleware(pine::metrics::Provider* provider, HttpStats*
 
 // Server configuration.
 struct ServerConfig {
-    std::string config_path;
-    std::string addr = ":8080";
-    int64_t max_request_body_size = 10 * 1024 * 1024;  // 10 MB
-    // HTTP socket timeouts, seconds. 0 means "use default":
-    //   read_header: 10s, read: 30s, write: 60s, idle: 120s.
-    // Mirrors pine-go's pineapple-server -read-header-timeout / -read-timeout
-    // / -write-timeout / -idle-timeout flags + server.Config defaults.
-    int read_header_timeout_seconds = 0;
-    int read_timeout_seconds = 0;
-    int write_timeout_seconds = 0;
-    int idle_timeout_seconds = 0;
+  std::string config_path;
+  std::string addr = ":8080";
+  int64_t max_request_body_size = 10 * 1024 * 1024;  // 10 MB
+  // HTTP socket timeouts, seconds. 0 means "use default":
+  //   read_header: 10s, read: 30s, write: 60s, idle: 120s.
+  // Mirrors pine-go's pineapple-server -read-header-timeout / -read-timeout
+  // / -write-timeout / -idle-timeout flags + server.Config defaults.
+  int read_header_timeout_seconds = 0;
+  int read_timeout_seconds = 0;
+  int write_timeout_seconds = 0;
+  int idle_timeout_seconds = 0;
 
-    // HTTP middlewares applied outer-to-inner (first sees request first).
-    // Mirrors pine-go server.Config.Middlewares.
-    std::vector<Middleware> middlewares;
+  // HTTP middlewares applied outer-to-inner (first sees request first).
+  // Mirrors pine-go server.Config.Middlewares.
+  std::vector<Middleware> middlewares;
 
-    // Optional metrics provider for HTTP-layer instrumentation. nullptr → no-op.
-    pine::metrics::Provider* metrics_provider = nullptr;
+  // Optional metrics provider for HTTP-layer instrumentation. nullptr → no-op.
+  pine::metrics::Provider* metrics_provider = nullptr;
 };
 
 // Minimal HTTP server for pine-cpp.
 class Server {
-public:
-    Server();
-    ~Server();
+ public:
+  Server();
+  ~Server();
 
-    // Run starts the server and blocks until stopped.
-    int run(const ServerConfig& cfg);
+  // Run starts the server and blocks until stopped.
+  int run(const ServerConfig& cfg);
 
-    // Stop signals the server to shut down.
-    void stop();
+  // Stop signals the server to shut down.
+  void stop();
 
-private:
-    // HTTP handlers
-    void handle_health(int client_fd, const std::string& method);
-    void handle_execute(int client_fd, const std::string& method,
-                        const std::string& body, int64_t content_length);
-    void handle_stats(int client_fd, const std::string& method);
-    void handle_dag(int client_fd, const std::string& method,
-                    const std::string& query_string);
-    void handle_not_found(int client_fd);
+ private:
+  // HTTP handlers
+  void handle_health(int client_fd, const std::string& method);
+  void handle_execute(int client_fd, const std::string& method, const std::string& body,
+                      int64_t content_length);
+  void handle_stats(int client_fd, const std::string& method);
+  void handle_dag(int client_fd, const std::string& method, const std::string& query_string);
+  void handle_not_found(int client_fd);
 
-    // Execute with stats tracking and tracing.
-    ExecuteResult execute_with_trace(const Request& request, bool return_trace,
-                                      int client_fd = -1);
+  // Execute with stats tracking and tracing.
+  ExecuteResult execute_with_trace(const Request& request, bool return_trace, int client_fd = -1);
 
-    // Config file watcher thread (polls mtime every 2s).
-    void watch_config();
+  // Config file watcher thread (polls mtime every 2s).
+  void watch_config();
 
-    // Reload engine from config file.
-    bool reload_config();
+  // Reload engine from config file.
+  bool reload_config();
 
-    // Response helpers
-    static void send_response(int fd, int status, const std::string& content_type,
-                              const std::string& body);
-    static void send_json(int fd, int status, const std::string& json_body);
-    static void send_error(int fd, int status, const std::string& message);
+  // Response helpers
+  static void send_response(int fd, int status, const std::string& content_type, const std::string& body);
+  static void send_json(int fd, int status, const std::string& json_body);
+  static void send_error(int fd, int status, const std::string& message);
 
-    // State (engine_ protected by engine_mu_ for hot-reload)
-    mutable std::shared_mutex engine_mu_;
-    std::unique_ptr<Engine> engine_;
-    std::unique_ptr<resource::Manager> resource_manager_;
-    std::unique_ptr<Stats> stats_;
-    ServerConfig config_;
-    std::atomic<bool> running_{false};
-    int listen_fd_ = -1;
+  // State (engine_ protected by engine_mu_ for hot-reload)
+  mutable std::shared_mutex engine_mu_;
+  std::unique_ptr<Engine> engine_;
+  std::unique_ptr<resource::Manager> resource_manager_;
+  std::unique_ptr<Stats> stats_;
+  ServerConfig config_;
+  std::atomic<bool> running_{false};
+  int listen_fd_ = -1;
 
-    // Scheduler-level stats
-    std::atomic<int64_t> run_count_{0};
+  // Scheduler-level stats
+  std::atomic<int64_t> run_count_{0};
 
-    // In-flight request counter for graceful shutdown.
-    // Mirrors pine-go http.Server.Shutdown waiting for active conns.
-    std::atomic<int64_t> in_flight_{0};
-    // Drain cv lets stop() wait on in_flight_ → 0 without sleep-for polling.
-    // The request thread guard decrements in_flight_ then notifies the cv.
-    std::mutex drain_mu_;
-    std::condition_variable drain_cv_;
+  // In-flight request counter for graceful shutdown.
+  // Mirrors pine-go http.Server.Shutdown waiting for active conns.
+  std::atomic<int64_t> in_flight_{0};
+  // Drain cv lets stop() wait on in_flight_ → 0 without sleep-for polling.
+  // The request thread guard decrements in_flight_ then notifies the cv.
+  std::mutex drain_mu_;
+  std::condition_variable drain_cv_;
 
-    // Hot-reload stats
-    std::atomic<int64_t> reload_count_{0};
-    std::atomic<int64_t> reload_error_count_{0};
-    std::atomic<int64_t> last_reload_duration_ns_{0};
-    // Provider-side hot-reload counters/histogram. Mirrors pine-go
-    // pkg/server/server.go:100-114. Pointers owned by the Provider; we
-    // only hold non-owning references for hot-path use.
-    metrics::Counter* m_reload_total_ = nullptr;
-    metrics::Counter* m_reload_errors_ = nullptr;
-    metrics::Histogram* m_reload_duration_ = nullptr;
+  // Hot-reload stats
+  std::atomic<int64_t> reload_count_{0};
+  std::atomic<int64_t> reload_error_count_{0};
+  std::atomic<int64_t> last_reload_duration_ns_{0};
+  // Provider-side hot-reload counters/histogram. Mirrors pine-go
+  // pkg/server/server.go:100-114. Pointers owned by the Provider; we
+  // only hold non-owning references for hot-path use.
+  metrics::Counter* m_reload_total_ = nullptr;
+  metrics::Counter* m_reload_errors_ = nullptr;
+  metrics::Histogram* m_reload_duration_ = nullptr;
 
-    // HTTP request stats fed by the default http_metrics middleware.
-    std::unique_ptr<HttpStats> http_stats_;
+  // HTTP request stats fed by the default http_metrics middleware.
+  std::unique_ptr<HttpStats> http_stats_;
 };
 
 }  // namespace server

--- a/pine-cpp/tests/test_column.cpp
+++ b/pine-cpp/tests/test_column.cpp
@@ -1,173 +1,172 @@
-#include <doctest/doctest.h>
-
 #include "pine/column.hpp"
 #include "pine/column_store.hpp"
+
+#include <doctest/doctest.h>
 
 using namespace pine;
 
 TEST_CASE("make_column: int values -> Int64Column") {
-    std::vector<JsonValue> vs{JsonValue(1.0), JsonValue(2.0), JsonValue(3.0)};
-    auto col = make_column(vs);
-    CHECK(col->type() == ColumnType::Int64);
-    CHECK(col->size() == 3);
-    CHECK(col->get(0).as_number() == 1.0);
-    CHECK(col->get(2).as_number() == 3.0);
+  std::vector<JsonValue> vs{JsonValue(1.0), JsonValue(2.0), JsonValue(3.0)};
+  auto col = make_column(vs);
+  CHECK(col->type() == ColumnType::Int64);
+  CHECK(col->size() == 3);
+  CHECK(col->get(0).as_number() == 1.0);
+  CHECK(col->get(2).as_number() == 3.0);
 }
 
 TEST_CASE("make_column: mixed int/double widens to DoubleColumn") {
-    std::vector<JsonValue> vs{JsonValue(1.0), JsonValue(2.5)};
-    auto col = make_column(vs);
-    CHECK(col->type() == ColumnType::Double);
-    CHECK(col->size() == 2);
-    CHECK(col->get(1).as_number() == 2.5);
+  std::vector<JsonValue> vs{JsonValue(1.0), JsonValue(2.5)};
+  auto col = make_column(vs);
+  CHECK(col->type() == ColumnType::Double);
+  CHECK(col->size() == 2);
+  CHECK(col->get(1).as_number() == 2.5);
 }
 
 TEST_CASE("make_column: string values -> StringColumn") {
-    std::vector<JsonValue> vs{JsonValue(std::string("a")), JsonValue(std::string("b"))};
-    auto col = make_column(vs);
-    CHECK(col->type() == ColumnType::String);
-    CHECK(col->get(0).as_string() == "a");
+  std::vector<JsonValue> vs{JsonValue(std::string("a")), JsonValue(std::string("b"))};
+  auto col = make_column(vs);
+  CHECK(col->type() == ColumnType::String);
+  CHECK(col->get(0).as_string() == "a");
 }
 
 TEST_CASE("make_column: bool values -> BoolColumn") {
-    std::vector<JsonValue> vs{JsonValue(true), JsonValue(false)};
-    auto col = make_column(vs);
-    CHECK(col->type() == ColumnType::Bool);
-    CHECK(col->get(0).as_bool() == true);
-    CHECK(col->get(1).as_bool() == false);
+  std::vector<JsonValue> vs{JsonValue(true), JsonValue(false)};
+  auto col = make_column(vs);
+  CHECK(col->type() == ColumnType::Bool);
+  CHECK(col->get(0).as_bool() == true);
+  CHECK(col->get(1).as_bool() == false);
 }
 
 TEST_CASE("make_column: heterogeneous types -> JsonColumn") {
-    std::vector<JsonValue> vs{JsonValue(1.0), JsonValue(std::string("s"))};
-    auto col = make_column(vs);
-    CHECK(col->type() == ColumnType::Json);
-    CHECK(col->get(0).as_number() == 1.0);
-    CHECK(col->get(1).as_string() == "s");
+  std::vector<JsonValue> vs{JsonValue(1.0), JsonValue(std::string("s"))};
+  auto col = make_column(vs);
+  CHECK(col->type() == ColumnType::Json);
+  CHECK(col->get(0).as_number() == 1.0);
+  CHECK(col->get(1).as_string() == "s");
 }
 
 TEST_CASE("make_column: empty -> JsonColumn size 0") {
-    auto col = make_column({});
-    CHECK(col->type() == ColumnType::Json);
-    CHECK(col->size() == 0);
+  auto col = make_column({});
+  CHECK(col->type() == ColumnType::Json);
+  CHECK(col->size() == 0);
 }
 
 TEST_CASE("Column: presence bitmap distinguishes absent / present-null / present-value") {
-    // {1, null, 3}: null is treated as present-null, so make_column produces
-    // a JsonColumn (typed columns cannot represent present-null).
-    std::vector<JsonValue> vs{JsonValue(1.0), JsonValue(), JsonValue(3.0)};
-    auto col = make_column(vs);
-    CHECK(col->type() == ColumnType::Json);
-    CHECK(col->is_null(1));
-    CHECK_FALSE(col->is_null(0));
-    CHECK_FALSE(col->is_null(2));
-    CHECK(col->get(1).is_null());
-    // All three slots are explicitly present (the null is a present-null).
-    CHECK(col->is_present(0));
-    CHECK(col->is_present(1));
-    CHECK(col->is_present(2));
+  // {1, null, 3}: null is treated as present-null, so make_column produces
+  // a JsonColumn (typed columns cannot represent present-null).
+  std::vector<JsonValue> vs{JsonValue(1.0), JsonValue(), JsonValue(3.0)};
+  auto col = make_column(vs);
+  CHECK(col->type() == ColumnType::Json);
+  CHECK(col->is_null(1));
+  CHECK_FALSE(col->is_null(0));
+  CHECK_FALSE(col->is_null(2));
+  CHECK(col->get(1).is_null());
+  // All three slots are explicitly present (the null is a present-null).
+  CHECK(col->is_present(0));
+  CHECK(col->is_present(1));
+  CHECK(col->is_present(2));
 }
 
 TEST_CASE("Column: append_null marks slot ABSENT (validity=false)") {
-    auto col = std::make_unique<Int64Column>();
-    REQUIRE(col->append(JsonValue(1.0)));
-    col->append_null();
-    REQUIRE(col->append(JsonValue(3.0)));
-    CHECK(col->is_present(0));
-    CHECK_FALSE(col->is_present(1));
-    CHECK(col->is_present(2));
-    CHECK(col->is_null(1));
+  auto col = std::make_unique<Int64Column>();
+  REQUIRE(col->append(JsonValue(1.0)));
+  col->append_null();
+  REQUIRE(col->append(JsonValue(3.0)));
+  CHECK(col->is_present(0));
+  CHECK_FALSE(col->is_present(1));
+  CHECK(col->is_present(2));
+  CHECK(col->is_null(1));
 }
 
 TEST_CASE("TypedColumn::set type-mismatch returns false (caller promotes)") {
-    auto col = std::make_unique<Int64Column>(3);
-    CHECK(col->set(0, JsonValue(42.0)));
-    CHECK_FALSE(col->set(0, JsonValue(std::string("nope"))));
+  auto col = std::make_unique<Int64Column>(3);
+  CHECK(col->set(0, JsonValue(42.0)));
+  CHECK_FALSE(col->set(0, JsonValue(std::string("nope"))));
 }
 
 TEST_CASE("Column::append + remove + reorder") {
-    std::vector<JsonValue> vs{JsonValue(10.0), JsonValue(20.0), JsonValue(30.0)};
-    auto col = make_column(vs);
-    REQUIRE(col->append(JsonValue(40.0)));
-    CHECK(col->size() == 4);
+  std::vector<JsonValue> vs{JsonValue(10.0), JsonValue(20.0), JsonValue(30.0)};
+  auto col = make_column(vs);
+  REQUIRE(col->append(JsonValue(40.0)));
+  CHECK(col->size() == 4);
 
-    col->remove({1});  // drop 20.0
-    CHECK(col->size() == 3);
-    CHECK(col->get(1).as_number() == 30.0);
+  col->remove({1});  // drop 20.0
+  CHECK(col->size() == 3);
+  CHECK(col->get(1).as_number() == 30.0);
 
-    col->reorder({2, 0, 1});  // [40, 10, 30]
-    CHECK(col->get(0).as_number() == 40.0);
-    CHECK(col->get(1).as_number() == 10.0);
-    CHECK(col->get(2).as_number() == 30.0);
+  col->reorder({2, 0, 1});  // [40, 10, 30]
+  CHECK(col->get(0).as_number() == 40.0);
+  CHECK(col->get(1).as_number() == 10.0);
+  CHECK(col->get(2).as_number() == 30.0);
 }
 
 TEST_CASE("Column::clone produces independent copy") {
-    std::vector<JsonValue> vs{JsonValue(1.0), JsonValue(2.0)};
-    auto col = make_column(vs);
-    auto copy = col->clone();
-    REQUIRE(copy->set(0, JsonValue(99.0)));
-    CHECK(col->get(0).as_number() == 1.0);
-    CHECK(copy->get(0).as_number() == 99.0);
+  std::vector<JsonValue> vs{JsonValue(1.0), JsonValue(2.0)};
+  auto col = make_column(vs);
+  auto copy = col->clone();
+  REQUIRE(copy->set(0, JsonValue(99.0)));
+  CHECK(col->get(0).as_number() == 1.0);
+  CHECK(copy->get(0).as_number() == 99.0);
 }
 
 TEST_CASE("Column::to_json_column promotes typed -> Json preserving values + nulls") {
-    // Build an Int64Column with [1, ABSENT, 3] (via append + append_null)
-    // and verify promotion to JsonColumn preserves presence semantics.
-    auto typed = std::make_unique<Int64Column>();
-    REQUIRE(typed->append(JsonValue(1.0)));
-    typed->append_null();
-    REQUIRE(typed->append(JsonValue(3.0)));
-    REQUIRE(typed->type() == ColumnType::Int64);
-    auto json_col = typed->to_json_column();
-    CHECK(json_col->type() == ColumnType::Json);
-    CHECK(json_col->get(0).as_number() == 1.0);
-    CHECK(json_col->is_null(1));
-    CHECK_FALSE(json_col->is_present(1));
-    CHECK(json_col->get(2).as_number() == 3.0);
+  // Build an Int64Column with [1, ABSENT, 3] (via append + append_null)
+  // and verify promotion to JsonColumn preserves presence semantics.
+  auto typed = std::make_unique<Int64Column>();
+  REQUIRE(typed->append(JsonValue(1.0)));
+  typed->append_null();
+  REQUIRE(typed->append(JsonValue(3.0)));
+  REQUIRE(typed->type() == ColumnType::Int64);
+  auto json_col = typed->to_json_column();
+  CHECK(json_col->type() == ColumnType::Json);
+  CHECK(json_col->get(0).as_number() == 1.0);
+  CHECK(json_col->is_null(1));
+  CHECK_FALSE(json_col->is_present(1));
+  CHECK(json_col->get(2).as_number() == 3.0);
 }
 
 TEST_CASE("JsonColumn accepts arbitrary types") {
-    JsonColumn col;
-    REQUIRE(col.append(JsonValue(1.0)));
-    REQUIRE(col.append(JsonValue(std::string("s"))));
-    REQUIRE(col.append(JsonValue(true)));
-    REQUIRE(col.append(JsonValue()));
-    CHECK(col.size() == 4);
-    CHECK(col.get(0).as_number() == 1.0);
-    CHECK(col.get(1).as_string() == "s");
-    CHECK(col.get(2).as_bool());
-    CHECK(col.is_null(3));
+  JsonColumn col;
+  REQUIRE(col.append(JsonValue(1.0)));
+  REQUIRE(col.append(JsonValue(std::string("s"))));
+  REQUIRE(col.append(JsonValue(true)));
+  REQUIRE(col.append(JsonValue()));
+  CHECK(col.size() == 4);
+  CHECK(col.get(0).as_number() == 1.0);
+  CHECK(col.get(1).as_string() == "s");
+  CHECK(col.get(2).as_bool());
+  CHECK(col.is_null(3));
 }
 
 TEST_CASE("TypedColumnStore::remove_rows rejects OOB indices") {
-    // Direct public-API contract: caller must not feed indices outside
-    // [0, row_count_). The ColumnFrame::apply_output path pre-validates,
-    // but the store surface is reachable from other callers and must
-    // self-defend.
-    pine::TypedColumnStore store(3);
-    std::vector<pine::JsonValue> vs{
-        pine::JsonValue(1.0), pine::JsonValue(2.0), pine::JsonValue(3.0)};
-    store.set_column("x", pine::make_column(vs));
+  // Direct public-API contract: caller must not feed indices outside
+  // [0, row_count_). The ColumnFrame::apply_output path pre-validates,
+  // but the store surface is reachable from other callers and must
+  // self-defend.
+  pine::TypedColumnStore store(3);
+  std::vector<pine::JsonValue> vs{pine::JsonValue(1.0), pine::JsonValue(2.0), pine::JsonValue(3.0)};
+  store.set_column("x", pine::make_column(vs));
 
-    CHECK_THROWS_AS(store.remove_rows({3}), std::invalid_argument);
-    CHECK_THROWS_AS(store.remove_rows({-1}), std::invalid_argument);
-    CHECK_THROWS_AS(store.remove_rows({0, 5}), std::invalid_argument);
+  CHECK_THROWS_AS(store.remove_rows({3}), std::invalid_argument);
+  CHECK_THROWS_AS(store.remove_rows({-1}), std::invalid_argument);
+  CHECK_THROWS_AS(store.remove_rows({0, 5}), std::invalid_argument);
 
-    // Valid path still works and keeps row_count_ + column sizes in sync.
-    store.remove_rows({1});
-    CHECK(store.row_count() == 2);
-    CHECK(store.column("x")->size() == 2);
+  // Valid path still works and keeps row_count_ + column sizes in sync.
+  store.remove_rows({1});
+  CHECK(store.row_count() == 2);
+  CHECK(store.column("x")->size() == 2);
 }
 
 TEST_CASE("Int64Column precision boundary detection") {
-    using pine::int64_lossy_as_double;
-    // Within IEEE 754 binary64 precise range: 0..2^53
-    CHECK_FALSE(int64_lossy_as_double(0));
-    CHECK_FALSE(int64_lossy_as_double(1LL << 53));
-    CHECK_FALSE(int64_lossy_as_double(-(1LL << 53)));
-    CHECK_FALSE(int64_lossy_as_double(9007199254740992LL));   // 2^53 exactly
-    // Beyond: precision loss in double round-trip
-    CHECK(int64_lossy_as_double(9007199254740993LL));         // 2^53 + 1
-    CHECK(int64_lossy_as_double(-9007199254740993LL));
-    CHECK(int64_lossy_as_double(INT64_MAX));
-    CHECK(int64_lossy_as_double(INT64_MIN));
+  using pine::int64_lossy_as_double;
+  // Within IEEE 754 binary64 precise range: 0..2^53
+  CHECK_FALSE(int64_lossy_as_double(0));
+  CHECK_FALSE(int64_lossy_as_double(1LL << 53));
+  CHECK_FALSE(int64_lossy_as_double(-(1LL << 53)));
+  CHECK_FALSE(int64_lossy_as_double(9007199254740992LL));  // 2^53 exactly
+  // Beyond: precision loss in double round-trip
+  CHECK(int64_lossy_as_double(9007199254740993LL));  // 2^53 + 1
+  CHECK(int64_lossy_as_double(-9007199254740993LL));
+  CHECK(int64_lossy_as_double(INT64_MAX));
+  CHECK(int64_lossy_as_double(INT64_MIN));
 }

--- a/pine-cpp/tests/test_column_frame.cpp
+++ b/pine-cpp/tests/test_column_frame.cpp
@@ -1,6 +1,6 @@
-#include <doctest/doctest.h>
-
 #include "pine/column_frame.hpp"
+
+#include <doctest/doctest.h>
 
 #include <algorithm>
 #include <cmath>
@@ -11,243 +11,244 @@ using namespace pine;
 namespace {
 
 ColumnFrame make_frame() {
-    std::vector<std::map<std::string, JsonValue>> items;
-    items.push_back({{"id", JsonValue(1.0)}, {"score", JsonValue(10.0)}});
-    items.push_back({{"id", JsonValue(2.0)}, {"score", JsonValue(20.0)}});
-    items.push_back({{"id", JsonValue(3.0)}, {"score", JsonValue(30.0)}});
-    return ColumnFrame({{"region", JsonValue(std::string("us"))}}, std::move(items));
+  std::vector<std::map<std::string, JsonValue>> items;
+  items.push_back({{"id", JsonValue(1.0)}, {"score", JsonValue(10.0)}});
+  items.push_back({{"id", JsonValue(2.0)}, {"score", JsonValue(20.0)}});
+  items.push_back({{"id", JsonValue(3.0)}, {"score", JsonValue(30.0)}});
+  return ColumnFrame({{"region", JsonValue(std::string("us"))}}, std::move(items));
 }
 
 }  // namespace
 
 TEST_CASE("ColumnFrame: construction populates typed columns") {
-    auto frame = make_frame();
-    CHECK(frame.item_count() == 3);
-    CHECK(frame.common("region").as_string() == "us");
-    CHECK(frame.item(0, "id").as_number() == 1.0);
-    CHECK(frame.item(2, "score").as_number() == 30.0);
-    auto fields = frame.item_fields();
-    CHECK(std::find(fields.begin(), fields.end(), "id") != fields.end());
-    CHECK(std::find(fields.begin(), fields.end(), "score") != fields.end());
+  auto frame = make_frame();
+  CHECK(frame.item_count() == 3);
+  CHECK(frame.common("region").as_string() == "us");
+  CHECK(frame.item(0, "id").as_number() == 1.0);
+  CHECK(frame.item(2, "score").as_number() == 30.0);
+  auto fields = frame.item_fields();
+  CHECK(std::find(fields.begin(), fields.end(), "id") != fields.end());
+  CHECK(std::find(fields.begin(), fields.end(), "score") != fields.end());
 }
 
 TEST_CASE("ColumnFrame: missing field returns null JsonValue") {
-    auto frame = make_frame();
-    CHECK(frame.item(0, "missing").is_null());
-    CHECK(frame.common("nope").is_null());
+  auto frame = make_frame();
+  CHECK(frame.item(0, "missing").is_null());
+  CHECK(frame.common("nope").is_null());
 }
 
 TEST_CASE("ColumnFrame: apply_output common writes") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.set_common("region", JsonValue(std::string("eu")));
-    out.set_common("new_field", JsonValue(42.0));
-    frame.apply_output(out, "op", false);
-    CHECK(frame.common("region").as_string() == "eu");
-    CHECK(frame.common("new_field").as_number() == 42.0);
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_common("region", JsonValue(std::string("eu")));
+  out.set_common("new_field", JsonValue(42.0));
+  frame.apply_output(out, "op", false);
+  CHECK(frame.common("region").as_string() == "eu");
+  CHECK(frame.common("new_field").as_number() == 42.0);
 }
 
 TEST_CASE("ColumnFrame: apply_output item writes (existing typed column)") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.set_item(0, "score", JsonValue(99.0));
-    out.set_item(2, "score", JsonValue(77.0));
-    frame.apply_output(out, "op", false);
-    CHECK(frame.item(0, "score").as_number() == 99.0);
-    CHECK(frame.item(1, "score").as_number() == 20.0);
-    CHECK(frame.item(2, "score").as_number() == 77.0);
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_item(0, "score", JsonValue(99.0));
+  out.set_item(2, "score", JsonValue(77.0));
+  frame.apply_output(out, "op", false);
+  CHECK(frame.item(0, "score").as_number() == 99.0);
+  CHECK(frame.item(1, "score").as_number() == 20.0);
+  CHECK(frame.item(2, "score").as_number() == 77.0);
 }
 
 TEST_CASE("ColumnFrame: apply_output creates new column on first write") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.set_item(1, "tag", JsonValue(std::string("x")));
-    frame.apply_output(out, "op", false);
-    CHECK(frame.item(0, "tag").is_null());
-    CHECK(frame.item(1, "tag").as_string() == "x");
-    CHECK(frame.item(2, "tag").is_null());
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_item(1, "tag", JsonValue(std::string("x")));
+  frame.apply_output(out, "op", false);
+  CHECK(frame.item(0, "tag").is_null());
+  CHECK(frame.item(1, "tag").as_string() == "x");
+  CHECK(frame.item(2, "tag").is_null());
 }
 
 TEST_CASE("ColumnFrame: apply_output type-mismatch promotes column to Json") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    // 'score' is currently typed (Int64/Double); writing a string forces promotion.
-    out.set_item(1, "score", JsonValue(std::string("not-a-number")));
-    frame.apply_output(out, "op", false);
-    CHECK(frame.item(0, "score").as_number() == 10.0);
-    CHECK(frame.item(1, "score").as_string() == "not-a-number");
-    CHECK(frame.item(2, "score").as_number() == 30.0);
+  auto frame = make_frame();
+  OperatorOutput out;
+  // 'score' is currently typed (Int64/Double); writing a string forces promotion.
+  out.set_item(1, "score", JsonValue(std::string("not-a-number")));
+  frame.apply_output(out, "op", false);
+  CHECK(frame.item(0, "score").as_number() == 10.0);
+  CHECK(frame.item(1, "score").as_string() == "not-a-number");
+  CHECK(frame.item(2, "score").as_number() == 30.0);
 }
 
 TEST_CASE("ColumnFrame: apply_output removes rows preserves remaining fields") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.remove_item(1);
-    frame.apply_output(out, "op", false);
-    CHECK(frame.item_count() == 2);
-    CHECK(frame.item(0, "id").as_number() == 1.0);
-    CHECK(frame.item(1, "id").as_number() == 3.0);
-    CHECK(frame.item(1, "score").as_number() == 30.0);
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.remove_item(1);
+  frame.apply_output(out, "op", false);
+  CHECK(frame.item_count() == 2);
+  CHECK(frame.item(0, "id").as_number() == 1.0);
+  CHECK(frame.item(1, "id").as_number() == 3.0);
+  CHECK(frame.item(1, "score").as_number() == 30.0);
 }
 
 TEST_CASE("ColumnFrame: apply_output reorders items") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.set_item_order({2, 0, 1});
-    frame.apply_output(out, "op", false);
-    CHECK(frame.item(0, "id").as_number() == 3.0);
-    CHECK(frame.item(1, "id").as_number() == 1.0);
-    CHECK(frame.item(2, "id").as_number() == 2.0);
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_item_order({2, 0, 1});
+  frame.apply_output(out, "op", false);
+  CHECK(frame.item(0, "id").as_number() == 3.0);
+  CHECK(frame.item(1, "id").as_number() == 1.0);
+  CHECK(frame.item(2, "id").as_number() == 2.0);
 }
 
 TEST_CASE("ColumnFrame: apply_output adds items, recall stamps _source") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.add_item({{"id", JsonValue(99.0)}, {"score", JsonValue(50.0)}});
-    out.add_item({{"id", JsonValue(100.0)}});
-    frame.apply_output(out, "recall_op", true);
-    CHECK(frame.item_count() == 5);
-    CHECK(frame.item(3, "id").as_number() == 99.0);
-    CHECK(frame.item(3, "_source").as_string() == "recall_op");
-    CHECK(frame.item(4, "id").as_number() == 100.0);
-    CHECK(frame.item(4, "score").is_null());
-    CHECK(frame.item(0, "_source").is_null());  // not added by recall, no stamp
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.add_item({{"id", JsonValue(99.0)}, {"score", JsonValue(50.0)}});
+  out.add_item({{"id", JsonValue(100.0)}});
+  frame.apply_output(out, "recall_op", true);
+  CHECK(frame.item_count() == 5);
+  CHECK(frame.item(3, "id").as_number() == 99.0);
+  CHECK(frame.item(3, "_source").as_string() == "recall_op");
+  CHECK(frame.item(4, "id").as_number() == 100.0);
+  CHECK(frame.item(4, "score").is_null());
+  CHECK(frame.item(0, "_source").is_null());  // not added by recall, no stamp
 }
 
 TEST_CASE("ColumnFrame: apply_output runs 5 stages in order (writes -> removes -> reorder -> additions)") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.set_item(0, "score", JsonValue(100.0));  // stage 2
-    out.remove_item(2);                          // stage 3 (item index in original numbering)
-    // After stage 3 we have 2 rows. Reorder must reference those 2.
-    out.set_item_order({1, 0});                  // stage 4
-    out.add_item({{"id", JsonValue(99.0)}});     // stage 5
-    frame.apply_output(out, "op", false);
-    CHECK(frame.item_count() == 3);
-    // After writes: row0.score=100, row1.score=20, row2.score=30
-    // After remove [2]: rows are (id=1,score=100), (id=2,score=20)
-    // After reorder [1,0]: rows are (id=2,score=20), (id=1,score=100)
-    // After add: (id=2,score=20), (id=1,score=100), (id=99)
-    CHECK(frame.item(0, "id").as_number() == 2.0);
-    CHECK(frame.item(0, "score").as_number() == 20.0);
-    CHECK(frame.item(1, "id").as_number() == 1.0);
-    CHECK(frame.item(1, "score").as_number() == 100.0);
-    CHECK(frame.item(2, "id").as_number() == 99.0);
-    CHECK(frame.item(2, "score").is_null());
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_item(0, "score", JsonValue(100.0));  // stage 2
+  out.remove_item(2);                          // stage 3 (item index in original numbering)
+  // After stage 3 we have 2 rows. Reorder must reference those 2.
+  out.set_item_order({1, 0});               // stage 4
+  out.add_item({{"id", JsonValue(99.0)}});  // stage 5
+  frame.apply_output(out, "op", false);
+  CHECK(frame.item_count() == 3);
+  // After writes: row0.score=100, row1.score=20, row2.score=30
+  // After remove [2]: rows are (id=1,score=100), (id=2,score=20)
+  // After reorder [1,0]: rows are (id=2,score=20), (id=1,score=100)
+  // After add: (id=2,score=20), (id=1,score=100), (id=99)
+  CHECK(frame.item(0, "id").as_number() == 2.0);
+  CHECK(frame.item(0, "score").as_number() == 20.0);
+  CHECK(frame.item(1, "id").as_number() == 1.0);
+  CHECK(frame.item(1, "score").as_number() == 100.0);
+  CHECK(frame.item(2, "id").as_number() == 99.0);
+  CHECK(frame.item(2, "score").is_null());
 }
 
 TEST_CASE("ColumnFrame: to_result projects strict fields") {
-    auto frame = make_frame();
-    auto r = frame.to_result({"region"}, {"id", "score"});
-    CHECK(r.common.at("region").as_string() == "us");
-    REQUIRE(r.items.size() == 3);
-    CHECK(r.items[0].at("id").as_number() == 1.0);
-    CHECK(r.items[2].at("score").as_number() == 30.0);
+  auto frame = make_frame();
+  auto r = frame.to_result({"region"}, {"id", "score"});
+  CHECK(r.common.at("region").as_string() == "us");
+  REQUIRE(r.items.size() == 3);
+  CHECK(r.items[0].at("id").as_number() == 1.0);
+  CHECK(r.items[2].at("score").as_number() == 30.0);
 }
 
 TEST_CASE("ColumnFrame: warnings collected per operator with operator-name prefix") {
-    // apply_output prepends `operator "<name>": ` to each warning, mirroring
-    // pine-go pine.go:246 (`fmt.Errorf("operator %q: %w", w.Operator, w.Err)`).
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.set_warning("op A warning");
-    frame.apply_output(out, "opA", false);
+  // apply_output prepends `operator "<name>": ` to each warning, mirroring
+  // pine-go pine.go:246 (`fmt.Errorf("operator %q: %w", w.Operator, w.Err)`).
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_warning("op A warning");
+  frame.apply_output(out, "opA", false);
 
-    OperatorOutput out2;
-    out2.set_warning("op B warning");
-    frame.apply_output(out2, "opB", false);
+  OperatorOutput out2;
+  out2.set_warning("op B warning");
+  frame.apply_output(out2, "opB", false);
 
-    auto w = frame.take_warnings();
-    REQUIRE(w.size() == 2);
-    CHECK(w[0] == "operator \"opA\": op A warning");
-    CHECK(w[1] == "operator \"opB\": op B warning");
+  auto w = frame.take_warnings();
+  REQUIRE(w.size() == 2);
+  CHECK(w[0] == "operator \"opA\": op A warning");
+  CHECK(w[1] == "operator \"opB\": op B warning");
 }
 
 TEST_CASE("ColumnFrame: out-of-range item write raises ExecutionError") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.set_item(99, "score", JsonValue(1.0));
-    CHECK_THROWS_AS(frame.apply_output(out, "op", false), ExecutionError);
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_item(99, "score", JsonValue(1.0));
+  CHECK_THROWS_AS(frame.apply_output(out, "op", false), ExecutionError);
 }
 
 TEST_CASE("ColumnFrame: SetItemOrder rejects non-permutation (duplicate index)") {
-    // Permutation check guards against silent data loss when an operator
-    // emits an order like [0, 0, 0] — without it the frame would replace
-    // every item with item 0, no error surfaced.
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.set_item_order({0, 0, 0});  // duplicate 0 three times
-    CHECK_THROWS_AS(frame.apply_output(out, "op", false), ExecutionError);
+  // Permutation check guards against silent data loss when an operator
+  // emits an order like [0, 0, 0] — without it the frame would replace
+  // every item with item 0, no error surfaced.
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_item_order({0, 0, 0});  // duplicate 0 three times
+  CHECK_THROWS_AS(frame.apply_output(out, "op", false), ExecutionError);
 }
 
 TEST_CASE("ColumnFrame: SetItemOrder accepts valid permutation") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    // make_frame builds 3 items (see helper above); reverse is a valid permutation.
-    out.set_item_order({2, 1, 0});
-    CHECK_NOTHROW(frame.apply_output(out, "op", false));
+  auto frame = make_frame();
+  OperatorOutput out;
+  // make_frame builds 3 items (see helper above); reverse is a valid permutation.
+  out.set_item_order({2, 1, 0});
+  CHECK_NOTHROW(frame.apply_output(out, "op", false));
 }
 
 TEST_CASE("ColumnFrame: make_window_view rejects out-of-bounds window (R8-2)") {
-    auto frame = make_frame();
-    CHECK_THROWS_AS(ColumnFrame::make_window_view(frame, 0, 4), Error);
-    CHECK_THROWS_AS(ColumnFrame::make_window_view(frame, 2, 2), Error);
-    CHECK_THROWS_AS(ColumnFrame::make_window_view(frame, 5, 0), Error);
-    CHECK_NOTHROW(ColumnFrame::make_window_view(frame, 0, 3));
-    CHECK_NOTHROW(ColumnFrame::make_window_view(frame, 1, 2));
-    CHECK_NOTHROW(ColumnFrame::make_window_view(frame, 3, 0));  // empty at end is fine
+  auto frame = make_frame();
+  CHECK_THROWS_AS(ColumnFrame::make_window_view(frame, 0, 4), Error);
+  CHECK_THROWS_AS(ColumnFrame::make_window_view(frame, 2, 2), Error);
+  CHECK_THROWS_AS(ColumnFrame::make_window_view(frame, 5, 0), Error);
+  CHECK_NOTHROW(ColumnFrame::make_window_view(frame, 0, 3));
+  CHECK_NOTHROW(ColumnFrame::make_window_view(frame, 1, 2));
+  CHECK_NOTHROW(ColumnFrame::make_window_view(frame, 3, 0));  // empty at end is fine
 }
 
 TEST_CASE("ColumnFrame: window view reads parent common via view_common_ (R8-1)") {
-    // The earlier window view drop-ctor left common_ empty and items_ as
-    // null. to_result was the only read path that did not delegate to
-    // view_common_/view_items_, and would crash on null deref. After R8-1
-    // we throw early instead of dereferencing.
-    auto frame = make_frame();
-    auto view = ColumnFrame::make_window_view(frame, 0, 2);
-    CHECK(view->common("region").as_string() == "us");
-    CHECK(view->item_count() == 2);
-    CHECK(view->item(0, "score").as_number() == 10.0);
-    CHECK_THROWS_AS(view->to_result({"region"}, {"id"}), Error);
+  // The earlier window view drop-ctor left common_ empty and items_ as
+  // null. to_result was the only read path that did not delegate to
+  // view_common_/view_items_, and would crash on null deref. After R8-1
+  // we throw early instead of dereferencing.
+  auto frame = make_frame();
+  auto view = ColumnFrame::make_window_view(frame, 0, 2);
+  CHECK(view->common("region").as_string() == "us");
+  CHECK(view->item_count() == 2);
+  CHECK(view->item(0, "score").as_number() == 10.0);
+  CHECK_THROWS_AS(view->to_result({"region"}, {"id"}), Error);
 }
 
 TEST_CASE("ColumnFrame: apply_output rejects NaN/Inf in common writes") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.set_common("ratio", JsonValue(std::numeric_limits<double>::quiet_NaN()));
-    try {
-        frame.apply_output(out, "op", false);
-        FAIL("expected NaN rejection");
-    } catch (const ExecutionError& e) {
-        std::string msg = e.what();
-        CHECK(msg.find("common write: field \"ratio\": NaN/Inf is not a valid JSON value") != std::string::npos);
-    }
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_common("ratio", JsonValue(std::numeric_limits<double>::quiet_NaN()));
+  try {
+    frame.apply_output(out, "op", false);
+    FAIL("expected NaN rejection");
+  } catch (const ExecutionError& e) {
+    std::string msg = e.what();
+    CHECK(msg.find("common write: field \"ratio\": NaN/Inf is not a valid JSON value") != std::string::npos);
+  }
 }
 
 TEST_CASE("ColumnFrame: apply_output rejects Inf in item writes") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    out.set_item(0, "x", JsonValue(std::numeric_limits<double>::infinity()));
-    try {
-        frame.apply_output(out, "op", false);
-        FAIL("expected Inf rejection");
-    } catch (const ExecutionError& e) {
-        std::string msg = e.what();
-        CHECK(msg.find("item[0] write: field \"x\": NaN/Inf is not a valid JSON value") != std::string::npos);
-    }
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_item(0, "x", JsonValue(std::numeric_limits<double>::infinity()));
+  try {
+    frame.apply_output(out, "op", false);
+    FAIL("expected Inf rejection");
+  } catch (const ExecutionError& e) {
+    std::string msg = e.what();
+    CHECK(msg.find("item[0] write: field \"x\": NaN/Inf is not a valid JSON value") != std::string::npos);
+  }
 }
 
 TEST_CASE("ColumnFrame: apply_output rejects NaN in additions") {
-    auto frame = make_frame();
-    OperatorOutput out;
-    std::map<std::string, JsonValue> row;
-    row["bad"] = JsonValue(std::numeric_limits<double>::quiet_NaN());
-    out.add_item(row);
-    try {
-        frame.apply_output(out, "op", true);
-        FAIL("expected NaN rejection in addition");
-    } catch (const ExecutionError& e) {
-        std::string msg = e.what();
-        CHECK(msg.find("added item write: field \"bad\": NaN/Inf is not a valid JSON value") != std::string::npos);
-    }
+  auto frame = make_frame();
+  OperatorOutput out;
+  std::map<std::string, JsonValue> row;
+  row["bad"] = JsonValue(std::numeric_limits<double>::quiet_NaN());
+  out.add_item(row);
+  try {
+    frame.apply_output(out, "op", true);
+    FAIL("expected NaN rejection in addition");
+  } catch (const ExecutionError& e) {
+    std::string msg = e.what();
+    CHECK(msg.find("added item write: field \"bad\": NaN/Inf is not a valid JSON value") !=
+          std::string::npos);
+  }
 }

--- a/pine-cpp/tests/test_config.cpp
+++ b/pine-cpp/tests/test_config.cpp
@@ -1,6 +1,6 @@
-#include <doctest/doctest.h>
-
 #include "pine/pine.hpp"
+
+#include <doctest/doctest.h>
 
 #include <algorithm>
 
@@ -49,33 +49,35 @@ constexpr const char* kSimpleConfig = R"({
 }  // namespace
 
 TEST_CASE("load_config_from_json: parses pipeline operators") {
-    Config cfg = load_config_from_json(kSimpleConfig);
-    REQUIRE(cfg.operators.size() == 2);
-    CHECK(cfg.operators.count("first") == 1);
-    CHECK(cfg.operators.count("second") == 1);
-    CHECK(cfg.operators.at("first").type_name == "transform_copy");
-    CHECK(cfg.operators.at("second").type_name == "filter_truncate");
+  Config cfg = load_config_from_json(kSimpleConfig);
+  REQUIRE(cfg.operators.size() == 2);
+  CHECK(cfg.operators.count("first") == 1);
+  CHECK(cfg.operators.count("second") == 1);
+  CHECK(cfg.operators.at("first").type_name == "transform_copy");
+  CHECK(cfg.operators.at("second").type_name == "filter_truncate");
 }
 
 TEST_CASE("apply_registry_traits: fills operator_type from registry") {
-    Config cfg = load_config_from_json(kSimpleConfig);
-    apply_registry_traits(cfg);
-    // filter_truncate is a "filter" in the registry → mutates row set.
-    CHECK(cfg.operators.at("second").operator_type == "filter");
+  Config cfg = load_config_from_json(kSimpleConfig);
+  apply_registry_traits(cfg);
+  // filter_truncate is a "filter" in the registry → mutates row set.
+  CHECK(cfg.operators.at("second").operator_type == "filter");
 }
 
 TEST_CASE("expand_operator_sequence_with_subflows: produces topological order") {
-    Config cfg = load_config_from_json(kSimpleConfig);
-    auto expanded = expand_operator_sequence_with_subflows(cfg);
-    REQUIRE(expanded.sequence.size() == 2);
-    // "first" must precede "second" because second consumes b which first produces.
-    auto first_idx = std::find(expanded.sequence.begin(), expanded.sequence.end(), "first") - expanded.sequence.begin();
-    auto second_idx = std::find(expanded.sequence.begin(), expanded.sequence.end(), "second") - expanded.sequence.begin();
-    CHECK(first_idx < second_idx);
+  Config cfg = load_config_from_json(kSimpleConfig);
+  auto expanded = expand_operator_sequence_with_subflows(cfg);
+  REQUIRE(expanded.sequence.size() == 2);
+  // "first" must precede "second" because second consumes b which first produces.
+  auto first_idx =
+      std::find(expanded.sequence.begin(), expanded.sequence.end(), "first") - expanded.sequence.begin();
+  auto second_idx =
+      std::find(expanded.sequence.begin(), expanded.sequence.end(), "second") - expanded.sequence.begin();
+  CHECK(first_idx < second_idx);
 }
 
 TEST_CASE("load_config_from_json: invalid JSON throws ConfigError") {
-    CHECK_THROWS_AS(load_config_from_json("{not valid json"), ConfigError);
+  CHECK_THROWS_AS(load_config_from_json("{not valid json"), ConfigError);
 }
 
 namespace {
@@ -125,26 +127,26 @@ constexpr const char* kConfigWithMetadata = R"({
 }  // namespace
 
 TEST_CASE("load_config_from_json: parses _PINEAPPLE_VERSION and _PINEAPPLE_CREATE_TIME") {
-    Config cfg = load_config_from_json(kConfigWithMetadata);
-    CHECK(cfg.pineapple_version == "1.2.3");
-    CHECK(cfg.pineapple_create_time == "2026-05-22T10:00:00Z");
+  Config cfg = load_config_from_json(kConfigWithMetadata);
+  CHECK(cfg.pineapple_version == "1.2.3");
+  CHECK(cfg.pineapple_create_time == "2026-05-22T10:00:00Z");
 }
 
 TEST_CASE("load_config_from_json: parses resource_config entries") {
-    Config cfg = load_config_from_json(kConfigWithMetadata);
-    REQUIRE(cfg.resource_config.size() == 2);
-    const auto& up = cfg.resource_config.at("user_profile");
-    CHECK(up.type == "static_table");
-    CHECK(up.interval == 60);
-    REQUIRE(up.params.is_object());
-    CHECK(up.params.as_object().at("path").as_string() == "/tmp/profile.json");
-    const auto& nd = cfg.resource_config.at("no_interval_default");
-    CHECK(nd.type == "noop");
-    CHECK(nd.interval == 0);
+  Config cfg = load_config_from_json(kConfigWithMetadata);
+  REQUIRE(cfg.resource_config.size() == 2);
+  const auto& up = cfg.resource_config.at("user_profile");
+  CHECK(up.type == "static_table");
+  CHECK(up.interval == 60);
+  REQUIRE(up.params.is_object());
+  CHECK(up.params.as_object().at("path").as_string() == "/tmp/profile.json");
+  const auto& nd = cfg.resource_config.at("no_interval_default");
+  CHECK(nd.type == "noop");
+  CHECK(nd.interval == 0);
 }
 
 TEST_CASE("load_config_from_json: omits resource_config when absent") {
-    Config cfg = load_config_from_json(kSimpleConfig);
-    CHECK(cfg.resource_config.empty());
-    CHECK(cfg.pineapple_create_time == "");
+  Config cfg = load_config_from_json(kSimpleConfig);
+  CHECK(cfg.resource_config.empty());
+  CHECK(cfg.pineapple_create_time == "");
 }

--- a/pine-cpp/tests/test_dag.cpp
+++ b/pine-cpp/tests/test_dag.cpp
@@ -1,6 +1,6 @@
-#include <doctest/doctest.h>
-
 #include "pine/pine.hpp"
+
+#include <doctest/doctest.h>
 
 using namespace pine;
 
@@ -45,49 +45,49 @@ constexpr const char* kConfig = R"({
 }  // namespace
 
 TEST_CASE("build_dag: produces ordered nodes with edges") {
-    Config cfg = load_config_from_json(kConfig);
-    apply_registry_traits(cfg);
-    auto expanded = expand_operator_sequence_with_subflows(cfg);
-    auto graph = build_dag(cfg, expanded);
+  Config cfg = load_config_from_json(kConfig);
+  apply_registry_traits(cfg);
+  auto expanded = expand_operator_sequence_with_subflows(cfg);
+  auto graph = build_dag(cfg, expanded);
 
-    REQUIRE(graph.nodes.size() == 2);
-    REQUIRE(graph.name_to_index.count("a") == 1);
-    REQUIRE(graph.name_to_index.count("b") == 1);
+  REQUIRE(graph.nodes.size() == 2);
+  REQUIRE(graph.name_to_index.count("a") == 1);
+  REQUIRE(graph.name_to_index.count("b") == 1);
 
-    int a_idx = graph.name_to_index.at("a");
-    int b_idx = graph.name_to_index.at("b");
-    // a -> b edge must exist.
-    bool has_edge = false;
-    for (int succ : graph.nodes[a_idx].succs) {
-        if (succ == b_idx) {
-            has_edge = true;
-            break;
-        }
+  int a_idx = graph.name_to_index.at("a");
+  int b_idx = graph.name_to_index.at("b");
+  // a -> b edge must exist.
+  bool has_edge = false;
+  for (int succ : graph.nodes[a_idx].succs) {
+    if (succ == b_idx) {
+      has_edge = true;
+      break;
     }
-    CHECK(has_edge);
-    CHECK(graph.nodes[b_idx].preds.size() >= 1);
+  }
+  CHECK(has_edge);
+  CHECK(graph.nodes[b_idx].preds.size() >= 1);
 }
 
 TEST_CASE("render_dot: emits digraph header") {
-    Config cfg = load_config_from_json(kConfig);
-    apply_registry_traits(cfg);
-    auto expanded = expand_operator_sequence_with_subflows(cfg);
-    auto graph = build_dag(cfg, expanded);
+  Config cfg = load_config_from_json(kConfig);
+  apply_registry_traits(cfg);
+  auto expanded = expand_operator_sequence_with_subflows(cfg);
+  auto graph = build_dag(cfg, expanded);
 
-    auto dot = render_dot(graph);
-    CHECK(dot.find("digraph") != std::string::npos);
-    CHECK(dot.find("\"a\"") != std::string::npos);
-    CHECK(dot.find("\"b\"") != std::string::npos);
+  auto dot = render_dot(graph);
+  CHECK(dot.find("digraph") != std::string::npos);
+  CHECK(dot.find("\"a\"") != std::string::npos);
+  CHECK(dot.find("\"b\"") != std::string::npos);
 }
 
 TEST_CASE("render_mermaid: emits graph header") {
-    Config cfg = load_config_from_json(kConfig);
-    apply_registry_traits(cfg);
-    auto expanded = expand_operator_sequence_with_subflows(cfg);
-    auto graph = build_dag(cfg, expanded);
+  Config cfg = load_config_from_json(kConfig);
+  apply_registry_traits(cfg);
+  auto expanded = expand_operator_sequence_with_subflows(cfg);
+  auto graph = build_dag(cfg, expanded);
 
-    auto mer = render_mermaid(graph);
-    CHECK((mer.find("graph") != std::string::npos || mer.find("flowchart") != std::string::npos));
-    CHECK(mer.find("a") != std::string::npos);
-    CHECK(mer.find("b") != std::string::npos);
+  auto mer = render_mermaid(graph);
+  CHECK((mer.find("graph") != std::string::npos || mer.find("flowchart") != std::string::npos));
+  CHECK(mer.find("a") != std::string::npos);
+  CHECK(mer.find("b") != std::string::npos);
 }

--- a/pine-cpp/tests/test_engine.cpp
+++ b/pine-cpp/tests/test_engine.cpp
@@ -1,8 +1,8 @@
-#include <doctest/doctest.h>
-
-#include "pine/pine.hpp"
 #include "pine/operator.hpp"
 #include "pine/operator_input.hpp"
+#include "pine/pine.hpp"
+
+#include <doctest/doctest.h>
 
 using namespace pine;
 
@@ -41,37 +41,37 @@ constexpr const char* kCopyConfig = R"({
 }  // namespace
 
 TEST_CASE("Engine::execute: runs simple transform_copy") {
-    Engine engine(load_config_from_json(kCopyConfig));
-    Request req;
-    req.common["src"] = JsonValue(std::string("hello"));
-    auto result = engine.execute(req);
-    REQUIRE(result.common.count("dst") == 1);
-    CHECK(result.common.at("dst").as_string() == "hello");
+  Engine engine(load_config_from_json(kCopyConfig));
+  Request req;
+  req.common["src"] = JsonValue(std::string("hello"));
+  auto result = engine.execute(req);
+  REQUIRE(result.common.count("dst") == 1);
+  CHECK(result.common.at("dst").as_string() == "hello");
 }
 
 TEST_CASE("Engine::execute_traced: produces trace entries") {
-    Engine engine(load_config_from_json(kCopyConfig));
-    Request req;
-    req.common["src"] = JsonValue(std::string("v"));
-    std::map<std::string, JsonValue> resources;
-    auto traced = engine.execute_traced(req, resources);
-    REQUIRE(traced.trace.size() == 1);
-    CHECK(traced.trace[0].name == "copy");
-    CHECK(traced.trace[0].skipped == false);
-    CHECK(traced.result.common.at("dst").as_string() == "v");
+  Engine engine(load_config_from_json(kCopyConfig));
+  Request req;
+  req.common["src"] = JsonValue(std::string("v"));
+  std::map<std::string, JsonValue> resources;
+  auto traced = engine.execute_traced(req, resources);
+  REQUIRE(traced.trace.size() == 1);
+  CHECK(traced.trace[0].name == "copy");
+  CHECK(traced.trace[0].skipped == false);
+  CHECK(traced.result.common.at("dst").as_string() == "v");
 }
 
 TEST_CASE("Engine::render_dag: returns non-empty output for both formats") {
-    Engine engine(load_config_from_json(kCopyConfig));
-    auto dot = engine.render_dag("dot");
-    CHECK(dot.find("digraph") != std::string::npos);
-    auto mer = engine.render_dag("mermaid");
-    CHECK(!mer.empty());
+  Engine engine(load_config_from_json(kCopyConfig));
+  auto dot = engine.render_dag("dot");
+  CHECK(dot.find("digraph") != std::string::npos);
+  auto mer = engine.render_dag("mermaid");
+  CHECK(!mer.empty());
 }
 
 TEST_CASE("Engine::render_dag: rejects unknown format") {
-    Engine engine(load_config_from_json(kCopyConfig));
-    CHECK_THROWS(engine.render_dag("unknown"));
+  Engine engine(load_config_from_json(kCopyConfig));
+  CHECK_THROWS(engine.render_dag("unknown"));
 }
 
 namespace {
@@ -109,46 +109,45 @@ constexpr const char* kCopyConfigWithLogPrefix = R"({
 }  // namespace
 
 TEST_CASE("Config::log_prefix: parsed from root and exposed by Engine") {
-    auto config = load_config_from_json(kCopyConfigWithLogPrefix);
-    CHECK(config.log_prefix == "[from-config] ");
-    Engine engine(std::move(config));
-    CHECK(engine.log_prefix() == "[from-config] ");
+  auto config = load_config_from_json(kCopyConfigWithLogPrefix);
+  CHECK(config.log_prefix == "[from-config] ");
+  Engine engine(std::move(config));
+  CHECK(engine.log_prefix() == "[from-config] ");
 }
 
 TEST_CASE("EngineOptions::log_prefix: overrides Config.log_prefix") {
-    auto config = load_config_from_json(kCopyConfigWithLogPrefix);
-    EngineOptions options;
-    options.log_prefix = std::string("[override] ");
-    Engine engine(std::move(config), std::move(options));
-    CHECK(engine.log_prefix() == "[override] ");
+  auto config = load_config_from_json(kCopyConfigWithLogPrefix);
+  EngineOptions options;
+  options.log_prefix = std::string("[override] ");
+  Engine engine(std::move(config), std::move(options));
+  CHECK(engine.log_prefix() == "[override] ");
 }
 
 TEST_CASE("Engine::log_prefix: empty when unset on both Config and EngineOptions") {
-    Engine engine(load_config_from_json(kCopyConfig));
-    CHECK(engine.log_prefix() == "");
+  Engine engine(load_config_from_json(kCopyConfig));
+  CHECK(engine.log_prefix() == "");
 }
 
 TEST_CASE("validate_output_against_type: Recall must not SetCommon") {
-    // Use a custom in-process operator registered just for this test to keep
-    // the assertion focused on the validate_output codepath. The Recall type
-    // forbids SetCommon, SetItem, RemoveItem, SetItemOrder.
-    struct BadRecall : public pine::Operator {
-        void init(const pine::OperatorConfig&) override {}
-        void execute(const pine::OperatorInput&, pine::OperatorOutput& out) override {
-            out.set_common("region", pine::JsonValue(std::string("us")));
-        }
-    };
-    static const pine::OperatorSchema s{
-        "bad_recall_set_common", pine::OpType::Recall,
-        "recall that illegally writes common",
-        {}};
-    static bool registered = false;
-    if (!registered) {
-        pine::register_operator_typed<BadRecall>(s);
-        registered = true;
+  // Use a custom in-process operator registered just for this test to keep
+  // the assertion focused on the validate_output codepath. The Recall type
+  // forbids SetCommon, SetItem, RemoveItem, SetItemOrder.
+  struct BadRecall : public pine::Operator {
+    void init(const pine::OperatorConfig&) override {
     }
+    void execute(const pine::OperatorInput&, pine::OperatorOutput& out) override {
+      out.set_common("region", pine::JsonValue(std::string("us")));
+    }
+  };
+  static const pine::OperatorSchema s{
+      "bad_recall_set_common", pine::OpType::Recall, "recall that illegally writes common", {}};
+  static bool registered = false;
+  if (!registered) {
+    pine::register_operator_typed<BadRecall>(s);
+    registered = true;
+  }
 
-    static const char* kBadRecallConfig = R"({
+  static const char* kBadRecallConfig = R"({
       "_PINEAPPLE_VERSION": "0.9.0",
       "pipeline_config": {
         "operators": {
@@ -171,20 +170,20 @@ TEST_CASE("validate_output_against_type: Recall must not SetCommon") {
         "item_output": []
       }
     })";
-    Engine engine(load_config_from_json(kBadRecallConfig));
-    Request req;
-    try {
-        engine.execute(req);
-        FAIL("expected ExecutionError");
-    } catch (const Error& e) {
-        std::string msg = e.what();
-        CHECK(msg.find("type violation: operator type Recall must not call [SetCommon]") != std::string::npos);
-        CHECK(msg.find("pine: execution error in operator \"r1\"") != std::string::npos);
-    }
+  Engine engine(load_config_from_json(kBadRecallConfig));
+  Request req;
+  try {
+    engine.execute(req);
+    FAIL("expected ExecutionError");
+  } catch (const Error& e) {
+    std::string msg = e.what();
+    CHECK(msg.find("type violation: operator type Recall must not call [SetCommon]") != std::string::npos);
+    CHECK(msg.find("pine: execution error in operator \"r1\"") != std::string::npos);
+  }
 }
 
 TEST_CASE("Engine::execute honors external stop_token") {
-    static const char* kCfg = R"({
+  static const char* kCfg = R"({
       "_PINEAPPLE_VERSION": "0.9.0",
       "pipeline_config": {
         "operators": {
@@ -209,45 +208,46 @@ TEST_CASE("Engine::execute honors external stop_token") {
         "item_output": []
       }
     })";
-    Engine engine(load_config_from_json(kCfg));
-    Request req;
-    req.common["src"] = JsonValue(std::string("v"));
-    std::stop_source src;
-    src.request_stop();  // pre-cancelled
-    static const std::map<std::string, JsonValue> empty_res;
-    // Pre-cancelled token: run_dag should see stop_requested at every wait
-    // and either return early or finish the trivial DAG. Either way the
-    // call must not deadlock and not throw spuriously.
-    auto result = engine.execute(req, empty_res, src.get_token());
-    // The simple linear DAG may have completed before observing cancel —
-    // both outcomes are valid; the API contract is "no deadlock, no UB".
-    CHECK(true);
+  Engine engine(load_config_from_json(kCfg));
+  Request req;
+  req.common["src"] = JsonValue(std::string("v"));
+  std::stop_source src;
+  src.request_stop();  // pre-cancelled
+  static const std::map<std::string, JsonValue> empty_res;
+  // Pre-cancelled token: run_dag should see stop_requested at every wait
+  // and either return early or finish the trivial DAG. Either way the
+  // call must not deadlock and not throw spuriously.
+  auto result = engine.execute(req, empty_res, src.get_token());
+  // The simple linear DAG may have completed before observing cancel —
+  // both outcomes are valid; the API contract is "no deadlock, no UB".
+  CHECK(true);
 }
 
 TEST_CASE("Engine::execute external cancel mid-flight on multi-node DAG (R10-4)") {
-    // Register a slow operator that sleeps N ms in execute. Registers once
-    // per process; if already registered (e.g. previous test invocation in
-    // the same binary) the existing schema is reused.
-    struct SlowOp : public pine::Operator {
-        void init(const pine::OperatorConfig&) override {}
-        void execute(const pine::OperatorInput&, pine::OperatorOutput&) override {
-            // Long enough that the watcher thread can deliver the cancel.
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        }
-    };
-    static const pine::OperatorSchema s{
-        "r10_slow_op", pine::OpType::Transform,
-        "test operator: sleeps 500 ms to validate mid-flight cancel",
-        {}};
-    static bool registered = false;
-    if (!registered) {
-        pine::register_operator_typed<SlowOp>(s);
-        registered = true;
+  // Register a slow operator that sleeps N ms in execute. Registers once
+  // per process; if already registered (e.g. previous test invocation in
+  // the same binary) the existing schema is reused.
+  struct SlowOp : public pine::Operator {
+    void init(const pine::OperatorConfig&) override {
     }
+    void execute(const pine::OperatorInput&, pine::OperatorOutput&) override {
+      // Long enough that the watcher thread can deliver the cancel.
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+  };
+  static const pine::OperatorSchema s{"r10_slow_op",
+                                      pine::OpType::Transform,
+                                      "test operator: sleeps 500 ms to validate mid-flight cancel",
+                                      {}};
+  static bool registered = false;
+  if (!registered) {
+    pine::register_operator_typed<SlowOp>(s);
+    registered = true;
+  }
 
-    // 3-node linear DAG (Transform only — Transform allows zero writes,
-    // so SlowOp's empty OperatorOutput passes ValidateOutput).
-    static const char* kCfg = R"({
+  // 3-node linear DAG (Transform only — Transform allows zero writes,
+  // so SlowOp's empty OperatorOutput passes ValidateOutput).
+  static const char* kCfg = R"({
       "_PINEAPPLE_VERSION": "0.9.0",
       "pipeline_config": {
         "operators": {
@@ -259,35 +259,35 @@ TEST_CASE("Engine::execute external cancel mid-flight on multi-node DAG (R10-4)"
       },
       "pipeline_group": {"main": {"pipeline": ["stage"]}}
     })";
-    Engine engine(load_config_from_json(kCfg));
-    Request req;
-    static const std::map<std::string, JsonValue> empty_res;
+  Engine engine(load_config_from_json(kCfg));
+  Request req;
+  static const std::map<std::string, JsonValue> empty_res;
 
-    std::stop_source src;
-    auto cancel_token = src.get_token();
+  std::stop_source src;
+  auto cancel_token = src.get_token();
 
-    // Fire the cancel 200 ms in — well inside s1's sleep but before s1/s2/s3 finish.
-    std::thread canceller([&src]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
-        src.request_stop();
-    });
+  // Fire the cancel 200 ms in — well inside s1's sleep but before s1/s2/s3 finish.
+  std::thread canceller([&src]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    src.request_stop();
+  });
 
-    auto t0 = std::chrono::steady_clock::now();
-    // execute should observe cancel and return before the full 3 × 500 ms.
-    // It may or may not throw — the contract is "no deadlock, return soon".
-    try {
-        engine.execute(req, empty_res, cancel_token);
-    } catch (const Error&) {
-        // ok — engine can rethrow a cancel-shaped error
-    }
-    auto elapsed = std::chrono::steady_clock::now() - t0;
-    canceller.join();
+  auto t0 = std::chrono::steady_clock::now();
+  // execute should observe cancel and return before the full 3 × 500 ms.
+  // It may or may not throw — the contract is "no deadlock, return soon".
+  try {
+    engine.execute(req, empty_res, cancel_token);
+  } catch (const Error&) {
+    // ok — engine can rethrow a cancel-shaped error
+  }
+  auto elapsed = std::chrono::steady_clock::now() - t0;
+  canceller.join();
 
-    // Without cancel, this would take ~1500 ms (3 × 500 ms). With cancel
-    // mid-s1, total time should be at most ~750 ms (current s1 finishes
-    // + a few ms cleanup). Use 1.2 s as a generous bound to keep CI
-    // noise-tolerant while still proving cancel took effect.
-    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
-    INFO("elapsed=" << ms << "ms");
-    CHECK(ms < 1200);
+  // Without cancel, this would take ~1500 ms (3 × 500 ms). With cancel
+  // mid-s1, total time should be at most ~750 ms (current s1 finishes
+  // + a few ms cleanup). Use 1.2 s as a generous bound to keep CI
+  // noise-tolerant while still proving cancel took effect.
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+  INFO("elapsed=" << ms << "ms");
+  CHECK(ms < 1200);
 }

--- a/pine-cpp/tests/test_error_chain.cpp
+++ b/pine-cpp/tests/test_error_chain.cpp
@@ -1,5 +1,5 @@
-#include "pine/pine.hpp"
 #include "pine/error_chain.hpp"
+#include "pine/pine.hpp"
 
 #include <doctest/doctest.h>
 
@@ -9,136 +9,138 @@
 namespace {
 
 class FakeRedisError : public std::runtime_error {
-public:
-    explicit FakeRedisError(const std::string& msg) : std::runtime_error(msg) {}
+ public:
+  explicit FakeRedisError(const std::string& msg) : std::runtime_error(msg) {
+  }
 };
 
 class FakeTimeoutError : public std::runtime_error {
-public:
-    explicit FakeTimeoutError(const std::string& msg) : std::runtime_error(msg) {}
+ public:
+  explicit FakeTimeoutError(const std::string& msg) : std::runtime_error(msg) {
+  }
 };
 
 }  // namespace
 
 TEST_CASE("ExecutionError preserves what() byte-exact after nested chain") {
-    pine::ExecutionError e("op_x", "redis call failed");
-    CHECK(std::string(e.what()) == "pine: execution error in operator \"op_x\": redis call failed");
-    CHECK(e.operator_name() == "op_x");
-    CHECK(e.inner() == "redis call failed");
+  pine::ExecutionError e("op_x", "redis call failed");
+  CHECK(std::string(e.what()) == "pine: execution error in operator \"op_x\": redis call failed");
+  CHECK(e.operator_name() == "op_x");
+  CHECK(e.inner() == "redis call failed");
 }
 
 TEST_CASE("PanicError preserves what() byte-exact after nested chain") {
-    pine::PanicError e("op_y", "boom");
-    CHECK(std::string(e.what()) == "pine: panic in operator \"op_y\": boom");
-    CHECK(e.operator_name() == "op_y");
+  pine::PanicError e("op_y", "boom");
+  CHECK(std::string(e.what()) == "pine: panic in operator \"op_y\": boom");
+  CHECK(e.operator_name() == "op_y");
 }
 
 TEST_CASE("std::throw_with_nested + std::rethrow_if_nested round-trips inner cause") {
-    bool caught_inner = false;
+  bool caught_inner = false;
+  try {
     try {
-        try {
-            throw FakeRedisError("key=foo not found");
-        } catch (...) {
-            std::throw_with_nested(pine::ExecutionError("redis_getter", "lookup failed"));
-        }
-    } catch (const pine::ExecutionError& outer) {
-        try {
-            std::rethrow_if_nested(outer);
-        } catch (const FakeRedisError& inner) {
-            caught_inner = true;
-            CHECK(std::string(inner.what()) == "key=foo not found");
-        }
+      throw FakeRedisError("key=foo not found");
+    } catch (...) {
+      std::throw_with_nested(pine::ExecutionError("redis_getter", "lookup failed"));
     }
-    CHECK(caught_inner);
+  } catch (const pine::ExecutionError& outer) {
+    try {
+      std::rethrow_if_nested(outer);
+    } catch (const FakeRedisError& inner) {
+      caught_inner = true;
+      CHECK(std::string(inner.what()) == "key=foo not found");
+    }
+  }
+  CHECK(caught_inner);
 }
 
 TEST_CASE("error_as<T> finds outer exception by type") {
-    pine::ExecutionError e("op_x", "boom");
-    const pine::ExecutionError* found = pine::error_as<pine::ExecutionError>(e);
-    REQUIRE(found != nullptr);
-    CHECK(found->operator_name() == "op_x");
+  pine::ExecutionError e("op_x", "boom");
+  const pine::ExecutionError* found = pine::error_as<pine::ExecutionError>(e);
+  REQUIRE(found != nullptr);
+  CHECK(found->operator_name() == "op_x");
 }
 
 TEST_CASE("error_as<T> walks nested chain to find inner cause") {
+  try {
     try {
-        try {
-            throw FakeRedisError("connection refused");
-        } catch (...) {
-            std::throw_with_nested(pine::ExecutionError("redis_getter", "fail"));
-        }
-    } catch (const pine::ExecutionError& e) {
-        const FakeRedisError* inner = pine::error_as<FakeRedisError>(e);
-        REQUIRE(inner != nullptr);
-        CHECK(std::string(inner->what()) == "connection refused");
+      throw FakeRedisError("connection refused");
+    } catch (...) {
+      std::throw_with_nested(pine::ExecutionError("redis_getter", "fail"));
     }
+  } catch (const pine::ExecutionError& e) {
+    const FakeRedisError* inner = pine::error_as<FakeRedisError>(e);
+    REQUIRE(inner != nullptr);
+    CHECK(std::string(inner->what()) == "connection refused");
+  }
 }
 
 TEST_CASE("error_as<T> returns nullptr when chain has no matching type") {
+  try {
     try {
-        try {
-            throw FakeRedisError("connection refused");
-        } catch (...) {
-            std::throw_with_nested(pine::ExecutionError("redis_getter", "fail"));
-        }
-    } catch (const pine::ExecutionError& e) {
-        CHECK(pine::error_as<FakeTimeoutError>(e) == nullptr);
+      throw FakeRedisError("connection refused");
+    } catch (...) {
+      std::throw_with_nested(pine::ExecutionError("redis_getter", "fail"));
     }
+  } catch (const pine::ExecutionError& e) {
+    CHECK(pine::error_as<FakeTimeoutError>(e) == nullptr);
+  }
 }
 
 TEST_CASE("error_as<T> handles ExecutionError thrown without nested cause") {
-    try {
-        throw pine::ExecutionError("op_x", "no inner");
-    } catch (const pine::ExecutionError& e) {
-        // Should be able to find the outer ExecutionError itself
-        REQUIRE(pine::error_as<pine::ExecutionError>(e) != nullptr);
-        // No nested cause, FakeRedisError lookup fails cleanly
-        CHECK(pine::error_as<FakeRedisError>(e) == nullptr);
-    }
+  try {
+    throw pine::ExecutionError("op_x", "no inner");
+  } catch (const pine::ExecutionError& e) {
+    // Should be able to find the outer ExecutionError itself
+    REQUIRE(pine::error_as<pine::ExecutionError>(e) != nullptr);
+    // No nested cause, FakeRedisError lookup fails cleanly
+    CHECK(pine::error_as<FakeRedisError>(e) == nullptr);
+  }
 }
 
 TEST_CASE("error_is<T> mirrors error_as<T> presence") {
+  try {
     try {
-        try {
-            throw FakeTimeoutError("deadline exceeded");
-        } catch (...) {
-            std::throw_with_nested(pine::ExecutionError("http_op", "remote failed"));
-        }
-    } catch (const pine::ExecutionError& e) {
-        CHECK(pine::error_is<FakeTimeoutError>(e));
-        CHECK(pine::error_is<pine::ExecutionError>(e));
-        CHECK_FALSE(pine::error_is<FakeRedisError>(e));
+      throw FakeTimeoutError("deadline exceeded");
+    } catch (...) {
+      std::throw_with_nested(pine::ExecutionError("http_op", "remote failed"));
     }
+  } catch (const pine::ExecutionError& e) {
+    CHECK(pine::error_is<FakeTimeoutError>(e));
+    CHECK(pine::error_is<pine::ExecutionError>(e));
+    CHECK_FALSE(pine::error_is<FakeRedisError>(e));
+  }
 }
 
 TEST_CASE("PanicError nested chain also walks correctly") {
+  try {
     try {
-        try {
-            throw std::runtime_error("operator died");
-        } catch (...) {
-            std::throw_with_nested(pine::PanicError("op_x", "operator died"));
-        }
-    } catch (const pine::PanicError& e) {
-        REQUIRE(pine::error_as<std::runtime_error>(e) != nullptr);
+      throw std::runtime_error("operator died");
+    } catch (...) {
+      std::throw_with_nested(pine::PanicError("op_x", "operator died"));
     }
+  } catch (const pine::PanicError& e) {
+    REQUIRE(pine::error_as<std::runtime_error>(e) != nullptr);
+  }
 }
 
 TEST_CASE("multi-level nested chain unwraps recursively") {
-    // Innermost -> middle wrapper -> outermost ExecutionError
+  // Innermost -> middle wrapper -> outermost ExecutionError
+  try {
     try {
-        try {
-            try {
-                throw FakeRedisError("deepest cause");
-            } catch (...) {
-                std::throw_with_nested(std::runtime_error("middle layer"));
-            }
-        } catch (...) {
-            std::throw_with_nested(pine::ExecutionError("op", "top-level"));
-        }
-    } catch (const pine::ExecutionError& outer) {
-        // Should be able to recover the deepest FakeRedisError even though
-        // it's two levels down.
-        const FakeRedisError* deepest = pine::error_as<FakeRedisError>(outer);
-        REQUIRE(deepest != nullptr);
-        CHECK(std::string(deepest->what()) == "deepest cause");
+      try {
+        throw FakeRedisError("deepest cause");
+      } catch (...) {
+        std::throw_with_nested(std::runtime_error("middle layer"));
+      }
+    } catch (...) {
+      std::throw_with_nested(pine::ExecutionError("op", "top-level"));
     }
+  } catch (const pine::ExecutionError& outer) {
+    // Should be able to recover the deepest FakeRedisError even though
+    // it's two levels down.
+    const FakeRedisError* deepest = pine::error_as<FakeRedisError>(outer);
+    REQUIRE(deepest != nullptr);
+    CHECK(std::string(deepest->what()) == "deepest cause");
+  }
 }

--- a/pine-cpp/tests/test_format_g.cpp
+++ b/pine-cpp/tests/test_format_g.cpp
@@ -1,51 +1,52 @@
 #include <doctest/doctest.h>
+
 #include "operators/_helpers.hpp"
 
 using pine::operators::go_format_g;
 
 TEST_CASE("go_format_g matches Go strconv.FormatFloat('g', -1, 64) at long-integer boundaries") {
-    // Each line below was captured from `strconv.FormatFloat(v, 'g', -1, 64)`
-    // in Go 1.22 — Go's exact source of truth.
-    CHECK(go_format_g(100.0) == "100");
-    CHECK(go_format_g(100000.0) == "100000");
-    CHECK(go_format_g(999999.0) == "999999");
-    CHECK(go_format_g(1000000.0) == "1e+06");
-    CHECK(go_format_g(10000000.0) == "1e+07");
-    CHECK(go_format_g(100000000.0) == "1e+08");
-    CHECK(go_format_g(123456789.0) == "1.23456789e+08");
-    CHECK(go_format_g(12345678.0) == "1.2345678e+07");
-    CHECK(go_format_g(1234567.0) == "1.234567e+06");
-    CHECK(go_format_g(0.0001) == "0.0001");
-    CHECK(go_format_g(0.00001) == "1e-05");
-    CHECK(go_format_g(1e21) == "1e+21");
-    CHECK(go_format_g(0.0) == "0");
-    CHECK(go_format_g(-0.0) == "-0");
-    CHECK(go_format_g(-100.0) == "-100");
-    CHECK(go_format_g(0.1) == "0.1");
-    CHECK(go_format_g(1.5) == "1.5");
+  // Each line below was captured from `strconv.FormatFloat(v, 'g', -1, 64)`
+  // in Go 1.22 — Go's exact source of truth.
+  CHECK(go_format_g(100.0) == "100");
+  CHECK(go_format_g(100000.0) == "100000");
+  CHECK(go_format_g(999999.0) == "999999");
+  CHECK(go_format_g(1000000.0) == "1e+06");
+  CHECK(go_format_g(10000000.0) == "1e+07");
+  CHECK(go_format_g(100000000.0) == "1e+08");
+  CHECK(go_format_g(123456789.0) == "1.23456789e+08");
+  CHECK(go_format_g(12345678.0) == "1.2345678e+07");
+  CHECK(go_format_g(1234567.0) == "1.234567e+06");
+  CHECK(go_format_g(0.0001) == "0.0001");
+  CHECK(go_format_g(0.00001) == "1e-05");
+  CHECK(go_format_g(1e21) == "1e+21");
+  CHECK(go_format_g(0.0) == "0");
+  CHECK(go_format_g(-0.0) == "-0");
+  CHECK(go_format_g(-100.0) == "-100");
+  CHECK(go_format_g(0.1) == "0.1");
+  CHECK(go_format_g(1.5) == "1.5");
 }
 
 TEST_CASE("go_format_lookup_key matches Go FormatInt / FormatFloat('f', -1)") {
-    using pine::operators::go_format_lookup_key;
-    // Integer-valued floats: FormatInt — no decimal point.
-    CHECK(go_format_lookup_key(0.0) == "0");
-    CHECK(go_format_lookup_key(1.0) == "1");
-    CHECK(go_format_lookup_key(-1.0) == "-1");
-    CHECK(go_format_lookup_key(100000.0) == "100000");
-    CHECK(go_format_lookup_key(1e7) == "10000000");
-    CHECK(go_format_lookup_key(1e15) == "1000000000000000");
+  using pine::operators::go_format_lookup_key;
+  // Integer-valued floats: FormatInt — no decimal point.
+  CHECK(go_format_lookup_key(0.0) == "0");
+  CHECK(go_format_lookup_key(1.0) == "1");
+  CHECK(go_format_lookup_key(-1.0) == "-1");
+  CHECK(go_format_lookup_key(100000.0) == "100000");
+  CHECK(go_format_lookup_key(1e7) == "10000000");
+  CHECK(go_format_lookup_key(1e15) == "1000000000000000");
 
-    // Non-integer floats: FormatFloat('f', -1) — never scientific.
-    // The exact byte-level comparison against Go FormatFloat is constrained:
-    // both produce the shortest round-tripping representation, with the
-    // 'f' format guaranteeing no exponent. The parity-critical case
-    // is 1e-5 — Go renders "0.00001"; C++ go_format_g would render "1e-05"
-    // and miss the lookup.
-    CHECK(go_format_lookup_key(0.5) == "0.5");
-    CHECK(go_format_lookup_key(0.1) == "0.1");
-    CHECK(go_format_lookup_key(-0.5) == "-0.5");
-    CHECK(go_format_lookup_key(1.5) == "1.5");
-    CHECK(go_format_lookup_key(1e-5).find('e') == std::string::npos);
-    CHECK(go_format_lookup_key(1e-5).find('E') == std::string::npos);
-    CHECK(go_format_lookup_key(1e-5) == "0.00001");
+  // Non-integer floats: FormatFloat('f', -1) — never scientific.
+  // The exact byte-level comparison against Go FormatFloat is constrained:
+  // both produce the shortest round-tripping representation, with the
+  // 'f' format guaranteeing no exponent. The parity-critical case
+  // is 1e-5 — Go renders "0.00001"; C++ go_format_g would render "1e-05"
+  // and miss the lookup.
+  CHECK(go_format_lookup_key(0.5) == "0.5");
+  CHECK(go_format_lookup_key(0.1) == "0.1");
+  CHECK(go_format_lookup_key(-0.5) == "-0.5");
+  CHECK(go_format_lookup_key(1.5) == "1.5");
+  CHECK(go_format_lookup_key(1e-5).find('e') == std::string::npos);
+  CHECK(go_format_lookup_key(1e-5).find('E') == std::string::npos);
+  CHECK(go_format_lookup_key(1e-5) == "0.00001");
 }

--- a/pine-cpp/tests/test_frame_equivalence.cpp
+++ b/pine-cpp/tests/test_frame_equivalence.cpp
@@ -6,11 +6,11 @@
 // apply_output stages (common write / item write / remove / reorder /
 // add) can leak through to /execute byte-exact while still passing the
 // per-impl doctests.
-#include <doctest/doctest.h>
-
 #include "pine/column_frame.hpp"
 #include "pine/frame.hpp"
 #include "pine/row_frame.hpp"
+
+#include <doctest/doctest.h>
 
 #include <algorithm>
 #include <cmath>
@@ -26,269 +26,302 @@ namespace {
 // Drive both impls with identical state. Returns the projected Result
 // pair so the test body can compare with a single equality check.
 struct Pair {
-    std::unique_ptr<RowFrame> row;
-    std::unique_ptr<ColumnFrame> col;
+  std::unique_ptr<RowFrame> row;
+  std::unique_ptr<ColumnFrame> col;
 };
 
-Pair make_pair(std::map<std::string, JsonValue> common,
-               std::vector<std::map<std::string, JsonValue>> items) {
-    return {std::make_unique<RowFrame>(common, items),
-            std::make_unique<ColumnFrame>(common, items)};
+Pair make_pair(std::map<std::string, JsonValue> common, std::vector<std::map<std::string, JsonValue>> items) {
+  return {std::make_unique<RowFrame>(common, items), std::make_unique<ColumnFrame>(common, items)};
 }
 
-void apply_both(Pair& p, const OperatorOutput& out,
-                const std::string& op_name, bool recall) {
-    p.row->apply_output(out, op_name, recall);
-    p.col->apply_output(out, op_name, recall);
+void apply_both(Pair& p, const OperatorOutput& out, const std::string& op_name, bool recall) {
+  p.row->apply_output(out, op_name, recall);
+  p.col->apply_output(out, op_name, recall);
 }
 
 bool result_equal(const Result& a, const Result& b) {
-    // JsonValue lacks operator== for object/array; compare via dump_json
-    // which is byte-deterministic across both impls.
-    JsonValue::object_t ao, bo;
-    for (const auto& [k, v] : a.common) ao[k] = v;
-    for (const auto& [k, v] : b.common) bo[k] = v;
-    if (dump_json(JsonValue(ao)) != dump_json(JsonValue(bo))) return false;
-    JsonValue::array_t ai, bi;
-    for (const auto& r : a.items) {
-        JsonValue::object_t row;
-        for (const auto& [k, v] : r) row[k] = v;
-        ai.push_back(JsonValue(row));
+  // JsonValue lacks operator== for object/array; compare via dump_json
+  // which is byte-deterministic across both impls.
+  JsonValue::object_t ao, bo;
+  for (const auto& [k, v] : a.common) {
+    ao[k] = v;
+  }
+  for (const auto& [k, v] : b.common) {
+    bo[k] = v;
+  }
+  if (dump_json(JsonValue(ao)) != dump_json(JsonValue(bo))) {
+    return false;
+  }
+  JsonValue::array_t ai, bi;
+  for (const auto& r : a.items) {
+    JsonValue::object_t row;
+    for (const auto& [k, v] : r) {
+      row[k] = v;
     }
-    for (const auto& r : b.items) {
-        JsonValue::object_t row;
-        for (const auto& [k, v] : r) row[k] = v;
-        bi.push_back(JsonValue(row));
+    ai.push_back(JsonValue(row));
+  }
+  for (const auto& r : b.items) {
+    JsonValue::object_t row;
+    for (const auto& [k, v] : r) {
+      row[k] = v;
     }
-    return dump_json(JsonValue(ai)) == dump_json(JsonValue(bi));
+    bi.push_back(JsonValue(row));
+  }
+  return dump_json(JsonValue(ai)) == dump_json(JsonValue(bi));
 }
 
 JsonValue rand_value(std::mt19937& rng) {
-    int k = rng() % 8;
-    switch (k) {
-        case 0: return JsonValue(static_cast<double>(rng() % 100));
-        case 1: return JsonValue(static_cast<double>(rng()) / 1000.0);
-        case 2: return JsonValue(std::string("s") + std::to_string(rng() % 10));
-        case 3: return JsonValue(true);
-        case 4: return JsonValue(false);
-        case 5: return JsonValue(nullptr);  // PRESENT-NULL
-        case 6: {
-            JsonValue::array_t a;
-            a.push_back(JsonValue(1.0));
-            a.push_back(JsonValue(2.0));
-            return JsonValue(a);
-        }
-        default: {
-            JsonValue::object_t o;
-            o["k"] = JsonValue(std::string("v"));
-            return JsonValue(o);
-        }
+  int k = rng() % 8;
+  switch (k) {
+    case 0:
+      return JsonValue(static_cast<double>(rng() % 100));
+    case 1:
+      return JsonValue(static_cast<double>(rng()) / 1000.0);
+    case 2:
+      return JsonValue(std::string("s") + std::to_string(rng() % 10));
+    case 3:
+      return JsonValue(true);
+    case 4:
+      return JsonValue(false);
+    case 5:
+      return JsonValue(nullptr);  // PRESENT-NULL
+    case 6: {
+      JsonValue::array_t a;
+      a.push_back(JsonValue(1.0));
+      a.push_back(JsonValue(2.0));
+      return JsonValue(a);
     }
+    default: {
+      JsonValue::object_t o;
+      o["k"] = JsonValue(std::string("v"));
+      return JsonValue(o);
+    }
+  }
 }
 
 OperatorOutput rand_output(std::mt19937& rng, std::size_t n_items) {
-    OperatorOutput out;
-    // common writes
-    int n_cw = rng() % 4;
-    for (int i = 0; i < n_cw; ++i) {
-        out.set_common("k" + std::to_string(rng() % 5), rand_value(rng));
+  OperatorOutput out;
+  // common writes
+  int n_cw = rng() % 4;
+  for (int i = 0; i < n_cw; ++i) {
+    out.set_common("k" + std::to_string(rng() % 5), rand_value(rng));
+  }
+  // item writes
+  if (n_items > 0) {
+    int n_iw = rng() % (n_items * 2 + 1);
+    for (int i = 0; i < n_iw; ++i) {
+      int idx = static_cast<int>(rng() % n_items);
+      out.set_item(idx, "f" + std::to_string(rng() % 5), rand_value(rng));
     }
-    // item writes
-    if (n_items > 0) {
-        int n_iw = rng() % (n_items * 2 + 1);
-        for (int i = 0; i < n_iw; ++i) {
-            int idx = static_cast<int>(rng() % n_items);
-            out.set_item(idx, "f" + std::to_string(rng() % 5), rand_value(rng));
-        }
-        // removals
-        int n_rm = rng() % (n_items / 2 + 1);
-        for (int i = 0; i < n_rm; ++i) {
-            out.remove_item(static_cast<int>(rng() % n_items));
-        }
+    // removals
+    int n_rm = rng() % (n_items / 2 + 1);
+    for (int i = 0; i < n_rm; ++i) {
+      out.remove_item(static_cast<int>(rng() % n_items));
     }
-    // additions (no recall stamp in this generator — recall=true path
-    // tested separately below)
-    int n_ad = rng() % 3;
-    for (int i = 0; i < n_ad; ++i) {
-        std::map<std::string, JsonValue> row;
-        int n_f = 1 + (rng() % 3);
-        for (int j = 0; j < n_f; ++j) {
-            row["f" + std::to_string(rng() % 5)] = rand_value(rng);
-        }
-        out.add_item(row);
+  }
+  // additions (no recall stamp in this generator — recall=true path
+  // tested separately below)
+  int n_ad = rng() % 3;
+  for (int i = 0; i < n_ad; ++i) {
+    std::map<std::string, JsonValue> row;
+    int n_f = 1 + (rng() % 3);
+    for (int j = 0; j < n_f; ++j) {
+      row["f" + std::to_string(rng() % 5)] = rand_value(rng);
     }
-    return out;
+    out.add_item(row);
+  }
+  return out;
 }
 
 }  // namespace
 
 TEST_CASE("Row/Column initial-state projection equivalence") {
-    std::vector<std::map<std::string, JsonValue>> items;
-    items.push_back({{"id", JsonValue(1.0)}, {"score", JsonValue(10.0)}});
-    items.push_back({{"id", JsonValue(2.0)}, {"score", JsonValue(20.0)}});
-    auto p = make_pair({{"region", JsonValue(std::string("us"))}}, items);
-    auto r = p.row->to_result({"region"}, {"id", "score"});
-    auto c = p.col->to_result({"region"}, {"id", "score"});
-    CHECK(result_equal(r, c));
+  std::vector<std::map<std::string, JsonValue>> items;
+  items.push_back({{"id", JsonValue(1.0)}, {"score", JsonValue(10.0)}});
+  items.push_back({{"id", JsonValue(2.0)}, {"score", JsonValue(20.0)}});
+  auto p = make_pair({{"region", JsonValue(std::string("us"))}}, items);
+  auto r = p.row->to_result({"region"}, {"id", "score"});
+  auto c = p.col->to_result({"region"}, {"id", "score"});
+  CHECK(result_equal(r, c));
 }
 
 TEST_CASE("Row/Column common writes equivalence") {
-    auto p = make_pair({{"region", JsonValue(std::string("us"))}},
-                       {{{"id", JsonValue(1.0)}}, {{"id", JsonValue(2.0)}}});
-    OperatorOutput out;
-    out.set_common("region", JsonValue(std::string("eu")));
-    out.set_common("ts", JsonValue(1234.0));
-    apply_both(p, out, "op", false);
-    CHECK(result_equal(p.row->to_result({"region", "ts"}, {"id"}),
-                       p.col->to_result({"region", "ts"}, {"id"})));
+  auto p = make_pair({{"region", JsonValue(std::string("us"))}},
+                     {{{"id", JsonValue(1.0)}}, {{"id", JsonValue(2.0)}}});
+  OperatorOutput out;
+  out.set_common("region", JsonValue(std::string("eu")));
+  out.set_common("ts", JsonValue(1234.0));
+  apply_both(p, out, "op", false);
+  CHECK(result_equal(p.row->to_result({"region", "ts"}, {"id"}), p.col->to_result({"region", "ts"}, {"id"})));
 }
 
 TEST_CASE("Row/Column item writes equivalence") {
-    auto p = make_pair({}, {{{"id", JsonValue(1.0)}, {"score", JsonValue(10.0)}},
-                            {{"id", JsonValue(2.0)}, {"score", JsonValue(20.0)}}});
-    OperatorOutput out;
-    out.set_item(0, "score", JsonValue(99.0));
-    out.set_item(1, "bonus", JsonValue(true));
-    apply_both(p, out, "op", false);
-    CHECK(result_equal(p.row->to_result({}, {"id", "score", "bonus"}),
-                       p.col->to_result({}, {"id", "score", "bonus"})));
+  auto p = make_pair({}, {{{"id", JsonValue(1.0)}, {"score", JsonValue(10.0)}},
+                          {{"id", JsonValue(2.0)}, {"score", JsonValue(20.0)}}});
+  OperatorOutput out;
+  out.set_item(0, "score", JsonValue(99.0));
+  out.set_item(1, "bonus", JsonValue(true));
+  apply_both(p, out, "op", false);
+  CHECK(result_equal(p.row->to_result({}, {"id", "score", "bonus"}),
+                     p.col->to_result({}, {"id", "score", "bonus"})));
 }
 
 TEST_CASE("Row/Column remove equivalence") {
-    std::vector<std::map<std::string, JsonValue>> items;
-    for (int i = 0; i < 5; ++i) items.push_back({{"id", JsonValue(static_cast<double>(i))}});
-    auto p = make_pair({}, items);
-    OperatorOutput out;
-    out.remove_item(1);
-    out.remove_item(3);
-    apply_both(p, out, "op", false);
-    CHECK(p.row->item_count() == p.col->item_count());
-    CHECK(p.row->item_count() == 3);
-    CHECK(result_equal(p.row->to_result({}, {"id"}), p.col->to_result({}, {"id"})));
+  std::vector<std::map<std::string, JsonValue>> items;
+  for (int i = 0; i < 5; ++i) {
+    items.push_back({{"id", JsonValue(static_cast<double>(i))}});
+  }
+  auto p = make_pair({}, items);
+  OperatorOutput out;
+  out.remove_item(1);
+  out.remove_item(3);
+  apply_both(p, out, "op", false);
+  CHECK(p.row->item_count() == p.col->item_count());
+  CHECK(p.row->item_count() == 3);
+  CHECK(result_equal(p.row->to_result({}, {"id"}), p.col->to_result({}, {"id"})));
 }
 
 TEST_CASE("Row/Column reorder equivalence") {
-    auto p = make_pair({}, {{{"id", JsonValue(0.0)}},
-                            {{"id", JsonValue(1.0)}},
-                            {{"id", JsonValue(2.0)}}});
-    OperatorOutput out;
-    out.set_item_order({2, 0, 1});
-    apply_both(p, out, "op", false);
-    CHECK(result_equal(p.row->to_result({}, {"id"}), p.col->to_result({}, {"id"})));
+  auto p = make_pair({}, {{{"id", JsonValue(0.0)}}, {{"id", JsonValue(1.0)}}, {{"id", JsonValue(2.0)}}});
+  OperatorOutput out;
+  out.set_item_order({2, 0, 1});
+  apply_both(p, out, "op", false);
+  CHECK(result_equal(p.row->to_result({}, {"id"}), p.col->to_result({}, {"id"})));
 }
 
 TEST_CASE("Row/Column additions + recall _source stamp equivalence") {
-    auto p = make_pair({}, {{{"id", JsonValue(0.0)}}});
-    OperatorOutput out;
-    out.add_item({{"id", JsonValue(100.0)}, {"name", JsonValue(std::string("added"))}});
-    out.add_item({{"id", JsonValue(200.0)}});
-    apply_both(p, out, "op_recall", /*recall=*/true);
-    CHECK(p.row->item_count() == 3);
-    CHECK(p.col->item_count() == 3);
-    CHECK(result_equal(p.row->to_result({}, {"id", "name", "_source"}),
-                       p.col->to_result({}, {"id", "name", "_source"})));
+  auto p = make_pair({}, {{{"id", JsonValue(0.0)}}});
+  OperatorOutput out;
+  out.add_item({{"id", JsonValue(100.0)}, {"name", JsonValue(std::string("added"))}});
+  out.add_item({{"id", JsonValue(200.0)}});
+  apply_both(p, out, "op_recall", /*recall=*/true);
+  CHECK(p.row->item_count() == 3);
+  CHECK(p.col->item_count() == 3);
+  CHECK(result_equal(p.row->to_result({}, {"id", "name", "_source"}),
+                     p.col->to_result({}, {"id", "name", "_source"})));
 }
 
 TEST_CASE("Row/Column five-stage ordering equivalence") {
-    std::vector<std::map<std::string, JsonValue>> items;
-    for (int i = 0; i < 4; ++i) {
-        items.push_back({{"id", JsonValue(static_cast<double>(i))},
-                         {"score", JsonValue(static_cast<double>(i * 10))}});
-    }
-    auto p = make_pair({{"src", JsonValue(std::string("v"))}}, items);
-    OperatorOutput out;
-    out.set_common("src", JsonValue(std::string("w")));
-    out.set_item(0, "score", JsonValue(-1.0));
-    out.remove_item(2);
-    // after remove → 3 items; reorder needs len-3 permutation
-    out.set_item_order({2, 0, 1});
-    out.add_item({{"id", JsonValue(99.0)}});
-    apply_both(p, out, "op", false);
-    CHECK(result_equal(p.row->to_result({"src"}, {"id", "score"}),
-                       p.col->to_result({"src"}, {"id", "score"})));
+  std::vector<std::map<std::string, JsonValue>> items;
+  for (int i = 0; i < 4; ++i) {
+    items.push_back(
+        {{"id", JsonValue(static_cast<double>(i))}, {"score", JsonValue(static_cast<double>(i * 10))}});
+  }
+  auto p = make_pair({{"src", JsonValue(std::string("v"))}}, items);
+  OperatorOutput out;
+  out.set_common("src", JsonValue(std::string("w")));
+  out.set_item(0, "score", JsonValue(-1.0));
+  out.remove_item(2);
+  // after remove → 3 items; reorder needs len-3 permutation
+  out.set_item_order({2, 0, 1});
+  out.add_item({{"id", JsonValue(99.0)}});
+  apply_both(p, out, "op", false);
+  CHECK(result_equal(p.row->to_result({"src"}, {"id", "score"}), p.col->to_result({"src"}, {"id", "score"})));
 }
 
 TEST_CASE("Row/Column NaN-rejection error message equivalence") {
-    auto p = make_pair({}, {{{"id", JsonValue(1.0)}}});
-    OperatorOutput out;
-    out.set_common("ratio", JsonValue(std::numeric_limits<double>::quiet_NaN()));
-    std::string row_err, col_err;
-    try { p.row->apply_output(out, "op", false); }
-    catch (const ExecutionError& e) { row_err = e.what(); }
-    try { p.col->apply_output(out, "op", false); }
-    catch (const ExecutionError& e) { col_err = e.what(); }
-    CHECK(!row_err.empty());
-    CHECK(!col_err.empty());
-    CHECK(row_err == col_err);
+  auto p = make_pair({}, {{{"id", JsonValue(1.0)}}});
+  OperatorOutput out;
+  out.set_common("ratio", JsonValue(std::numeric_limits<double>::quiet_NaN()));
+  std::string row_err, col_err;
+  try {
+    p.row->apply_output(out, "op", false);
+  } catch (const ExecutionError& e) {
+    row_err = e.what();
+  }
+  try {
+    p.col->apply_output(out, "op", false);
+  } catch (const ExecutionError& e) {
+    col_err = e.what();
+  }
+  CHECK(!row_err.empty());
+  CHECK(!col_err.empty());
+  CHECK(row_err == col_err);
 }
 
 TEST_CASE("Row/Column reorder-permutation error message equivalence") {
-    auto p = make_pair({}, {{{"id", JsonValue(0.0)}},
-                            {{"id", JsonValue(1.0)}},
-                            {{"id", JsonValue(2.0)}}});
-    OperatorOutput out;
-    out.set_item_order({0, 0, 0});  // duplicate index
-    std::string row_err, col_err;
-    try { p.row->apply_output(out, "op", false); }
-    catch (const ExecutionError& e) { row_err = e.what(); }
-    try { p.col->apply_output(out, "op", false); }
-    catch (const ExecutionError& e) { col_err = e.what(); }
-    CHECK(!row_err.empty());
-    CHECK(row_err == col_err);
+  auto p = make_pair({}, {{{"id", JsonValue(0.0)}}, {{"id", JsonValue(1.0)}}, {{"id", JsonValue(2.0)}}});
+  OperatorOutput out;
+  out.set_item_order({0, 0, 0});  // duplicate index
+  std::string row_err, col_err;
+  try {
+    p.row->apply_output(out, "op", false);
+  } catch (const ExecutionError& e) {
+    row_err = e.what();
+  }
+  try {
+    p.col->apply_output(out, "op", false);
+  } catch (const ExecutionError& e) {
+    col_err = e.what();
+  }
+  CHECK(!row_err.empty());
+  CHECK(row_err == col_err);
 }
 
 TEST_CASE("Row/Column differential fuzz") {
-    // 100 seeded rounds with random (common, items, OperatorOutput).
-    // Either both succeed with identical Result, or both throw with
-    // identical message. seed range 0..99; bump if regressions slip
-    // past this batch in CI.
-    for (int seed = 0; seed < 100; ++seed) {
-        std::mt19937 rng(static_cast<std::uint32_t>(seed));
-        std::size_t n_items = rng() % 7;
-        std::map<std::string, JsonValue> common;
-        for (int i = 0, n = rng() % 4; i < n; ++i) {
-            common["c" + std::to_string(i)] = rand_value(rng);
-        }
-        std::vector<std::map<std::string, JsonValue>> items;
-        for (std::size_t i = 0; i < n_items; ++i) {
-            std::map<std::string, JsonValue> row;
-            int n_f = 1 + static_cast<int>(rng() % 4);
-            for (int j = 0; j < n_f; ++j) {
-                row["f" + std::to_string(j)] = rand_value(rng);
-            }
-            items.push_back(std::move(row));
-        }
-
-        auto p = make_pair(common, items);
-        auto out = rand_output(rng, n_items);
-
-        std::string row_err, col_err;
-        try { p.row->apply_output(out, "op", false); }
-        catch (const ExecutionError& e) { row_err = e.what(); }
-        catch (const Error& e) { row_err = e.what(); }
-        try { p.col->apply_output(out, "op", false); }
-        catch (const ExecutionError& e) { col_err = e.what(); }
-        catch (const Error& e) { col_err = e.what(); }
-
-        INFO("seed=" << seed);
-        REQUIRE(row_err.empty() == col_err.empty());
-        if (!row_err.empty()) {
-            // Error messages may differ in trailing OOB wording (impls
-            // store rows differently); compare the leading segment up
-            // to the first colon so the class/segment matches.
-            auto row_pre = row_err.substr(0, row_err.find(':'));
-            auto col_pre = col_err.substr(0, col_err.find(':'));
-            CHECK(row_pre == col_pre);
-            continue;
-        }
-        // Both succeeded — projections must match exactly.
-        std::vector<std::string> ck;
-        for (int i = 0; i < 5; ++i) ck.push_back("k" + std::to_string(i));
-        std::vector<std::string> ik;
-        for (int i = 0; i < 5; ++i) ik.push_back("f" + std::to_string(i));
-        ik.push_back("_source");
-        auto r = p.row->to_result(ck, ik);
-        auto c = p.col->to_result(ck, ik);
-        CHECK(result_equal(r, c));
+  // 100 seeded rounds with random (common, items, OperatorOutput).
+  // Either both succeed with identical Result, or both throw with
+  // identical message. seed range 0..99; bump if regressions slip
+  // past this batch in CI.
+  for (int seed = 0; seed < 100; ++seed) {
+    std::mt19937 rng(static_cast<std::uint32_t>(seed));
+    std::size_t n_items = rng() % 7;
+    std::map<std::string, JsonValue> common;
+    for (int i = 0, n = rng() % 4; i < n; ++i) {
+      common["c" + std::to_string(i)] = rand_value(rng);
     }
+    std::vector<std::map<std::string, JsonValue>> items;
+    for (std::size_t i = 0; i < n_items; ++i) {
+      std::map<std::string, JsonValue> row;
+      int n_f = 1 + static_cast<int>(rng() % 4);
+      for (int j = 0; j < n_f; ++j) {
+        row["f" + std::to_string(j)] = rand_value(rng);
+      }
+      items.push_back(std::move(row));
+    }
+
+    auto p = make_pair(common, items);
+    auto out = rand_output(rng, n_items);
+
+    std::string row_err, col_err;
+    try {
+      p.row->apply_output(out, "op", false);
+    } catch (const ExecutionError& e) {
+      row_err = e.what();
+    } catch (const Error& e) {
+      row_err = e.what();
+    }
+    try {
+      p.col->apply_output(out, "op", false);
+    } catch (const ExecutionError& e) {
+      col_err = e.what();
+    } catch (const Error& e) {
+      col_err = e.what();
+    }
+
+    INFO("seed=" << seed);
+    REQUIRE(row_err.empty() == col_err.empty());
+    if (!row_err.empty()) {
+      // Error messages may differ in trailing OOB wording (impls
+      // store rows differently); compare the leading segment up
+      // to the first colon so the class/segment matches.
+      auto row_pre = row_err.substr(0, row_err.find(':'));
+      auto col_pre = col_err.substr(0, col_err.find(':'));
+      CHECK(row_pre == col_pre);
+      continue;
+    }
+    // Both succeeded — projections must match exactly.
+    std::vector<std::string> ck;
+    for (int i = 0; i < 5; ++i) {
+      ck.push_back("k" + std::to_string(i));
+    }
+    std::vector<std::string> ik;
+    for (int i = 0; i < 5; ++i) {
+      ik.push_back("f" + std::to_string(i));
+    }
+    ik.push_back("_source");
+    auto r = p.row->to_result(ck, ik);
+    auto c = p.col->to_result(ck, ik);
+    CHECK(result_equal(r, c));
+  }
 }

--- a/pine-cpp/tests/test_http_metrics.cpp
+++ b/pine-cpp/tests/test_http_metrics.cpp
@@ -1,4 +1,3 @@
-#include "server/server.hpp"
 #include "pine/metrics.hpp"
 
 #include <doctest/doctest.h>
@@ -9,98 +8,112 @@
 #include <string>
 #include <vector>
 
+#include "server/server.hpp"
+
 namespace {
 
 class RecorderProvider : public pine::metrics::Provider {
-public:
-    struct CounterImpl : pine::metrics::Counter {
-        std::vector<std::vector<std::string>> labels;
-        pine::metrics::Counter* with(const std::vector<std::string>& v) override {
-            labels.push_back(v);
-            return this;
-        }
-        void inc() override {}
-    };
-    struct GaugeImpl : pine::metrics::Gauge {
-        pine::metrics::Gauge* with(const std::vector<std::string>&) override { return this; }
-        void set(double) override {}
-        void add(double) override {}
-    };
-    struct HistogramImpl : pine::metrics::Histogram {
-        std::vector<std::vector<std::string>> labels;
-        std::vector<double> values;
-        pine::metrics::Histogram* with(const std::vector<std::string>& v) override {
-            labels.push_back(v);
-            return this;
-        }
-        void observe(double v) override { values.push_back(v); }
-    };
-    pine::metrics::Counter* new_counter(const pine::metrics::MetricOpts& o) override {
-        return counters_.emplace(o.name, std::make_unique<CounterImpl>()).first->second.get();
+ public:
+  struct CounterImpl : pine::metrics::Counter {
+    std::vector<std::vector<std::string>> labels;
+    pine::metrics::Counter* with(const std::vector<std::string>& v) override {
+      labels.push_back(v);
+      return this;
     }
-    pine::metrics::Gauge* new_gauge(const pine::metrics::MetricOpts& o) override {
-        return gauges_.emplace(o.name, std::make_unique<GaugeImpl>()).first->second.get();
+    void inc() override {
     }
-    pine::metrics::Histogram* new_histogram(const pine::metrics::HistogramOpts& o) override {
-        return histograms_.emplace(o.opts.name, std::make_unique<HistogramImpl>()).first->second.get();
+  };
+  struct GaugeImpl : pine::metrics::Gauge {
+    pine::metrics::Gauge* with(const std::vector<std::string>&) override {
+      return this;
     }
-    CounterImpl* counter(const std::string& n) { return counters_.count(n) ? counters_[n].get() : nullptr; }
-    HistogramImpl* histogram(const std::string& n) { return histograms_.count(n) ? histograms_[n].get() : nullptr; }
-private:
-    std::map<std::string, std::unique_ptr<CounterImpl>> counters_;
-    std::map<std::string, std::unique_ptr<GaugeImpl>> gauges_;
-    std::map<std::string, std::unique_ptr<HistogramImpl>> histograms_;
+    void set(double) override {
+    }
+    void add(double) override {
+    }
+  };
+  struct HistogramImpl : pine::metrics::Histogram {
+    std::vector<std::vector<std::string>> labels;
+    std::vector<double> values;
+    pine::metrics::Histogram* with(const std::vector<std::string>& v) override {
+      labels.push_back(v);
+      return this;
+    }
+    void observe(double v) override {
+      values.push_back(v);
+    }
+  };
+  pine::metrics::Counter* new_counter(const pine::metrics::MetricOpts& o) override {
+    return counters_.emplace(o.name, std::make_unique<CounterImpl>()).first->second.get();
+  }
+  pine::metrics::Gauge* new_gauge(const pine::metrics::MetricOpts& o) override {
+    return gauges_.emplace(o.name, std::make_unique<GaugeImpl>()).first->second.get();
+  }
+  pine::metrics::Histogram* new_histogram(const pine::metrics::HistogramOpts& o) override {
+    return histograms_.emplace(o.opts.name, std::make_unique<HistogramImpl>()).first->second.get();
+  }
+  CounterImpl* counter(const std::string& n) {
+    return counters_.count(n) ? counters_[n].get() : nullptr;
+  }
+  HistogramImpl* histogram(const std::string& n) {
+    return histograms_.count(n) ? histograms_[n].get() : nullptr;
+  }
+
+ private:
+  std::map<std::string, std::unique_ptr<CounterImpl>> counters_;
+  std::map<std::string, std::unique_ptr<GaugeImpl>> gauges_;
+  std::map<std::string, std::unique_ptr<HistogramImpl>> histograms_;
 };
 
 }  // namespace
 
 TEST_CASE("http_metrics: records requests_total + duration with bucketed status/path") {
-    using namespace pine::server;
-    RecorderProvider provider;
-    Middleware mw = http_metrics_middleware(&provider);
+  using namespace pine::server;
+  RecorderProvider provider;
+  Middleware mw = http_metrics_middleware(&provider);
 
-    MiddlewareContext ctx;
-    ctx.method = "POST";
-    ctx.path = "/execute";
-    ctx.normalized_path = "/execute";
-    ctx.status = 200;
+  MiddlewareContext ctx;
+  ctx.method = "POST";
+  ctx.path = "/execute";
+  ctx.normalized_path = "/execute";
+  ctx.status = 200;
 
-    mw(ctx, []() { /* inner handler no-op; status stays 200 */ });
+  mw(ctx, []() { /* inner handler no-op; status stays 200 */ });
 
-    auto* total = provider.counter("pine_http_requests_total");
-    REQUIRE(total);
-    REQUIRE(total->labels.size() == 1);
-    CHECK(total->labels[0] == std::vector<std::string>{"POST", "/execute", "2xx"});
+  auto* total = provider.counter("pine_http_requests_total");
+  REQUIRE(total);
+  REQUIRE(total->labels.size() == 1);
+  CHECK(total->labels[0] == std::vector<std::string>{"POST", "/execute", "2xx"});
 
-    auto* dur = provider.histogram("pine_http_request_duration_seconds");
-    REQUIRE(dur);
-    REQUIRE(dur->labels.size() == 1);
-    CHECK(dur->labels[0] == std::vector<std::string>{"POST", "/execute"});
-    CHECK(dur->values.size() == 1);
-    CHECK(dur->values[0] >= 0.0);
+  auto* dur = provider.histogram("pine_http_request_duration_seconds");
+  REQUIRE(dur);
+  REQUIRE(dur->labels.size() == 1);
+  CHECK(dur->labels[0] == std::vector<std::string>{"POST", "/execute"});
+  CHECK(dur->values.size() == 1);
+  CHECK(dur->values[0] >= 0.0);
 }
 
 TEST_CASE("http_metrics: status_bucket maps 4xx/5xx") {
-    using namespace pine::server;
-    RecorderProvider provider;
-    Middleware mw = http_metrics_middleware(&provider);
+  using namespace pine::server;
+  RecorderProvider provider;
+  Middleware mw = http_metrics_middleware(&provider);
 
-    {
-        MiddlewareContext ctx;
-        ctx.method = "GET";
-        ctx.normalized_path = "/health";
-        mw(ctx, [&]() { ctx.status = 404; });
-    }
-    {
-        MiddlewareContext ctx;
-        ctx.method = "POST";
-        ctx.normalized_path = "/execute";
-        mw(ctx, [&]() { ctx.status = 500; });
-    }
+  {
+    MiddlewareContext ctx;
+    ctx.method = "GET";
+    ctx.normalized_path = "/health";
+    mw(ctx, [&]() { ctx.status = 404; });
+  }
+  {
+    MiddlewareContext ctx;
+    ctx.method = "POST";
+    ctx.normalized_path = "/execute";
+    mw(ctx, [&]() { ctx.status = 500; });
+  }
 
-    auto* total = provider.counter("pine_http_requests_total");
-    REQUIRE(total);
-    REQUIRE(total->labels.size() == 2);
-    CHECK(total->labels[0][2] == "4xx");
-    CHECK(total->labels[1][2] == "5xx");
+  auto* total = provider.counter("pine_http_requests_total");
+  REQUIRE(total);
+  REQUIRE(total->labels.size() == 2);
+  CHECK(total->labels[0][2] == "4xx");
+  CHECK(total->labels[1][2] == "5xx");
 }

--- a/pine-cpp/tests/test_http_stats.cpp
+++ b/pine-cpp/tests/test_http_stats.cpp
@@ -1,61 +1,61 @@
-#include "server/http_stats.hpp"
-
 #include <doctest/doctest.h>
 
 #include <string>
 
+#include "server/http_stats.hpp"
+
 TEST_CASE("HttpStats records and sorts entries") {
-    pine::server::HttpStats stats;
-    stats.record_request("POST", "/execute", "2xx", 1500);
-    stats.record_request("GET", "/health", "2xx", 200);
-    stats.record_request("GET", "/health", "2xx", 300);
-    stats.record_request("GET", "_other", "4xx", 100);
-    stats.record_request("POST", "/execute", "5xx", 999);
+  pine::server::HttpStats stats;
+  stats.record_request("POST", "/execute", "2xx", 1500);
+  stats.record_request("GET", "/health", "2xx", 200);
+  stats.record_request("GET", "/health", "2xx", 300);
+  stats.record_request("GET", "_other", "4xx", 100);
+  stats.record_request("POST", "/execute", "5xx", 999);
 
-    auto reqs = stats.requests_snapshot();
-    CHECK(reqs["POST /execute 2xx"] == 1);
-    CHECK(reqs["GET /health 2xx"] == 2);
-    CHECK(reqs["GET _other 4xx"] == 1);
-    CHECK(reqs["POST /execute 5xx"] == 1);
-    CHECK(reqs.size() == 4);
+  auto reqs = stats.requests_snapshot();
+  CHECK(reqs["POST /execute 2xx"] == 1);
+  CHECK(reqs["GET /health 2xx"] == 2);
+  CHECK(reqs["GET _other 4xx"] == 1);
+  CHECK(reqs["POST /execute 5xx"] == 1);
+  CHECK(reqs.size() == 4);
 
-    // std::map iterates in lexicographic key order; verify by walking entries.
-    auto it = reqs.begin();
-    CHECK(it->first == "GET /health 2xx");
-    ++it;
-    CHECK(it->first == "GET _other 4xx");
-    ++it;
-    CHECK(it->first == "POST /execute 2xx");
-    ++it;
-    CHECK(it->first == "POST /execute 5xx");
+  // std::map iterates in lexicographic key order; verify by walking entries.
+  auto it = reqs.begin();
+  CHECK(it->first == "GET /health 2xx");
+  ++it;
+  CHECK(it->first == "GET _other 4xx");
+  ++it;
+  CHECK(it->first == "POST /execute 2xx");
+  ++it;
+  CHECK(it->first == "POST /execute 5xx");
 
-    auto durs = stats.durations_snapshot();
-    CHECK(durs["GET /health"].count == 2);
-    CHECK(durs["GET /health"].sum_ns == 500);
-    CHECK(durs["POST /execute"].count == 2);
-    CHECK(durs["POST /execute"].sum_ns == 2499);
-    CHECK(durs["GET _other"].count == 1);
-    CHECK(durs["GET _other"].sum_ns == 100);
+  auto durs = stats.durations_snapshot();
+  CHECK(durs["GET /health"].count == 2);
+  CHECK(durs["GET /health"].sum_ns == 500);
+  CHECK(durs["POST /execute"].count == 2);
+  CHECK(durs["POST /execute"].sum_ns == 2499);
+  CHECK(durs["GET _other"].count == 1);
+  CHECK(durs["GET _other"].sum_ns == 100);
 }
 
 TEST_CASE("HttpStats key contains METHOD path bucket but path normalized to whitelist") {
-    // Defensive check: the request_total key is `<METHOD> <path> <bucket>`
-    // space-separated. If a future path contained a space, the key would
-    // ambiguous. The Section 13 +9 schema check on /stats.http already
-    // catches drift across runtimes, but lock the invariant here too —
-    // record a request with a path that contains a space and confirm
-    // HttpStats does not let the caller produce an ambiguous key by
-    // requiring normalize_path() at the call site.
-    pine::server::HttpStats stats;
-    // Direct record_request with an unnormalized path: this is the
-    // callable surface. Whoever invokes it is responsible for
-    // normalize_path-ing first. We test what happens if they don't:
-    stats.record_request("GET", "/path with space", "2xx", 100);
-    auto snap = stats.requests_snapshot();
-    // The key shape is preserved literally; the defense lives at
-    // normalize_path (server.cpp), which is the only entry exercised by
-    // the http_metrics_middleware. This test exists to make the
-    // contract explicit: HttpStats does not parse keys.
-    CHECK(snap.size() == 1);
-    CHECK(snap.begin()->first == "GET /path with space 2xx");
+  // Defensive check: the request_total key is `<METHOD> <path> <bucket>`
+  // space-separated. If a future path contained a space, the key would
+  // ambiguous. The Section 13 +9 schema check on /stats.http already
+  // catches drift across runtimes, but lock the invariant here too —
+  // record a request with a path that contains a space and confirm
+  // HttpStats does not let the caller produce an ambiguous key by
+  // requiring normalize_path() at the call site.
+  pine::server::HttpStats stats;
+  // Direct record_request with an unnormalized path: this is the
+  // callable surface. Whoever invokes it is responsible for
+  // normalize_path-ing first. We test what happens if they don't:
+  stats.record_request("GET", "/path with space", "2xx", 100);
+  auto snap = stats.requests_snapshot();
+  // The key shape is preserved literally; the defense lives at
+  // normalize_path (server.cpp), which is the only entry exercised by
+  // the http_metrics_middleware. This test exists to make the
+  // contract explicit: HttpStats does not parse keys.
+  CHECK(snap.size() == 1);
+  CHECK(snap.begin()->first == "GET /path with space 2xx");
 }

--- a/pine-cpp/tests/test_json.cpp
+++ b/pine-cpp/tests/test_json.cpp
@@ -1,60 +1,60 @@
-#include <doctest/doctest.h>
-
 #include "pine/pine.hpp"
+
+#include <doctest/doctest.h>
 
 using namespace pine;
 
 TEST_CASE("parse_json: scalar values") {
-    CHECK(parse_json("null").is_null());
-    CHECK(parse_json("true").as_bool() == true);
-    CHECK(parse_json("false").as_bool() == false);
-    CHECK(parse_json("42").as_number() == doctest::Approx(42.0));
-    CHECK(parse_json("-3.14").as_number() == doctest::Approx(-3.14));
-    CHECK(parse_json("\"hello\"").as_string() == "hello");
+  CHECK(parse_json("null").is_null());
+  CHECK(parse_json("true").as_bool() == true);
+  CHECK(parse_json("false").as_bool() == false);
+  CHECK(parse_json("42").as_number() == doctest::Approx(42.0));
+  CHECK(parse_json("-3.14").as_number() == doctest::Approx(-3.14));
+  CHECK(parse_json("\"hello\"").as_string() == "hello");
 }
 
 TEST_CASE("parse_json: arrays and objects") {
-    auto arr = parse_json("[1, 2, 3]");
-    REQUIRE(arr.is_array());
-    REQUIRE(arr.as_array().size() == 3);
-    CHECK(arr.as_array()[0].as_number() == doctest::Approx(1.0));
+  auto arr = parse_json("[1, 2, 3]");
+  REQUIRE(arr.is_array());
+  REQUIRE(arr.as_array().size() == 3);
+  CHECK(arr.as_array()[0].as_number() == doctest::Approx(1.0));
 
-    auto obj = parse_json("{\"a\": 1, \"b\": \"x\"}");
-    REQUIRE(obj.is_object());
-    CHECK(obj.find("a")->as_number() == doctest::Approx(1.0));
-    CHECK(obj.find("b")->as_string() == "x");
-    CHECK(obj.find("missing") == nullptr);
+  auto obj = parse_json("{\"a\": 1, \"b\": \"x\"}");
+  REQUIRE(obj.is_object());
+  CHECK(obj.find("a")->as_number() == doctest::Approx(1.0));
+  CHECK(obj.find("b")->as_string() == "x");
+  CHECK(obj.find("missing") == nullptr);
 }
 
 TEST_CASE("parse_json: escaped strings") {
-    auto v = parse_json("\"line1\\nline2\\ttab\\\"quote\"");
-    CHECK(v.as_string() == "line1\nline2\ttab\"quote");
+  auto v = parse_json("\"line1\\nline2\\ttab\\\"quote\"");
+  CHECK(v.as_string() == "line1\nline2\ttab\"quote");
 }
 
 TEST_CASE("parse_json: invalid input throws") {
-    CHECK_THROWS(parse_json("{not json}"));
-    CHECK_THROWS(parse_json("[1, 2,"));
-    CHECK_THROWS(parse_json(""));
+  CHECK_THROWS(parse_json("{not json}"));
+  CHECK_THROWS(parse_json("[1, 2,"));
+  CHECK_THROWS(parse_json(""));
 }
 
 TEST_CASE("dump_json: roundtrip preserves structure") {
-    auto original = parse_json(R"({"name":"pine","items":[1,2,3],"flag":true,"empty":null})");
-    auto dumped = dump_json(original, 0);
-    auto reparsed = parse_json(dumped);
-    REQUIRE(reparsed.is_object());
-    CHECK(reparsed.find("name")->as_string() == "pine");
-    CHECK(reparsed.find("items")->as_array().size() == 3);
-    CHECK(reparsed.find("flag")->as_bool() == true);
-    CHECK(reparsed.find("empty")->is_null());
+  auto original = parse_json(R"({"name":"pine","items":[1,2,3],"flag":true,"empty":null})");
+  auto dumped = dump_json(original, 0);
+  auto reparsed = parse_json(dumped);
+  REQUIRE(reparsed.is_object());
+  CHECK(reparsed.find("name")->as_string() == "pine");
+  CHECK(reparsed.find("items")->as_array().size() == 3);
+  CHECK(reparsed.find("flag")->as_bool() == true);
+  CHECK(reparsed.find("empty")->is_null());
 }
 
 TEST_CASE("JsonValue truthy semantics") {
-    // null and bool follow value; everything else is truthy.
-    CHECK(JsonValue(nullptr).truthy() == false);
-    CHECK(JsonValue(false).truthy() == false);
-    CHECK(JsonValue(true).truthy() == true);
-    CHECK(JsonValue(0.0).truthy() == true);
-    CHECK(JsonValue(1.0).truthy() == true);
-    CHECK(JsonValue(std::string("")).truthy() == true);
-    CHECK(JsonValue(std::string("x")).truthy() == true);
+  // null and bool follow value; everything else is truthy.
+  CHECK(JsonValue(nullptr).truthy() == false);
+  CHECK(JsonValue(false).truthy() == false);
+  CHECK(JsonValue(true).truthy() == true);
+  CHECK(JsonValue(0.0).truthy() == true);
+  CHECK(JsonValue(1.0).truthy() == true);
+  CHECK(JsonValue(std::string("")).truthy() == true);
+  CHECK(JsonValue(std::string("x")).truthy() == true);
 }

--- a/pine-cpp/tests/test_metrics.cpp
+++ b/pine-cpp/tests/test_metrics.cpp
@@ -1,5 +1,5 @@
-#include "pine/pine.hpp"
 #include "pine/metrics.hpp"
+#include "pine/pine.hpp"
 
 #include <doctest/doctest.h>
 
@@ -14,46 +14,63 @@ namespace {
 
 // Recording metrics provider for assertions. Reuses one instance per metric name.
 class RecordingProvider : public metrics::Provider {
-public:
-    struct CounterImpl : metrics::Counter {
-        std::atomic<int64_t> count{0};
-        metrics::Counter* with(const std::vector<std::string>&) override { return this; }
-        void inc() override { count.fetch_add(1, std::memory_order_relaxed); }
-    };
-    struct GaugeImpl : metrics::Gauge {
-        std::atomic<int64_t> last_set{0};
-        std::atomic<int64_t> set_calls{0};
-        metrics::Gauge* with(const std::vector<std::string>&) override { return this; }
-        void set(double v) override {
-            last_set.store(static_cast<int64_t>(v), std::memory_order_relaxed);
-            set_calls.fetch_add(1, std::memory_order_relaxed);
-        }
-        void add(double) override {}
-    };
-    struct HistogramImpl : metrics::Histogram {
-        std::atomic<int64_t> observe_calls{0};
-        metrics::Histogram* with(const std::vector<std::string>&) override { return this; }
-        void observe(double) override { observe_calls.fetch_add(1, std::memory_order_relaxed); }
-    };
-
-    metrics::Counter* new_counter(const metrics::MetricOpts& o) override {
-        return counters_.emplace(o.name, std::make_unique<CounterImpl>()).first->second.get();
+ public:
+  struct CounterImpl : metrics::Counter {
+    std::atomic<int64_t> count{0};
+    metrics::Counter* with(const std::vector<std::string>&) override {
+      return this;
     }
-    metrics::Gauge* new_gauge(const metrics::MetricOpts& o) override {
-        return gauges_.emplace(o.name, std::make_unique<GaugeImpl>()).first->second.get();
+    void inc() override {
+      count.fetch_add(1, std::memory_order_relaxed);
     }
-    metrics::Histogram* new_histogram(const metrics::HistogramOpts& o) override {
-        return histograms_.emplace(o.opts.name, std::make_unique<HistogramImpl>()).first->second.get();
+  };
+  struct GaugeImpl : metrics::Gauge {
+    std::atomic<int64_t> last_set{0};
+    std::atomic<int64_t> set_calls{0};
+    metrics::Gauge* with(const std::vector<std::string>&) override {
+      return this;
     }
+    void set(double v) override {
+      last_set.store(static_cast<int64_t>(v), std::memory_order_relaxed);
+      set_calls.fetch_add(1, std::memory_order_relaxed);
+    }
+    void add(double) override {
+    }
+  };
+  struct HistogramImpl : metrics::Histogram {
+    std::atomic<int64_t> observe_calls{0};
+    metrics::Histogram* with(const std::vector<std::string>&) override {
+      return this;
+    }
+    void observe(double) override {
+      observe_calls.fetch_add(1, std::memory_order_relaxed);
+    }
+  };
 
-    CounterImpl* counter(const std::string& name) { return counters_.count(name) ? counters_[name].get() : nullptr; }
-    GaugeImpl* gauge(const std::string& name) { return gauges_.count(name) ? gauges_[name].get() : nullptr; }
-    HistogramImpl* histogram(const std::string& name) { return histograms_.count(name) ? histograms_[name].get() : nullptr; }
+  metrics::Counter* new_counter(const metrics::MetricOpts& o) override {
+    return counters_.emplace(o.name, std::make_unique<CounterImpl>()).first->second.get();
+  }
+  metrics::Gauge* new_gauge(const metrics::MetricOpts& o) override {
+    return gauges_.emplace(o.name, std::make_unique<GaugeImpl>()).first->second.get();
+  }
+  metrics::Histogram* new_histogram(const metrics::HistogramOpts& o) override {
+    return histograms_.emplace(o.opts.name, std::make_unique<HistogramImpl>()).first->second.get();
+  }
 
-private:
-    std::map<std::string, std::unique_ptr<CounterImpl>> counters_;
-    std::map<std::string, std::unique_ptr<GaugeImpl>> gauges_;
-    std::map<std::string, std::unique_ptr<HistogramImpl>> histograms_;
+  CounterImpl* counter(const std::string& name) {
+    return counters_.count(name) ? counters_[name].get() : nullptr;
+  }
+  GaugeImpl* gauge(const std::string& name) {
+    return gauges_.count(name) ? gauges_[name].get() : nullptr;
+  }
+  HistogramImpl* histogram(const std::string& name) {
+    return histograms_.count(name) ? histograms_[name].get() : nullptr;
+  }
+
+ private:
+  std::map<std::string, std::unique_ptr<CounterImpl>> counters_;
+  std::map<std::string, std::unique_ptr<GaugeImpl>> gauges_;
+  std::map<std::string, std::unique_ptr<HistogramImpl>> histograms_;
 };
 
 const char* kConfig = R"({
@@ -73,49 +90,49 @@ const char* kConfig = R"({
 }  // namespace
 
 TEST_CASE("metrics: nop provider is the default and discards observations") {
-    auto cfg = load_config_from_json(kConfig);
-    Engine engine(std::move(cfg));
-    CHECK(engine.metrics_provider() == metrics::nop_provider());
+  auto cfg = load_config_from_json(kConfig);
+  Engine engine(std::move(cfg));
+  CHECK(engine.metrics_provider() == metrics::nop_provider());
 
-    Request req;
-    Result result = engine.execute(req);
-    CHECK(result.items.size() == 2);
+  Request req;
+  Result result = engine.execute(req);
+  CHECK(result.items.size() == 2);
 }
 
 TEST_CASE("metrics: provider receives scheduler/op/dag observations") {
-    RecordingProvider provider;
-    EngineOptions opts;
-    opts.metrics_provider = &provider;
+  RecordingProvider provider;
+  EngineOptions opts;
+  opts.metrics_provider = &provider;
 
-    auto cfg = load_config_from_json(kConfig);
-    Engine engine(std::move(cfg), opts);
+  auto cfg = load_config_from_json(kConfig);
+  Engine engine(std::move(cfg), opts);
 
-    Request req;
-    engine.execute(req);
+  Request req;
+  engine.execute(req);
 
-    auto* runs = provider.counter("pine_scheduler_runs_total");
-    REQUIRE(runs);
-    CHECK(runs->count.load() == 1);
+  auto* runs = provider.counter("pine_scheduler_runs_total");
+  REQUIRE(runs);
+  CHECK(runs->count.load() == 1);
 
-    auto* op_exec = provider.counter("pine_operator_exec_total");
-    REQUIRE(op_exec);
-    CHECK(op_exec->count.load() == 1);
+  auto* op_exec = provider.counter("pine_operator_exec_total");
+  REQUIRE(op_exec);
+  CHECK(op_exec->count.load() == 1);
 
-    auto* dag_total = provider.counter("pine_dag_executions_total");
-    REQUIRE(dag_total);
-    CHECK(dag_total->count.load() >= 1);
+  auto* dag_total = provider.counter("pine_dag_executions_total");
+  REQUIRE(dag_total);
+  CHECK(dag_total->count.load() >= 1);
 
-    auto* dur = provider.histogram("pine_operator_exec_duration_seconds");
-    REQUIRE(dur);
-    CHECK(dur->observe_calls.load() == 1);
+  auto* dur = provider.histogram("pine_operator_exec_duration_seconds");
+  REQUIRE(dur);
+  CHECK(dur->observe_calls.load() == 1);
 
-    auto* dag_dur = provider.histogram("pine_dag_execution_duration_seconds");
-    REQUIRE(dag_dur);
-    CHECK(dag_dur->observe_calls.load() == 1);
+  auto* dag_dur = provider.histogram("pine_dag_execution_duration_seconds");
+  REQUIRE(dag_dur);
+  CHECK(dag_dur->observe_calls.load() == 1);
 
-    auto* active = provider.gauge("pine_operator_active");
-    REQUIRE(active);
-    // Each op invokes set twice — once at entry (current high
-    // water-mark) and once at ActiveGuard destruction (after dec).
-    CHECK(active->set_calls.load() == 2);
+  auto* active = provider.gauge("pine_operator_active");
+  REQUIRE(active);
+  // Each op invokes set twice — once at entry (current high
+  // water-mark) and once at ActiveGuard destruction (after dec).
+  CHECK(active->set_calls.load() == 2);
 }

--- a/pine-cpp/tests/test_metrics_aware.cpp
+++ b/pine-cpp/tests/test_metrics_aware.cpp
@@ -1,7 +1,7 @@
-#include "pine/pine.hpp"
+#include "pine/metrics.hpp"
 #include "pine/operator.hpp"
 #include "pine/operator_input.hpp"
-#include "pine/metrics.hpp"
+#include "pine/pine.hpp"
 
 #include <doctest/doctest.h>
 
@@ -15,15 +15,16 @@ namespace {
 // Tracks whether the Engine injected a non-null provider matching the
 // one passed via EngineOptions.
 class ProbeOp : public Operator, public MetricsAware {
-public:
-    static metrics::Provider* injected;
-    static int call_count;
+ public:
+  static metrics::Provider* injected;
+  static int call_count;
 
-    void execute(const OperatorInput&, OperatorOutput&) override {}
-    void set_metrics_provider(metrics::Provider* p) override {
-        injected = p;
-        ++call_count;
-    }
+  void execute(const OperatorInput&, OperatorOutput&) override {
+  }
+  void set_metrics_provider(metrics::Provider* p) override {
+    injected = p;
+    ++call_count;
+  }
 };
 metrics::Provider* ProbeOp::injected = nullptr;
 int ProbeOp::call_count = 0;
@@ -31,26 +32,27 @@ int ProbeOp::call_count = 0;
 // Operator that does NOT implement MetricsAware; engine must NOT call
 // set_metrics_provider on it (compile-time safety; we just register it).
 class NonAwareOp : public Operator {
-public:
-    void execute(const OperatorInput&, OperatorOutput&) override {}
+ public:
+  void execute(const OperatorInput&, OperatorOutput&) override {
+  }
 };
 
 const bool _reg_probe = [] {
-    OperatorSchema schema{
-        .name = "test_metrics_probe",
-        .type = OpType::Recall,
-        .description = "metrics-aware probe",
-        .params = {},
-    };
-    register_operator_typed<ProbeOp>(std::move(schema));
-    OperatorSchema schema2{
-        .name = "test_metrics_nonaware",
-        .type = OpType::Recall,
-        .description = "non-aware probe",
-        .params = {},
-    };
-    register_operator_typed<NonAwareOp>(std::move(schema2));
-    return true;
+  OperatorSchema schema{
+      .name = "test_metrics_probe",
+      .type = OpType::Recall,
+      .description = "metrics-aware probe",
+      .params = {},
+  };
+  register_operator_typed<ProbeOp>(std::move(schema));
+  OperatorSchema schema2{
+      .name = "test_metrics_nonaware",
+      .type = OpType::Recall,
+      .description = "non-aware probe",
+      .params = {},
+  };
+  register_operator_typed<NonAwareOp>(std::move(schema2));
+  return true;
 }();
 
 const char* kConfig = R"({
@@ -71,42 +73,71 @@ const char* kConfig = R"({
 })";
 
 class CountingProvider : public metrics::Provider {
-public:
-    struct C : metrics::Counter { metrics::Counter* with(const std::vector<std::string>&) override { return this; } void inc() override {} };
-    struct G : metrics::Gauge   { metrics::Gauge*   with(const std::vector<std::string>&) override { return this; } void set(double) override {} void add(double) override {} };
-    struct H : metrics::Histogram { metrics::Histogram* with(const std::vector<std::string>&) override { return this; } void observe(double) override {} };
-    metrics::Counter*   new_counter(const metrics::MetricOpts&) override   { return new_counter_called = true, &c_; }
-    metrics::Gauge*     new_gauge(const metrics::MetricOpts&) override     { return &g_; }
-    metrics::Histogram* new_histogram(const metrics::HistogramOpts&) override { return &h_; }
-    bool new_counter_called = false;
-private:
-    C c_; G g_; H h_;
+ public:
+  struct C : metrics::Counter {
+    metrics::Counter* with(const std::vector<std::string>&) override {
+      return this;
+    }
+    void inc() override {
+    }
+  };
+  struct G : metrics::Gauge {
+    metrics::Gauge* with(const std::vector<std::string>&) override {
+      return this;
+    }
+    void set(double) override {
+    }
+    void add(double) override {
+    }
+  };
+  struct H : metrics::Histogram {
+    metrics::Histogram* with(const std::vector<std::string>&) override {
+      return this;
+    }
+    void observe(double) override {
+    }
+  };
+  metrics::Counter* new_counter(const metrics::MetricOpts&) override {
+    return new_counter_called = true, &c_;
+  }
+  metrics::Gauge* new_gauge(const metrics::MetricOpts&) override {
+    return &g_;
+  }
+  metrics::Histogram* new_histogram(const metrics::HistogramOpts&) override {
+    return &h_;
+  }
+  bool new_counter_called = false;
+
+ private:
+  C c_;
+  G g_;
+  H h_;
 };
 
 }  // namespace
 
 TEST_CASE("metrics_aware: engine injects configured provider after init") {
-    ProbeOp::injected = nullptr;
-    ProbeOp::call_count = 0;
+  ProbeOp::injected = nullptr;
+  ProbeOp::call_count = 0;
 
-    CountingProvider provider;
-    EngineOptions opts;
-    opts.metrics_provider = &provider;
+  CountingProvider provider;
+  EngineOptions opts;
+  opts.metrics_provider = &provider;
 
-    auto cfg = load_config_from_json(kConfig);
-    Engine engine(std::move(cfg), opts);
+  auto cfg = load_config_from_json(kConfig);
+  Engine engine(std::move(cfg), opts);
 
-    CHECK(ProbeOp::call_count == 1);
-    CHECK(ProbeOp::injected == &provider);
+  CHECK(ProbeOp::call_count == 1);
+  CHECK(ProbeOp::injected == &provider);
 }
 
 TEST_CASE("metrics_aware: nop provider is injected when none configured") {
-    ProbeOp::injected = nullptr;
-    ProbeOp::call_count = 0;
+  ProbeOp::injected = nullptr;
+  ProbeOp::call_count = 0;
 
-    auto cfg = load_config_from_json(kConfig);
-    Engine engine(std::move(cfg));
+  auto cfg = load_config_from_json(kConfig);
+  Engine engine(std::move(cfg));
 
-    CHECK(ProbeOp::call_count == 1);
-    CHECK(ProbeOp::injected == metrics::nop_provider());
+  CHECK(ProbeOp::call_count == 1);
+  CHECK(ProbeOp::injected == metrics::nop_provider());
 }

--- a/pine-cpp/tests/test_operator_output.cpp
+++ b/pine-cpp/tests/test_operator_output.cpp
@@ -1,70 +1,70 @@
-#include <doctest/doctest.h>
-
 #include "pine/pine.hpp"
+
+#include <doctest/doctest.h>
 
 using namespace pine;
 
 TEST_CASE("OperatorOutput: set_common collects field writes") {
-    OperatorOutput out;
-    out.set_common("a", JsonValue(std::string("v1")));
-    out.set_common("b", JsonValue(2.0));
-    CHECK(out.common_writes().size() == 2);
-    CHECK(out.common_writes().at("a").as_string() == "v1");
-    CHECK(out.common_writes().at("b").as_number() == 2.0);
+  OperatorOutput out;
+  out.set_common("a", JsonValue(std::string("v1")));
+  out.set_common("b", JsonValue(2.0));
+  CHECK(out.common_writes().size() == 2);
+  CHECK(out.common_writes().at("a").as_string() == "v1");
+  CHECK(out.common_writes().at("b").as_number() == 2.0);
 }
 
 TEST_CASE("OperatorOutput: set_item collects ordered (idx, field, value) log") {
-    OperatorOutput out;
-    out.set_item(0, "x", JsonValue(std::string("hello")));
-    out.set_item(0, "y", JsonValue(true));
-    out.set_item(2, "x", JsonValue(std::string("world")));
-    REQUIRE(out.item_writes().size() == 3);
-    CHECK(out.item_writes()[0].index == 0);
-    CHECK(out.item_writes()[0].field == "x");
-    CHECK(out.item_writes()[0].value.as_string() == "hello");
-    CHECK(out.item_writes()[1].index == 0);
-    CHECK(out.item_writes()[1].field == "y");
-    CHECK(out.item_writes()[1].value.as_bool() == true);
-    CHECK(out.item_writes()[2].index == 2);
-    CHECK(out.item_writes()[2].field == "x");
-    CHECK(out.item_writes()[2].value.as_string() == "world");
+  OperatorOutput out;
+  out.set_item(0, "x", JsonValue(std::string("hello")));
+  out.set_item(0, "y", JsonValue(true));
+  out.set_item(2, "x", JsonValue(std::string("world")));
+  REQUIRE(out.item_writes().size() == 3);
+  CHECK(out.item_writes()[0].index == 0);
+  CHECK(out.item_writes()[0].field == "x");
+  CHECK(out.item_writes()[0].value.as_string() == "hello");
+  CHECK(out.item_writes()[1].index == 0);
+  CHECK(out.item_writes()[1].field == "y");
+  CHECK(out.item_writes()[1].value.as_bool() == true);
+  CHECK(out.item_writes()[2].index == 2);
+  CHECK(out.item_writes()[2].field == "x");
+  CHECK(out.item_writes()[2].value.as_string() == "world");
 }
 
 TEST_CASE("OperatorOutput: add_item appends rows") {
-    OperatorOutput out;
-    std::map<std::string, JsonValue> r1;
-    r1["id"] = JsonValue(std::string("a"));
-    out.add_item(r1);
-    out.add_item({{"id", JsonValue(std::string("b"))}});
-    REQUIRE(out.added_items().size() == 2);
-    CHECK(out.added_items()[0].at("id").as_string() == "a");
-    CHECK(out.added_items()[1].at("id").as_string() == "b");
+  OperatorOutput out;
+  std::map<std::string, JsonValue> r1;
+  r1["id"] = JsonValue(std::string("a"));
+  out.add_item(r1);
+  out.add_item({{"id", JsonValue(std::string("b"))}});
+  REQUIRE(out.added_items().size() == 2);
+  CHECK(out.added_items()[0].at("id").as_string() == "a");
+  CHECK(out.added_items()[1].at("id").as_string() == "b");
 }
 
 TEST_CASE("OperatorOutput: remove_item dedupes by set") {
-    OperatorOutput out;
-    out.remove_item(0);
-    out.remove_item(2);
-    out.remove_item(0);
-    CHECK(out.removed_items().size() == 2);
-    CHECK(out.removed_items().count(0) == 1);
-    CHECK(out.removed_items().count(2) == 1);
+  OperatorOutput out;
+  out.remove_item(0);
+  out.remove_item(2);
+  out.remove_item(0);
+  CHECK(out.removed_items().size() == 2);
+  CHECK(out.removed_items().count(0) == 1);
+  CHECK(out.removed_items().count(2) == 1);
 }
 
 TEST_CASE("OperatorOutput: set_item_order is opt-in via has_item_order") {
-    OperatorOutput out;
-    CHECK_FALSE(out.has_item_order());
-    out.set_item_order({2, 0, 1});
-    CHECK(out.has_item_order());
-    REQUIRE(out.item_order().size() == 3);
-    CHECK(out.item_order()[0] == 2);
+  OperatorOutput out;
+  CHECK_FALSE(out.has_item_order());
+  out.set_item_order({2, 0, 1});
+  CHECK(out.has_item_order());
+  REQUIRE(out.item_order().size() == 3);
+  CHECK(out.item_order()[0] == 2);
 }
 
 TEST_CASE("OperatorOutput: set_warning is first-wins") {
-    OperatorOutput out;
-    CHECK_FALSE(out.has_warning());
-    out.set_warning("first");
-    out.set_warning("second");
-    CHECK(out.has_warning());
-    CHECK(out.warning() == "first");
+  OperatorOutput out;
+  CHECK_FALSE(out.has_warning());
+  out.set_warning("first");
+  out.set_warning("second");
+  CHECK(out.has_warning());
+  CHECK(out.warning() == "first");
 }

--- a/pine-cpp/tests/test_panic.cpp
+++ b/pine-cpp/tests/test_panic.cpp
@@ -1,24 +1,24 @@
-#include <doctest/doctest.h>
-
 #include "pine/pine.hpp"
+
+#include <doctest/doctest.h>
 
 #include <stdexcept>
 
 using namespace pine;
 
 TEST_CASE("PanicError: carries operator name + value and formats message") {
-    PanicError err("my_op", "boom");
-    CHECK(err.operator_name() == "my_op");
-    CHECK(err.value() == "boom");
-    CHECK(std::string(err.what()) == "pine: panic in operator \"my_op\": boom");
+  PanicError err("my_op", "boom");
+  CHECK(err.operator_name() == "my_op");
+  CHECK(err.value() == "boom");
+  CHECK(std::string(err.what()) == "pine: panic in operator \"my_op\": boom");
 }
 
 TEST_CASE("PanicError: is a pine::Error") {
-    PanicError err("op", "x");
-    const Error* base = &err;
-    CHECK(base != nullptr);
-    const std::exception* stdex = &err;
-    CHECK(std::string(stdex->what()).find("op") != std::string::npos);
+  PanicError err("op", "x");
+  const Error* base = &err;
+  CHECK(base != nullptr);
+  const std::exception* stdex = &err;
+  CHECK(std::string(stdex->what()).find("op") != std::string::npos);
 }
 
 namespace {
@@ -55,38 +55,38 @@ constexpr const char* kBadCopyConfig = R"({
 }  // namespace
 
 TEST_CASE("dispatch_with_recovery: pine::ExecutionError passes through unwrapped") {
-    Engine engine(load_config_from_json(kBadCopyConfig));
-    Request req;
-    // a is present but null → passes validation, ExecutionError "required field \"a\" is nil"
-    req.common["a"] = JsonValue();
-    bool caught_execution = false;
-    bool caught_panic = false;
-    try {
-        engine.execute(req);
-    } catch (const PanicError&) {
-        caught_panic = true;
-    } catch (const ExecutionError& e) {
-        caught_execution = true;
-        std::string msg = e.what();
-        CHECK(msg.find("operator \"bad\"") != std::string::npos);
-        CHECK(msg.find("required field") != std::string::npos);
-    }
-    CHECK(caught_execution);
-    CHECK_FALSE(caught_panic);
+  Engine engine(load_config_from_json(kBadCopyConfig));
+  Request req;
+  // a is present but null → passes validation, ExecutionError "required field \"a\" is nil"
+  req.common["a"] = JsonValue();
+  bool caught_execution = false;
+  bool caught_panic = false;
+  try {
+    engine.execute(req);
+  } catch (const PanicError&) {
+    caught_panic = true;
+  } catch (const ExecutionError& e) {
+    caught_execution = true;
+    std::string msg = e.what();
+    CHECK(msg.find("operator \"bad\"") != std::string::npos);
+    CHECK(msg.find("required field") != std::string::npos);
+  }
+  CHECK(caught_execution);
+  CHECK_FALSE(caught_panic);
 }
 
 TEST_CASE("PanicError captures stack trace via std::stacktrace") {
-    pine::PanicError p("opX", "boom");
-    CHECK(std::string(p.what()).find("pine: panic in operator \"opX\": boom") != std::string::npos);
-    // stack may be empty if the toolchain lacks std::stacktrace linkage,
-    // but with PINE_HAS_STACKTRACE the field should be populated.
+  pine::PanicError p("opX", "boom");
+  CHECK(std::string(p.what()).find("pine: panic in operator \"opX\": boom") != std::string::npos);
+  // stack may be empty if the toolchain lacks std::stacktrace linkage,
+  // but with PINE_HAS_STACKTRACE the field should be populated.
 #if defined(PINE_HAS_STACKTRACE)
-    CHECK(!p.stack().empty());
-    std::string detailed = p.detailed_error();
-    CHECK(detailed.find("stack trace:") != std::string::npos);
-    CHECK(detailed.find(p.what()) != std::string::npos);
+  CHECK(!p.stack().empty());
+  std::string detailed = p.detailed_error();
+  CHECK(detailed.find("stack trace:") != std::string::npos);
+  CHECK(detailed.find(p.what()) != std::string::npos);
 #else
-    CHECK(p.stack().empty());
-    CHECK(p.detailed_error() == std::string(p.what()));
+  CHECK(p.stack().empty());
+  CHECK(p.detailed_error() == std::string(p.what()));
 #endif
 }

--- a/pine-cpp/tests/test_parallel.cpp
+++ b/pine-cpp/tests/test_parallel.cpp
@@ -1,6 +1,6 @@
-#include <doctest/doctest.h>
-
 #include "pine/pine.hpp"
+
+#include <doctest/doctest.h>
 
 using namespace pine;
 
@@ -47,69 +47,66 @@ constexpr const char* kParallelConfig = R"({
   }
 })";
 
-Request make_request(const std::vector<std::string>& ids,
-                     const std::string& tag,
-                     const std::string& scene) {
-    Request req;
-    req.common["tag"] = JsonValue(tag);
-    req.common["scene"] = JsonValue(scene);
-    for (const auto& id : ids) {
-        std::map<std::string, JsonValue> row;
-        row["id"] = JsonValue(id);
-        req.items.push_back(std::move(row));
-    }
-    return req;
+Request make_request(const std::vector<std::string>& ids, const std::string& tag, const std::string& scene) {
+  Request req;
+  req.common["tag"] = JsonValue(tag);
+  req.common["scene"] = JsonValue(scene);
+  for (const auto& id : ids) {
+    std::map<std::string, JsonValue> row;
+    row["id"] = JsonValue(id);
+    req.items.push_back(std::move(row));
+  }
+  return req;
 }
 
 }  // namespace
 
 TEST_CASE("parallel_execute: 6 items across 3 shards preserves order and field writes") {
-    Engine engine(load_config_from_json(kParallelConfig));
-    auto result = engine.execute(make_request({"a","b","c","d","e","f"}, "promo", "feed"));
+  Engine engine(load_config_from_json(kParallelConfig));
+  auto result = engine.execute(make_request({"a", "b", "c", "d", "e", "f"}, "promo", "feed"));
 
-    REQUIRE(result.items.size() == 6);
-    std::vector<std::string> expected_ids = {"a","b","c","d","e","f"};
-    for (std::size_t i = 0; i < result.items.size(); ++i) {
-        CHECK(result.items[i].at("id").as_string() == expected_ids[i]);
-        CHECK(result.items[i].at("tag").as_string() == "promo");
-        CHECK(result.items[i].at("item_scene").as_string() == "feed");
-    }
+  REQUIRE(result.items.size() == 6);
+  std::vector<std::string> expected_ids = {"a", "b", "c", "d", "e", "f"};
+  for (std::size_t i = 0; i < result.items.size(); ++i) {
+    CHECK(result.items[i].at("id").as_string() == expected_ids[i]);
+    CHECK(result.items[i].at("tag").as_string() == "promo");
+    CHECK(result.items[i].at("item_scene").as_string() == "feed");
+  }
 }
 
 TEST_CASE("parallel_execute: fewer items than parallelism degrades to N=total") {
-    Engine engine(load_config_from_json(kParallelConfig));
-    auto result = engine.execute(make_request({"x","y"}, "vip", "search"));
+  Engine engine(load_config_from_json(kParallelConfig));
+  auto result = engine.execute(make_request({"x", "y"}, "vip", "search"));
 
-    REQUIRE(result.items.size() == 2);
-    CHECK(result.items[0].at("id").as_string() == "x");
-    CHECK(result.items[0].at("tag").as_string() == "vip");
-    CHECK(result.items[0].at("item_scene").as_string() == "search");
-    CHECK(result.items[1].at("id").as_string() == "y");
+  REQUIRE(result.items.size() == 2);
+  CHECK(result.items[0].at("id").as_string() == "x");
+  CHECK(result.items[0].at("tag").as_string() == "vip");
+  CHECK(result.items[0].at("item_scene").as_string() == "search");
+  CHECK(result.items[1].at("id").as_string() == "y");
 }
 
 TEST_CASE("parallel_execute: single item with parallelism>1 — degenerate shard") {
-    Engine engine(load_config_from_json(kParallelConfig));
-    auto result = engine.execute(make_request({"z"}, "solo", "home"));
+  Engine engine(load_config_from_json(kParallelConfig));
+  auto result = engine.execute(make_request({"z"}, "solo", "home"));
 
-    REQUIRE(result.items.size() == 1);
-    CHECK(result.items[0].at("id").as_string() == "z");
-    CHECK(result.items[0].at("tag").as_string() == "solo");
-    CHECK(result.items[0].at("item_scene").as_string() == "home");
+  REQUIRE(result.items.size() == 1);
+  CHECK(result.items[0].at("id").as_string() == "z");
+  CHECK(result.items[0].at("tag").as_string() == "solo");
+  CHECK(result.items[0].at("item_scene").as_string() == "home");
 }
 
 TEST_CASE("parallel_execute: zero items passthrough is safe") {
-    Engine engine(load_config_from_json(kParallelConfig));
-    auto result = engine.execute(make_request({}, "none", "empty"));
-    CHECK(result.items.empty());
+  Engine engine(load_config_from_json(kParallelConfig));
+  auto result = engine.execute(make_request({}, "none", "empty"));
+  CHECK(result.items.empty());
 }
 
 TEST_CASE("parallel_execute: traced execution still records one entry per operator") {
-    Engine engine(load_config_from_json(kParallelConfig));
-    std::map<std::string, JsonValue> resources;
-    auto traced = engine.execute_traced(
-        make_request({"a","b","c","d","e","f"}, "x", "y"), resources);
-    REQUIRE(traced.trace.size() == 2);
-    CHECK(traced.trace[0].name == "copy_tag");
-    CHECK(traced.trace[0].skipped == false);
-    CHECK(traced.trace[1].name == "dispatch_scene");
+  Engine engine(load_config_from_json(kParallelConfig));
+  std::map<std::string, JsonValue> resources;
+  auto traced = engine.execute_traced(make_request({"a", "b", "c", "d", "e", "f"}, "x", "y"), resources);
+  REQUIRE(traced.trace.size() == 2);
+  CHECK(traced.trace[0].name == "copy_tag");
+  CHECK(traced.trace[0].skipped == false);
+  CHECK(traced.trace[1].name == "dispatch_scene");
 }

--- a/pine-cpp/tests/test_register_operator.cpp
+++ b/pine-cpp/tests/test_register_operator.cpp
@@ -1,79 +1,77 @@
-#include "pine/pine.hpp"
 #include "pine/operator.hpp"
 #include "pine/operator_input.hpp"
+#include "pine/pine.hpp"
+
 #include <doctest/doctest.h>
 
 using namespace pine;
 
 TEST_CASE("register_operator: builtin operators are registered via static init") {
-    auto names = registered_operator_names();
-    CHECK(names.size() >= 17);
-    CHECK(registry_entry("filter_condition") != nullptr);
-    CHECK(registry_entry("transform_redis_get") != nullptr);
-    CHECK(registry_entry("recall_static") != nullptr);
-    CHECK(registry_entry("reorder_sort") != nullptr);
+  auto names = registered_operator_names();
+  CHECK(names.size() >= 17);
+  CHECK(registry_entry("filter_condition") != nullptr);
+  CHECK(registry_entry("transform_redis_get") != nullptr);
+  CHECK(registry_entry("recall_static") != nullptr);
+  CHECK(registry_entry("reorder_sort") != nullptr);
 }
 
 TEST_CASE("register_operator: traits are correct") {
-    const auto* e = registry_entry("filter_truncate");
-    REQUIRE(e != nullptr);
-    CHECK(e->schema.type == OpType::Filter);
-    CHECK(e->consumes_row_set == true);
-    CHECK(e->mutates_row_set == true);
-    CHECK(e->schema.params.count("top_n") == 1);
-    CHECK(e->schema.params.at("top_n").required == true);
+  const auto* e = registry_entry("filter_truncate");
+  REQUIRE(e != nullptr);
+  CHECK(e->schema.type == OpType::Filter);
+  CHECK(e->consumes_row_set == true);
+  CHECK(e->mutates_row_set == true);
+  CHECK(e->schema.params.count("top_n") == 1);
+  CHECK(e->schema.params.at("top_n").required == true);
 }
 
 TEST_CASE("register_operator: factory is callable") {
-    const auto* e = registry_entry("transform_size");
-    REQUIRE(e != nullptr);
-    REQUIRE(e->factory);
-    auto instance = e->factory();
-    CHECK(instance != nullptr);
+  const auto* e = registry_entry("transform_size");
+  REQUIRE(e != nullptr);
+  REQUIRE(e->factory);
+  auto instance = e->factory();
+  CHECK(instance != nullptr);
 }
 
 TEST_CASE("register_operator: unknown operator returns nullptr") {
-    CHECK(registry_entry("nonexistent_operator_xyz") == nullptr);
+  CHECK(registry_entry("nonexistent_operator_xyz") == nullptr);
 }
 
 TEST_CASE("register_operator: duplicate throws RegistryError") {
-    static const OperatorSchema dup_schema{
-        .name = "filter_condition",
-        .type = OpType::Filter,
-        .description = "dup",
-        .params = {},
-    };
-    struct DupOp : public Operator, public ConsumesRowSet, public MutatesRowSet {
-        void execute(const OperatorInput&, OperatorOutput&) override {}
-    };
-    CHECK_THROWS_AS(
-        register_operator_typed<DupOp>(dup_schema),
-        RegistryError);
+  static const OperatorSchema dup_schema{
+      .name = "filter_condition",
+      .type = OpType::Filter,
+      .description = "dup",
+      .params = {},
+  };
+  struct DupOp : public Operator, public ConsumesRowSet, public MutatesRowSet {
+    void execute(const OperatorInput&, OperatorOutput&) override {
+    }
+  };
+  CHECK_THROWS_AS(register_operator_typed<DupOp>(dup_schema), RegistryError);
 }
 
 TEST_CASE("register_operator: empty name throws RegistryError") {
-    static const OperatorSchema empty_schema{
-        .name = "",
-        .type = OpType::Filter,
-        .description = "desc",
-        .params = {},
-    };
-    struct EmptyNameOp : public Operator {
-        void execute(const OperatorInput&, OperatorOutput&) override {}
-    };
-    CHECK_THROWS_AS(
-        register_operator_typed<EmptyNameOp>(empty_schema),
-        RegistryError);
+  static const OperatorSchema empty_schema{
+      .name = "",
+      .type = OpType::Filter,
+      .description = "desc",
+      .params = {},
+  };
+  struct EmptyNameOp : public Operator {
+    void execute(const OperatorInput&, OperatorOutput&) override {
+    }
+  };
+  CHECK_THROWS_AS(register_operator_typed<EmptyNameOp>(empty_schema), RegistryError);
 }
 
 TEST_CASE("register_operator: null factory throws RegistryError") {
-    static const OperatorSchema null_schema{
-        .name = "test_null_factory",
-        .type = OpType::Filter,
-        .description = "desc",
-        .params = {},
-    };
-    CHECK_THROWS_AS(
-        register_operator_with_traits(null_schema, nullptr, false, false, false, false),
-        RegistryError);
+  static const OperatorSchema null_schema{
+      .name = "test_null_factory",
+      .type = OpType::Filter,
+      .description = "desc",
+      .params = {},
+  };
+  CHECK_THROWS_AS(register_operator_with_traits(null_schema, nullptr, false, false, false, false),
+                  RegistryError);
 }

--- a/pine-cpp/tests/test_registry.cpp
+++ b/pine-cpp/tests/test_registry.cpp
@@ -1,48 +1,48 @@
-#include <doctest/doctest.h>
-
-#include "pine/pine.hpp"
 #include "pine/operator.hpp"
+#include "pine/pine.hpp"
+
+#include <doctest/doctest.h>
 
 using namespace pine;
 
 TEST_CASE("registry: returns entry for known operators") {
-    const auto* entry = registry_entry("filter_truncate");
-    REQUIRE(entry != nullptr);
-    CHECK(op_type_to_string(entry->schema.type) == std::string("filter"));
+  const auto* entry = registry_entry("filter_truncate");
+  REQUIRE(entry != nullptr);
+  CHECK(op_type_to_string(entry->schema.type) == std::string("filter"));
 
-    entry = registry_entry("transform_copy");
-    REQUIRE(entry != nullptr);
-    CHECK(op_type_to_string(entry->schema.type) == std::string("transform"));
+  entry = registry_entry("transform_copy");
+  REQUIRE(entry != nullptr);
+  CHECK(op_type_to_string(entry->schema.type) == std::string("transform"));
 
-    entry = registry_entry("recall_static");
-    REQUIRE(entry != nullptr);
-    CHECK(op_type_to_string(entry->schema.type) == std::string("recall"));
+  entry = registry_entry("recall_static");
+  REQUIRE(entry != nullptr);
+  CHECK(op_type_to_string(entry->schema.type) == std::string("recall"));
 }
 
 TEST_CASE("registry: returns null for unknown type") {
-    CHECK(registry_entry("definitely_not_a_real_operator") == nullptr);
+  CHECK(registry_entry("definitely_not_a_real_operator") == nullptr);
 }
 
 TEST_CASE("export_schema_json: produces JSON parseable as an array") {
-    std::string schema = export_schema_json();
-    auto v = parse_json(schema);
-    REQUIRE(v.is_array());
-    CHECK(v.as_array().size() > 0);
+  std::string schema = export_schema_json();
+  auto v = parse_json(schema);
+  REQUIRE(v.is_array());
+  CHECK(v.as_array().size() > 0);
 
-    // First entry should be an object with at least "Name" and "Params".
-    const auto& first = v.as_array().front();
-    REQUIRE(first.is_object());
-    CHECK(first.find("Name") != nullptr);
-    CHECK(first.find("Params") != nullptr);
+  // First entry should be an object with at least "Name" and "Params".
+  const auto& first = v.as_array().front();
+  REQUIRE(first.is_object());
+  CHECK(first.find("Name") != nullptr);
+  CHECK(first.find("Params") != nullptr);
 }
 
 TEST_CASE("export_schema_json: every entry has stable shape") {
-    auto v = parse_json(export_schema_json());
-    REQUIRE(v.is_array());
-    for (const auto& entry : v.as_array()) {
-        REQUIRE(entry.is_object());
-        REQUIRE(entry.find("Name") != nullptr);
-        REQUIRE(entry.find("Name")->is_string());
-        REQUIRE(entry.find("Params") != nullptr);
-    }
+  auto v = parse_json(export_schema_json());
+  REQUIRE(v.is_array());
+  for (const auto& entry : v.as_array()) {
+    REQUIRE(entry.is_object());
+    REQUIRE(entry.find("Name") != nullptr);
+    REQUIRE(entry.find("Name")->is_string());
+    REQUIRE(entry.find("Params") != nullptr);
+  }
 }

--- a/pine-cpp/tests/test_remote_pineapple.cpp
+++ b/pine-cpp/tests/test_remote_pineapple.cpp
@@ -1,12 +1,10 @@
+#include "pine/column_frame.hpp"
 #include "pine/operator.hpp"
 #include "pine/operator_input.hpp"
-#include "pine/column_frame.hpp"
 #include "pine/pine.hpp"
-#include "http/ssrf.hpp"
-
-#include <doctest/doctest.h>
 
 #include <arpa/inet.h>
+#include <doctest/doctest.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -19,327 +17,350 @@
 #include <thread>
 #include <vector>
 
+#include "http/ssrf.hpp"
+
 namespace {
 
 // Minimal blocking HTTP/1.1 mock server. Reads one request, sends a single
 // canned response, then closes. Used to exercise the operator's plain-HTTP
 // happy path on the loopback interface.
 class MockServer {
-public:
-    explicit MockServer(std::string response_body, int status = 200,
-                        std::chrono::milliseconds delay = std::chrono::milliseconds(0))
-        : status_(status), body_(std::move(response_body)), delay_(delay) {
-        fd_ = socket(AF_INET, SOCK_STREAM, 0);
-        REQUIRE(fd_ >= 0);
-        int yes = 1;
-        setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
-        sockaddr_in addr{};
-        addr.sin_family = AF_INET;
-        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-        addr.sin_port = 0;
-        REQUIRE(bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0);
-        socklen_t len = sizeof(addr);
-        REQUIRE(getsockname(fd_, reinterpret_cast<sockaddr*>(&addr), &len) == 0);
-        port_ = ntohs(addr.sin_port);
-        REQUIRE(listen(fd_, 4) == 0);
-        thread_ = std::thread([this] { run(); });
+ public:
+  explicit MockServer(std::string response_body, int status = 200,
+                      std::chrono::milliseconds delay = std::chrono::milliseconds(0))
+      : status_(status), body_(std::move(response_body)), delay_(delay) {
+    fd_ = socket(AF_INET, SOCK_STREAM, 0);
+    REQUIRE(fd_ >= 0);
+    int yes = 1;
+    setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    REQUIRE(bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0);
+    socklen_t len = sizeof(addr);
+    REQUIRE(getsockname(fd_, reinterpret_cast<sockaddr*>(&addr), &len) == 0);
+    port_ = ntohs(addr.sin_port);
+    REQUIRE(listen(fd_, 4) == 0);
+    thread_ = std::thread([this] { run(); });
+  }
+
+  ~MockServer() {
+    stopping_ = true;
+    if (fd_ >= 0) {
+      shutdown(fd_, SHUT_RDWR);
+      close(fd_);
+      fd_ = -1;
     }
-
-    ~MockServer() {
-        stopping_ = true;
-        if (fd_ >= 0) {
-            shutdown(fd_, SHUT_RDWR);
-            close(fd_);
-            fd_ = -1;
-        }
-        if (thread_.joinable()) thread_.join();
+    if (thread_.joinable()) {
+      thread_.join();
     }
+  }
 
-    int port() const { return port_; }
-    std::string last_request() const { return last_request_; }
+  int port() const {
+    return port_;
+  }
+  std::string last_request() const {
+    return last_request_;
+  }
 
-private:
-    void run() {
-        sockaddr_in peer{};
-        socklen_t plen = sizeof(peer);
-        int client = accept(fd_, reinterpret_cast<sockaddr*>(&peer), &plen);
-        if (client < 0) return;
-        if (delay_.count() > 0) std::this_thread::sleep_for(delay_);
-        char buf[8192];
-        ssize_t n = recv(client, buf, sizeof(buf) - 1, 0);
-        if (n > 0) {
-            buf[n] = '\0';
-            last_request_ = std::string(buf, static_cast<size_t>(n));
-        }
-        std::string status_text;
-        switch (status_) {
-            case 200: status_text = "OK"; break;
-            case 400: status_text = "Bad Request"; break;
-            case 500: status_text = "Internal Server Error"; break;
-            default: status_text = "Unknown"; break;
-        }
-        std::string resp = "HTTP/1.1 " + std::to_string(status_) + " " + status_text + "\r\n";
-        resp += "Content-Type: application/json\r\n";
-        resp += "Content-Length: " + std::to_string(body_.size()) + "\r\n";
-        resp += "Connection: close\r\n\r\n";
-        resp += body_;
-        ssize_t off = 0;
-        while (off < static_cast<ssize_t>(resp.size())) {
-            ssize_t w = send(client, resp.data() + off, resp.size() - off, 0);
-            if (w <= 0) break;
-            off += w;
-        }
-        shutdown(client, SHUT_RDWR);
-        close(client);
+ private:
+  void run() {
+    sockaddr_in peer{};
+    socklen_t plen = sizeof(peer);
+    int client = accept(fd_, reinterpret_cast<sockaddr*>(&peer), &plen);
+    if (client < 0) {
+      return;
     }
+    if (delay_.count() > 0) {
+      std::this_thread::sleep_for(delay_);
+    }
+    char buf[8192];
+    ssize_t n = recv(client, buf, sizeof(buf) - 1, 0);
+    if (n > 0) {
+      buf[n] = '\0';
+      last_request_ = std::string(buf, static_cast<size_t>(n));
+    }
+    std::string status_text;
+    switch (status_) {
+      case 200:
+        status_text = "OK";
+        break;
+      case 400:
+        status_text = "Bad Request";
+        break;
+      case 500:
+        status_text = "Internal Server Error";
+        break;
+      default:
+        status_text = "Unknown";
+        break;
+    }
+    std::string resp = "HTTP/1.1 " + std::to_string(status_) + " " + status_text + "\r\n";
+    resp += "Content-Type: application/json\r\n";
+    resp += "Content-Length: " + std::to_string(body_.size()) + "\r\n";
+    resp += "Connection: close\r\n\r\n";
+    resp += body_;
+    ssize_t off = 0;
+    while (off < static_cast<ssize_t>(resp.size())) {
+      ssize_t w = send(client, resp.data() + off, resp.size() - off, 0);
+      if (w <= 0) {
+        break;
+      }
+      off += w;
+    }
+    shutdown(client, SHUT_RDWR);
+    close(client);
+  }
 
-    int fd_ = -1;
-    int port_ = 0;
-    int status_;
-    std::string body_;
-    std::chrono::milliseconds delay_;
-    std::thread thread_;
-    std::atomic<bool> stopping_{false};
-    std::string last_request_;
+  int fd_ = -1;
+  int port_ = 0;
+  int status_;
+  std::string body_;
+  std::chrono::milliseconds delay_;
+  std::thread thread_;
+  std::atomic<bool> stopping_{false};
+  std::string last_request_;
 };
 
-pine::OperatorConfig make_cfg(int port, bool allow_private = true,
-                              bool fail_on_error = true,
+pine::OperatorConfig make_cfg(int port, bool allow_private = true, bool fail_on_error = true,
                               double timeout = 5.0) {
-    pine::OperatorConfig cfg;
-    cfg.name = "remote";
-    cfg.type_name = "transform_by_remote_pineapple";
-    cfg.params = pine::JsonValue(pine::JsonValue::object_t{
-        {"host", pine::JsonValue("127.0.0.1")},
-        {"port", pine::JsonValue(static_cast<double>(port))},
-        {"endpoint", pine::JsonValue("/execute")},
-        {"allow_private", pine::JsonValue(allow_private)},
-        {"fail_on_error", pine::JsonValue(fail_on_error)},
-        {"timeout", pine::JsonValue(timeout)},
-    });
-    cfg.metadata.common_input = {"a"};
-    cfg.metadata.common_output = {"b"};
-    cfg.metadata.item_input = {"x"};
-    cfg.metadata.item_output = {"y"};
-    return cfg;
+  pine::OperatorConfig cfg;
+  cfg.name = "remote";
+  cfg.type_name = "transform_by_remote_pineapple";
+  cfg.params = pine::JsonValue(pine::JsonValue::object_t{
+      {"host", pine::JsonValue("127.0.0.1")},
+      {"port", pine::JsonValue(static_cast<double>(port))},
+      {"endpoint", pine::JsonValue("/execute")},
+      {"allow_private", pine::JsonValue(allow_private)},
+      {"fail_on_error", pine::JsonValue(fail_on_error)},
+      {"timeout", pine::JsonValue(timeout)},
+  });
+  cfg.metadata.common_input = {"a"};
+  cfg.metadata.common_output = {"b"};
+  cfg.metadata.item_input = {"x"};
+  cfg.metadata.item_output = {"y"};
+  return cfg;
 }
 
 std::unique_ptr<pine::Operator> create_op() {
-    const auto* entry = pine::registry_entry("transform_by_remote_pineapple");
-    REQUIRE(entry != nullptr);
-    return entry->factory();
+  const auto* entry = pine::registry_entry("transform_by_remote_pineapple");
+  REQUIRE(entry != nullptr);
+  return entry->factory();
 }
 
 pine::ColumnFrame build_frame() {
-    std::map<std::string, pine::JsonValue> common{{"a", pine::JsonValue("hello")}};
-    std::vector<std::map<std::string, pine::JsonValue>> items{
-        {{"x", pine::JsonValue("v1")}},
-        {{"x", pine::JsonValue("v2")}},
-    };
-    return pine::ColumnFrame(std::move(common), std::move(items));
+  std::map<std::string, pine::JsonValue> common{{"a", pine::JsonValue("hello")}};
+  std::vector<std::map<std::string, pine::JsonValue>> items{
+      {{"x", pine::JsonValue("v1")}},
+      {{"x", pine::JsonValue("v2")}},
+  };
+  return pine::ColumnFrame(std::move(common), std::move(items));
 }
 
 // Build an OperatorInput from a frame using the standard remote config metadata.
 pine::OperatorInput build_input_from_frame(pine::ColumnFrame& frame, const pine::OperatorConfig& cfg) {
-    auto spec = pine::compute_input_field_spec(cfg);
-    return pine::build_operator_input(frame, cfg.name, spec);
+  auto spec = pine::compute_input_field_spec(cfg);
+  return pine::build_operator_input(frame, cfg.name, spec);
 }
 
 }  // namespace
 
 TEST_CASE("remote_pineapple: ssrf rejects localhost / loopback") {
-    using pine::http::host_is_private;
-    using pine::http::ip_literal_is_private;
+  using pine::http::host_is_private;
+  using pine::http::ip_literal_is_private;
 
-    CHECK(host_is_private("localhost"));
-    CHECK(host_is_private(""));
-    // Case-insensitive: LOCALHOST / LocalHost variants must all reject.
-    CHECK(host_is_private("LOCALHOST"));
-    CHECK(host_is_private("LocalHost"));
-    CHECK(host_is_private("localHOST"));
-    CHECK(ip_literal_is_private("127.0.0.1"));
-    CHECK(ip_literal_is_private("10.1.2.3"));
-    CHECK(ip_literal_is_private("172.16.0.1"));
-    CHECK(ip_literal_is_private("192.168.1.1"));
-    CHECK(ip_literal_is_private("169.254.1.1"));
-    CHECK(ip_literal_is_private("::1"));
-    CHECK(ip_literal_is_private("fc00::1"));
-    CHECK_FALSE(ip_literal_is_private("8.8.8.8"));
-    CHECK_FALSE(ip_literal_is_private("1.1.1.1"));
+  CHECK(host_is_private("localhost"));
+  CHECK(host_is_private(""));
+  // Case-insensitive: LOCALHOST / LocalHost variants must all reject.
+  CHECK(host_is_private("LOCALHOST"));
+  CHECK(host_is_private("LocalHost"));
+  CHECK(host_is_private("localHOST"));
+  CHECK(ip_literal_is_private("127.0.0.1"));
+  CHECK(ip_literal_is_private("10.1.2.3"));
+  CHECK(ip_literal_is_private("172.16.0.1"));
+  CHECK(ip_literal_is_private("192.168.1.1"));
+  CHECK(ip_literal_is_private("169.254.1.1"));
+  CHECK(ip_literal_is_private("::1"));
+  CHECK(ip_literal_is_private("fc00::1"));
+  CHECK_FALSE(ip_literal_is_private("8.8.8.8"));
+  CHECK_FALSE(ip_literal_is_private("1.1.1.1"));
 }
 
 TEST_CASE("remote_pineapple: ssrf rejects obfuscated IPv4 literals") {
-    using pine::http::host_is_private;
-    // Hex form: 0x7f000001 = 127.0.0.1
-    CHECK(host_is_private("0x7f000001"));
-    CHECK(host_is_private("0X7F000001"));
-    // 32-bit integer form: 2130706433 = 127.0.0.1
-    CHECK(host_is_private("2130706433"));
-    // Short-form IPv4: 127.1 = 127.0.0.1 in BSD parser
-    CHECK(host_is_private("127.1"));
-    CHECK(host_is_private("127.0.1"));
-    CHECK(host_is_private("10.1"));
-    // Real hostnames must still pass through (the obfuscation rejector
-    // only fires on shapes that look numeric — not "google.com").
-    std::string reason;
-    CHECK_FALSE(host_is_private("example.com", &reason));
+  using pine::http::host_is_private;
+  // Hex form: 0x7f000001 = 127.0.0.1
+  CHECK(host_is_private("0x7f000001"));
+  CHECK(host_is_private("0X7F000001"));
+  // 32-bit integer form: 2130706433 = 127.0.0.1
+  CHECK(host_is_private("2130706433"));
+  // Short-form IPv4: 127.1 = 127.0.0.1 in BSD parser
+  CHECK(host_is_private("127.1"));
+  CHECK(host_is_private("127.0.1"));
+  CHECK(host_is_private("10.1"));
+  // Real hostnames must still pass through (the obfuscation rejector
+  // only fires on shapes that look numeric — not "google.com").
+  std::string reason;
+  CHECK_FALSE(host_is_private("example.com", &reason));
 }
 
 TEST_CASE("remote_pineapple: sockaddr_is_private dial-time guard") {
-    using pine::http::sockaddr_is_private;
-    sockaddr_in in4{};
-    in4.sin_family = AF_INET;
-    inet_pton(AF_INET, "127.0.0.1", &in4.sin_addr);
-    CHECK(sockaddr_is_private(reinterpret_cast<sockaddr*>(&in4)));
+  using pine::http::sockaddr_is_private;
+  sockaddr_in in4{};
+  in4.sin_family = AF_INET;
+  inet_pton(AF_INET, "127.0.0.1", &in4.sin_addr);
+  CHECK(sockaddr_is_private(reinterpret_cast<sockaddr*>(&in4)));
 
-    inet_pton(AF_INET, "169.254.169.254", &in4.sin_addr);
-    CHECK(sockaddr_is_private(reinterpret_cast<sockaddr*>(&in4)));
+  inet_pton(AF_INET, "169.254.169.254", &in4.sin_addr);
+  CHECK(sockaddr_is_private(reinterpret_cast<sockaddr*>(&in4)));
 
-    inet_pton(AF_INET, "8.8.8.8", &in4.sin_addr);
-    CHECK_FALSE(sockaddr_is_private(reinterpret_cast<sockaddr*>(&in4)));
+  inet_pton(AF_INET, "8.8.8.8", &in4.sin_addr);
+  CHECK_FALSE(sockaddr_is_private(reinterpret_cast<sockaddr*>(&in4)));
 
-    sockaddr_in6 in6{};
-    in6.sin6_family = AF_INET6;
-    inet_pton(AF_INET6, "::1", &in6.sin6_addr);
-    CHECK(sockaddr_is_private(reinterpret_cast<sockaddr*>(&in6)));
+  sockaddr_in6 in6{};
+  in6.sin6_family = AF_INET6;
+  inet_pton(AF_INET6, "::1", &in6.sin6_addr);
+  CHECK(sockaddr_is_private(reinterpret_cast<sockaddr*>(&in6)));
 
-    inet_pton(AF_INET6, "2606:4700:4700::1111", &in6.sin6_addr);
-    CHECK_FALSE(sockaddr_is_private(reinterpret_cast<sockaddr*>(&in6)));
+  inet_pton(AF_INET6, "2606:4700:4700::1111", &in6.sin6_addr);
+  CHECK_FALSE(sockaddr_is_private(reinterpret_cast<sockaddr*>(&in6)));
 
-    CHECK_FALSE(sockaddr_is_private(nullptr));
+  CHECK_FALSE(sockaddr_is_private(nullptr));
 }
 
 TEST_CASE("remote_pineapple: ssrf private range coverage (RFC 6890 / 6598)") {
-    using pine::http::ip_literal_is_private;
-    // CGN — RFC 6598
-    CHECK(ip_literal_is_private("100.64.0.0"));
-    CHECK(ip_literal_is_private("100.96.0.10"));
-    CHECK(ip_literal_is_private("100.127.255.255"));
-    CHECK_FALSE(ip_literal_is_private("100.128.0.0"));  // outside /10
-    CHECK_FALSE(ip_literal_is_private("100.63.255.255"));
-    // Multicast / reserved / broadcast
-    CHECK(ip_literal_is_private("224.0.0.1"));
-    CHECK(ip_literal_is_private("239.255.255.255"));
-    CHECK(ip_literal_is_private("240.0.0.0"));
-    CHECK(ip_literal_is_private("255.255.255.255"));
-    // TEST-NET / documentation / benchmark / 6to4
-    CHECK(ip_literal_is_private("192.0.0.0"));
-    CHECK(ip_literal_is_private("192.0.2.42"));
-    CHECK(ip_literal_is_private("192.88.99.1"));
-    CHECK(ip_literal_is_private("198.18.0.0"));
-    CHECK(ip_literal_is_private("198.19.255.255"));
-    CHECK(ip_literal_is_private("198.51.100.5"));
-    CHECK(ip_literal_is_private("203.0.113.5"));
-    // Real public addresses remain dialable
-    CHECK_FALSE(ip_literal_is_private("8.8.8.8"));
-    CHECK_FALSE(ip_literal_is_private("1.1.1.1"));
-    CHECK_FALSE(ip_literal_is_private("203.0.114.1"));   // just past TEST-NET-3
-    CHECK_FALSE(ip_literal_is_private("198.20.0.0"));    // just past benchmark
+  using pine::http::ip_literal_is_private;
+  // CGN — RFC 6598
+  CHECK(ip_literal_is_private("100.64.0.0"));
+  CHECK(ip_literal_is_private("100.96.0.10"));
+  CHECK(ip_literal_is_private("100.127.255.255"));
+  CHECK_FALSE(ip_literal_is_private("100.128.0.0"));  // outside /10
+  CHECK_FALSE(ip_literal_is_private("100.63.255.255"));
+  // Multicast / reserved / broadcast
+  CHECK(ip_literal_is_private("224.0.0.1"));
+  CHECK(ip_literal_is_private("239.255.255.255"));
+  CHECK(ip_literal_is_private("240.0.0.0"));
+  CHECK(ip_literal_is_private("255.255.255.255"));
+  // TEST-NET / documentation / benchmark / 6to4
+  CHECK(ip_literal_is_private("192.0.0.0"));
+  CHECK(ip_literal_is_private("192.0.2.42"));
+  CHECK(ip_literal_is_private("192.88.99.1"));
+  CHECK(ip_literal_is_private("198.18.0.0"));
+  CHECK(ip_literal_is_private("198.19.255.255"));
+  CHECK(ip_literal_is_private("198.51.100.5"));
+  CHECK(ip_literal_is_private("203.0.113.5"));
+  // Real public addresses remain dialable
+  CHECK_FALSE(ip_literal_is_private("8.8.8.8"));
+  CHECK_FALSE(ip_literal_is_private("1.1.1.1"));
+  CHECK_FALSE(ip_literal_is_private("203.0.114.1"));  // just past TEST-NET-3
+  CHECK_FALSE(ip_literal_is_private("198.20.0.0"));   // just past benchmark
 }
 
 TEST_CASE("remote_pineapple: ssrf IPv6 extended coverage") {
-    using pine::http::ip_literal_is_private;
-    // Multicast (ff00::/8)
-    CHECK(ip_literal_is_private("ff02::1"));
-    CHECK(ip_literal_is_private("ff00::"));
-    // Discard prefix (100::/64)
-    CHECK(ip_literal_is_private("100::"));
-    CHECK(ip_literal_is_private("100::1"));
-    CHECK_FALSE(ip_literal_is_private("100:1::"));  // not in 100::/64
-    // Documentation (2001:db8::/32)
-    CHECK(ip_literal_is_private("2001:db8::"));
-    CHECK(ip_literal_is_private("2001:db8:ffff::1"));
-    CHECK_FALSE(ip_literal_is_private("2001:db9::"));
-    // Public IPv6 remains dialable
-    CHECK_FALSE(ip_literal_is_private("2606:4700:4700::1111"));
-    CHECK_FALSE(ip_literal_is_private("2a00:1450:4001:830::200e"));
+  using pine::http::ip_literal_is_private;
+  // Multicast (ff00::/8)
+  CHECK(ip_literal_is_private("ff02::1"));
+  CHECK(ip_literal_is_private("ff00::"));
+  // Discard prefix (100::/64)
+  CHECK(ip_literal_is_private("100::"));
+  CHECK(ip_literal_is_private("100::1"));
+  CHECK_FALSE(ip_literal_is_private("100:1::"));  // not in 100::/64
+  // Documentation (2001:db8::/32)
+  CHECK(ip_literal_is_private("2001:db8::"));
+  CHECK(ip_literal_is_private("2001:db8:ffff::1"));
+  CHECK_FALSE(ip_literal_is_private("2001:db9::"));
+  // Public IPv6 remains dialable
+  CHECK_FALSE(ip_literal_is_private("2606:4700:4700::1111"));
+  CHECK_FALSE(ip_literal_is_private("2a00:1450:4001:830::200e"));
 }
 
 TEST_CASE("remote_pineapple: init rejects loopback when allow_private=false") {
-    auto op = create_op();
-    pine::OperatorConfig cfg = make_cfg(12345, /*allow_private=*/false);
-    CHECK_THROWS_AS(op->init(cfg), pine::ExecutionError);
+  auto op = create_op();
+  pine::OperatorConfig cfg = make_cfg(12345, /*allow_private=*/false);
+  CHECK_THROWS_AS(op->init(cfg), pine::ExecutionError);
 }
 
 TEST_CASE("remote_pineapple: happy path maps response fields") {
-    std::string body = R"({"common":{"b":"world"},"items":[{"y":"r1"},{"y":"r2"}]})";
-    MockServer srv(body, 200);
+  std::string body = R"({"common":{"b":"world"},"items":[{"y":"r1"},{"y":"r2"}]})";
+  MockServer srv(body, 200);
 
-    auto op = create_op();
-    auto cfg = make_cfg(srv.port());
-    op->init(cfg);
+  auto op = create_op();
+  auto cfg = make_cfg(srv.port());
+  op->init(cfg);
 
-    auto frame = build_frame();
-    pine::OperatorOutput out;
-    auto input = build_input_from_frame(frame, cfg);
-    op->execute(input, out);
+  auto frame = build_frame();
+  pine::OperatorOutput out;
+  auto input = build_input_from_frame(frame, cfg);
+  op->execute(input, out);
 
-    const auto& cw = out.common_writes();
-    REQUIRE(cw.count("b") == 1);
-    CHECK(cw.at("b").as_string() == "world");
+  const auto& cw = out.common_writes();
+  REQUIRE(cw.count("b") == 1);
+  CHECK(cw.at("b").as_string() == "world");
 
-    const auto& iw = out.item_writes();
-    REQUIRE(iw.size() == 2);
-    std::map<int, std::string> by_idx;
-    for (const auto& w : iw) {
-        if (w.field == "y") by_idx[w.index] = w.value.as_string();
+  const auto& iw = out.item_writes();
+  REQUIRE(iw.size() == 2);
+  std::map<int, std::string> by_idx;
+  for (const auto& w : iw) {
+    if (w.field == "y") {
+      by_idx[w.index] = w.value.as_string();
     }
-    CHECK(by_idx.at(0) == "r1");
-    CHECK(by_idx.at(1) == "r2");
+  }
+  CHECK(by_idx.at(0) == "r1");
+  CHECK(by_idx.at(1) == "r2");
 
-    // Verify request body included our local common/item values, keyed by the
-    // local field names (no common_request/item_request override).
-    // R13-1: dump_json(value, 0) now uses compact format (no space after colon).
-    auto req = srv.last_request();
-    CHECK(req.find("\"a\":\"hello\"") != std::string::npos);
-    CHECK(req.find("\"x\":\"v1\"") != std::string::npos);
-    CHECK(req.find("\"x\":\"v2\"") != std::string::npos);
+  // Verify request body included our local common/item values, keyed by the
+  // local field names (no common_request/item_request override).
+  // R13-1: dump_json(value, 0) now uses compact format (no space after colon).
+  auto req = srv.last_request();
+  CHECK(req.find("\"a\":\"hello\"") != std::string::npos);
+  CHECK(req.find("\"x\":\"v1\"") != std::string::npos);
+  CHECK(req.find("\"x\":\"v2\"") != std::string::npos);
 }
 
 TEST_CASE("remote_pineapple: HTTP 500 throws when fail_on_error=true") {
-    MockServer srv(R"({"error":"boom"})", 500);
-    auto op = create_op();
-    auto cfg = make_cfg(srv.port(), /*allow_private=*/true, /*fail_on_error=*/true);
-    op->init(cfg);
-    auto frame = build_frame();
-    pine::OperatorOutput out;
-    auto input = build_input_from_frame(frame, cfg);
-    CHECK_THROWS_AS(op->execute(input, out), pine::ExecutionError);
+  MockServer srv(R"({"error":"boom"})", 500);
+  auto op = create_op();
+  auto cfg = make_cfg(srv.port(), /*allow_private=*/true, /*fail_on_error=*/true);
+  op->init(cfg);
+  auto frame = build_frame();
+  pine::OperatorOutput out;
+  auto input = build_input_from_frame(frame, cfg);
+  CHECK_THROWS_AS(op->execute(input, out), pine::ExecutionError);
 }
 
 TEST_CASE("remote_pineapple: HTTP 500 emits warning when fail_on_error=false") {
-    MockServer srv(R"({"error":"boom"})", 500);
-    auto op = create_op();
-    auto cfg = make_cfg(srv.port(), /*allow_private=*/true, /*fail_on_error=*/false);
-    op->init(cfg);
-    auto frame = build_frame();
-    pine::OperatorOutput out;
-    auto input = build_input_from_frame(frame, cfg);
-    op->execute(input, out);
-    CHECK(out.warning().find("HTTP 500") != std::string::npos);
+  MockServer srv(R"({"error":"boom"})", 500);
+  auto op = create_op();
+  auto cfg = make_cfg(srv.port(), /*allow_private=*/true, /*fail_on_error=*/false);
+  op->init(cfg);
+  auto frame = build_frame();
+  pine::OperatorOutput out;
+  auto input = build_input_from_frame(frame, cfg);
+  op->execute(input, out);
+  CHECK(out.warning().find("HTTP 500") != std::string::npos);
 }
 
 TEST_CASE("remote_pineapple: downstream error field surfaces as warning") {
-    MockServer srv(R"({"common":{},"items":[],"error":"downstream broke"})", 200);
-    auto op = create_op();
-    auto cfg = make_cfg(srv.port(), /*allow_private=*/true, /*fail_on_error=*/false);
-    op->init(cfg);
-    auto frame = build_frame();
-    pine::OperatorOutput out;
-    auto input = build_input_from_frame(frame, cfg);
-    op->execute(input, out);
-    CHECK(out.warning().find("downstream error: downstream broke") != std::string::npos);
+  MockServer srv(R"({"common":{},"items":[],"error":"downstream broke"})", 200);
+  auto op = create_op();
+  auto cfg = make_cfg(srv.port(), /*allow_private=*/true, /*fail_on_error=*/false);
+  op->init(cfg);
+  auto frame = build_frame();
+  pine::OperatorOutput out;
+  auto input = build_input_from_frame(frame, cfg);
+  op->execute(input, out);
+  CHECK(out.warning().find("downstream error: downstream broke") != std::string::npos);
 }
 
 TEST_CASE("remote_pineapple: timeout produces request-failed warning") {
-    MockServer srv(R"({"common":{}})", 200, std::chrono::milliseconds(500));
-    auto op = create_op();
-    auto cfg = make_cfg(srv.port(), /*allow_private=*/true,
-                        /*fail_on_error=*/false, /*timeout=*/0.05);
-    op->init(cfg);
-    auto frame = build_frame();
-    pine::OperatorOutput out;
-    auto input = build_input_from_frame(frame, cfg);
-    op->execute(input, out);
-    CHECK(out.warning().find("request failed") != std::string::npos);
+  MockServer srv(R"({"common":{}})", 200, std::chrono::milliseconds(500));
+  auto op = create_op();
+  auto cfg = make_cfg(srv.port(), /*allow_private=*/true,
+                      /*fail_on_error=*/false, /*timeout=*/0.05);
+  op->init(cfg);
+  auto frame = build_frame();
+  pine::OperatorOutput out;
+  auto input = build_input_from_frame(frame, cfg);
+  op->execute(input, out);
+  CHECK(out.warning().find("request failed") != std::string::npos);
 }

--- a/pine-cpp/tests/test_resource.cpp
+++ b/pine-cpp/tests/test_resource.cpp
@@ -1,5 +1,5 @@
-#include "pine/resource.hpp"
 #include "pine/pine.hpp"
+#include "pine/resource.hpp"
 
 #include <doctest/doctest.h>
 
@@ -13,87 +13,83 @@ using namespace pine;
 namespace {
 
 struct RegistryFixture {
-    RegistryFixture() { resource::reset_fetcher_registry(); }
-    ~RegistryFixture() { resource::reset_fetcher_registry(); }
+  RegistryFixture() {
+    resource::reset_fetcher_registry();
+  }
+  ~RegistryFixture() {
+    resource::reset_fetcher_registry();
+  }
 };
 
 }  // namespace
 
 TEST_CASE("resource: register_resource + snapshot returns loaded values") {
-    resource::Manager mgr;
-    mgr.register_resource(
-        "static_one",
-        []() { return JsonValue(std::string("v1")); },
-        std::chrono::seconds(60));
-    mgr.start();
+  resource::Manager mgr;
+  mgr.register_resource(
+      "static_one", []() { return JsonValue(std::string("v1")); }, std::chrono::seconds(60));
+  mgr.start();
 
-    auto snap = mgr.snapshot();
-    CHECK(snap.count("static_one") == 1);
-    CHECK(snap["static_one"].as_string() == "v1");
-    mgr.stop();
+  auto snap = mgr.snapshot();
+  CHECK(snap.count("static_one") == 1);
+  CHECK(snap["static_one"].as_string() == "v1");
+  mgr.stop();
 }
 
 TEST_CASE("resource: duplicate name throws") {
-    resource::Manager mgr;
-    mgr.register_resource("dup", []() { return JsonValue(1); },
-                          std::chrono::seconds(60));
-    CHECK_THROWS_AS(
-        mgr.register_resource("dup", []() { return JsonValue(2); },
-                              std::chrono::seconds(60)),
-        std::runtime_error);
+  resource::Manager mgr;
+  mgr.register_resource("dup", []() { return JsonValue(1); }, std::chrono::seconds(60));
+  CHECK_THROWS_AS(mgr.register_resource(
+                      "dup", []() { return JsonValue(2); }, std::chrono::seconds(60)),
+                  std::runtime_error);
 }
 
 TEST_CASE("resource: factory registry roundtrip") {
-    RegistryFixture _;
-    int factory_calls = 0;
-    resource::register_fetcher_factory(
-        "test_factory",
-        [&factory_calls](const JsonValue& /*params*/) {
-            factory_calls++;
-            return resource::Fetcher{[]() { return JsonValue(std::string("hello")); }};
-        });
-    CHECK(resource::lookup_fetcher_factory("test_factory") != nullptr);
-    CHECK(resource::lookup_fetcher_factory("missing") == nullptr);
-    auto types = resource::registered_fetcher_types();
-    CHECK(types.size() == 1);
-    CHECK(types[0] == "test_factory");
+  RegistryFixture _;
+  int factory_calls = 0;
+  resource::register_fetcher_factory("test_factory", [&factory_calls](const JsonValue& /*params*/) {
+    factory_calls++;
+    return resource::Fetcher{[]() { return JsonValue(std::string("hello")); }};
+  });
+  CHECK(resource::lookup_fetcher_factory("test_factory") != nullptr);
+  CHECK(resource::lookup_fetcher_factory("missing") == nullptr);
+  auto types = resource::registered_fetcher_types();
+  CHECK(types.size() == 1);
+  CHECK(types[0] == "test_factory");
 
-    Config cfg;
-    cfg.resource_config["r1"] = ResourceEntry{"test_factory", 0, JsonValue{}};
+  Config cfg;
+  cfg.resource_config["r1"] = ResourceEntry{"test_factory", 0, JsonValue{}};
 
-    resource::Manager mgr;
-    mgr.load_from_config(cfg);
-    CHECK(factory_calls == 1);
-    mgr.start();
-    auto snap = mgr.snapshot();
-    CHECK(snap["r1"].as_string() == "hello");
-    mgr.stop();
+  resource::Manager mgr;
+  mgr.load_from_config(cfg);
+  CHECK(factory_calls == 1);
+  mgr.start();
+  auto snap = mgr.snapshot();
+  CHECK(snap["r1"].as_string() == "hello");
+  mgr.stop();
 }
 
 TEST_CASE("resource: load_from_config rejects unknown types") {
-    RegistryFixture _;
-    Config cfg;
-    cfg.resource_config["x"] = ResourceEntry{"unknown_type", 0, JsonValue{}};
+  RegistryFixture _;
+  Config cfg;
+  cfg.resource_config["x"] = ResourceEntry{"unknown_type", 0, JsonValue{}};
 
-    resource::Manager mgr;
-    CHECK_THROWS_AS(mgr.load_from_config(cfg), std::runtime_error);
+  resource::Manager mgr;
+  CHECK_THROWS_AS(mgr.load_from_config(cfg), std::runtime_error);
 }
 
 TEST_CASE("resource: background refresh updates the value") {
-    std::atomic<int> counter{0};
-    resource::Manager mgr;
-    mgr.register_resource(
-        "tick",
-        [&counter]() { return JsonValue(counter.fetch_add(1) + 1); },
-        std::chrono::seconds(1));
-    mgr.start();
+  std::atomic<int> counter{0};
+  resource::Manager mgr;
+  mgr.register_resource(
+      "tick", [&counter]() { return JsonValue(counter.fetch_add(1) + 1); }, std::chrono::seconds(1));
+  mgr.start();
 
-    auto initial = mgr.snapshot()["tick"].as_number();
-    CHECK(initial == 1.0);
+  auto initial = mgr.snapshot()["tick"].as_number();
+  CHECK(initial == 1.0);
 
-    // Wait just over the 1s refresh interval.
-    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
-    auto next = mgr.snapshot()["tick"].as_number();
-    CHECK(next > initial);
-    mgr.stop();
+  // Wait just over the 1s refresh interval.
+  std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+  auto next = mgr.snapshot()["tick"].as_number();
+  CHECK(next > initial);
+  mgr.stop();
 }

--- a/pine-cpp/tests/test_row_frame.cpp
+++ b/pine-cpp/tests/test_row_frame.cpp
@@ -1,7 +1,7 @@
-#include <doctest/doctest.h>
-
-#include "pine/row_frame.hpp"
 #include "pine/frame.hpp"
+#include "pine/row_frame.hpp"
+
+#include <doctest/doctest.h>
 
 #include <cmath>
 #include <limits>
@@ -12,78 +12,77 @@ using namespace pine;
 namespace {
 
 std::unique_ptr<RowFrame> make_row_frame() {
-    std::vector<std::map<std::string, JsonValue>> items;
-    items.push_back({{"id", JsonValue(1.0)}, {"score", JsonValue(10.0)}});
-    items.push_back({{"id", JsonValue(2.0)}, {"score", JsonValue(20.0)}});
-    items.push_back({{"id", JsonValue(3.0)}, {"score", JsonValue(30.0)}});
-    return std::make_unique<RowFrame>(
-        std::map<std::string, JsonValue>{{"region", JsonValue(std::string("us"))}},
-        std::move(items));
+  std::vector<std::map<std::string, JsonValue>> items;
+  items.push_back({{"id", JsonValue(1.0)}, {"score", JsonValue(10.0)}});
+  items.push_back({{"id", JsonValue(2.0)}, {"score", JsonValue(20.0)}});
+  items.push_back({{"id", JsonValue(3.0)}, {"score", JsonValue(30.0)}});
+  return std::make_unique<RowFrame>(
+      std::map<std::string, JsonValue>{{"region", JsonValue(std::string("us"))}}, std::move(items));
 }
 
 }  // namespace
 
 TEST_CASE("RowFrame: construction + reads") {
-    auto frame = make_row_frame();
-    CHECK(frame->item_count() == 3);
-    CHECK(frame->common("region").as_string() == "us");
-    CHECK(frame->item(0, "id").as_number() == 1.0);
-    CHECK(frame->item(2, "score").as_number() == 30.0);
-    CHECK(frame->item_has(0, "score"));
-    CHECK_FALSE(frame->item_has(0, "missing"));
+  auto frame = make_row_frame();
+  CHECK(frame->item_count() == 3);
+  CHECK(frame->common("region").as_string() == "us");
+  CHECK(frame->item(0, "id").as_number() == 1.0);
+  CHECK(frame->item(2, "score").as_number() == 30.0);
+  CHECK(frame->item_has(0, "score"));
+  CHECK_FALSE(frame->item_has(0, "missing"));
 }
 
 TEST_CASE("RowFrame: apply_output runs 5 stages") {
-    auto frame = make_row_frame();
-    OperatorOutput out;
-    out.set_common("region", JsonValue(std::string("eu")));
-    out.set_item(0, "score", JsonValue(11.0));
-    out.add_item({{"id", JsonValue(4.0)}});
-    frame->apply_output(out, "op", false);
-    CHECK(frame->common("region").as_string() == "eu");
-    CHECK(frame->item(0, "score").as_number() == 11.0);
-    CHECK(frame->item_count() == 4);
-    CHECK(frame->item(3, "id").as_number() == 4.0);
+  auto frame = make_row_frame();
+  OperatorOutput out;
+  out.set_common("region", JsonValue(std::string("eu")));
+  out.set_item(0, "score", JsonValue(11.0));
+  out.add_item({{"id", JsonValue(4.0)}});
+  frame->apply_output(out, "op", false);
+  CHECK(frame->common("region").as_string() == "eu");
+  CHECK(frame->item(0, "score").as_number() == 11.0);
+  CHECK(frame->item_count() == 4);
+  CHECK(frame->item(3, "id").as_number() == 4.0);
 }
 
 TEST_CASE("RowFrame: apply_output rejects NaN/Inf") {
-    auto frame = make_row_frame();
-    OperatorOutput out;
-    out.set_common("ratio", JsonValue(std::numeric_limits<double>::quiet_NaN()));
-    CHECK_THROWS_AS(frame->apply_output(out, "op", false), ExecutionError);
+  auto frame = make_row_frame();
+  OperatorOutput out;
+  out.set_common("ratio", JsonValue(std::numeric_limits<double>::quiet_NaN()));
+  CHECK_THROWS_AS(frame->apply_output(out, "op", false), ExecutionError);
 }
 
 TEST_CASE("RowFrame: window view + bounds check") {
-    auto frame = make_row_frame();
-    CHECK_THROWS_AS(frame->make_window_view(0, 4), Error);
-    auto view = frame->make_window_view(1, 2);
-    CHECK(view->item_count() == 2);
-    CHECK(view->item(0, "id").as_number() == 2.0);
-    CHECK(view->item(1, "score").as_number() == 30.0);
-    CHECK(view->common("region").as_string() == "us");
-    // write paths must throw on view
-    CHECK_THROWS_AS(view->set_common("k", JsonValue(1.0)), Error);
-    OperatorOutput empty;
-    CHECK_THROWS_AS(view->apply_output(empty, "op", false), Error);
-    CHECK_THROWS_AS(view->to_result({"region"}, {"id"}), Error);
+  auto frame = make_row_frame();
+  CHECK_THROWS_AS(frame->make_window_view(0, 4), Error);
+  auto view = frame->make_window_view(1, 2);
+  CHECK(view->item_count() == 2);
+  CHECK(view->item(0, "id").as_number() == 2.0);
+  CHECK(view->item(1, "score").as_number() == 30.0);
+  CHECK(view->common("region").as_string() == "us");
+  // write paths must throw on view
+  CHECK_THROWS_AS(view->set_common("k", JsonValue(1.0)), Error);
+  OperatorOutput empty;
+  CHECK_THROWS_AS(view->apply_output(empty, "op", false), Error);
+  CHECK_THROWS_AS(view->to_result({"region"}, {"id"}), Error);
 }
 
 TEST_CASE("make_frame factory selects implementation by storage_mode") {
-    std::map<std::string, JsonValue> common{{"r", JsonValue(std::string("v"))}};
-    std::vector<std::map<std::string, JsonValue>> items{{{"id", JsonValue(1.0)}}};
-    auto col = make_frame("column", common, items);
-    auto row = make_frame("row", common, items);
-    auto fallback = make_frame("", common, items);
+  std::map<std::string, JsonValue> common{{"r", JsonValue(std::string("v"))}};
+  std::vector<std::map<std::string, JsonValue>> items{{{"id", JsonValue(1.0)}}};
+  auto col = make_frame("column", common, items);
+  auto row = make_frame("row", common, items);
+  auto fallback = make_frame("", common, items);
 
-    // Behavioral parity — both impls expose the same logical view.
-    CHECK(col->item_count() == 1);
-    CHECK(row->item_count() == 1);
-    CHECK(fallback->item_count() == 1);
-    CHECK(col->common("r").as_string() == "v");
-    CHECK(row->common("r").as_string() == "v");
+  // Behavioral parity — both impls expose the same logical view.
+  CHECK(col->item_count() == 1);
+  CHECK(row->item_count() == 1);
+  CHECK(fallback->item_count() == 1);
+  CHECK(col->common("r").as_string() == "v");
+  CHECK(row->common("r").as_string() == "v");
 
-    // Implementation discriminated by dynamic_cast.
-    CHECK(dynamic_cast<RowFrame*>(row.get()) != nullptr);
-    CHECK(dynamic_cast<RowFrame*>(col.get()) == nullptr);
-    CHECK(dynamic_cast<RowFrame*>(fallback.get()) == nullptr);  // defaults to column
+  // Implementation discriminated by dynamic_cast.
+  CHECK(dynamic_cast<RowFrame*>(row.get()) != nullptr);
+  CHECK(dynamic_cast<RowFrame*>(col.get()) == nullptr);
+  CHECK(dynamic_cast<RowFrame*>(fallback.get()) == nullptr);  // defaults to column
 }

--- a/pine-cpp/tests/test_stats_provider.cpp
+++ b/pine-cpp/tests/test_stats_provider.cpp
@@ -1,57 +1,65 @@
-#include "pine/pine.hpp"
 #include "pine/operator.hpp"
 #include "pine/operator_input.hpp"
+#include "pine/pine.hpp"
 
 #include <doctest/doctest.h>
 
-#include <memory>
 #include <map>
+#include <memory>
 #include <string>
 
 using namespace pine;
 
 namespace {
-using pine::Engine; // Fix ambiguity with pine::Engine/Engine
+using pine::Engine;  // Fix ambiguity with pine::Engine/Engine
 
 // Provide a global accessor to inject stats
 class StatsMockOp;
 StatsMockOp* g_mock_op = nullptr;
 
 class StatsMockOp : public Operator, public StatsProvider {
-public:
-    std::map<std::string, int64_t> stats;
-    StatsMockOp() { g_mock_op = this; }
-    ~StatsMockOp() { if (g_mock_op == this) g_mock_op = nullptr; }
-    void execute(const OperatorInput&, OperatorOutput&) override {}
-    std::map<std::string, int64_t> operator_stats() const override {
-        return stats;
+ public:
+  std::map<std::string, int64_t> stats;
+  StatsMockOp() {
+    g_mock_op = this;
+  }
+  ~StatsMockOp() {
+    if (g_mock_op == this) {
+      g_mock_op = nullptr;
     }
+  }
+  void execute(const OperatorInput&, OperatorOutput&) override {
+  }
+  std::map<std::string, int64_t> operator_stats() const override {
+    return stats;
+  }
 };
 
 class EmptyStatsMockOp : public Operator, public StatsProvider {
-public:
-    void execute(const OperatorInput&, OperatorOutput&) override {}
-    std::map<std::string, int64_t> operator_stats() const override {
-        return {}; // Exposes StatsProvider but returns empty map
-    }
+ public:
+  void execute(const OperatorInput&, OperatorOutput&) override {
+  }
+  std::map<std::string, int64_t> operator_stats() const override {
+    return {};  // Exposes StatsProvider but returns empty map
+  }
 };
 
 void run_test() {
-    OperatorSchema schema1{
-        .name = "test_stats_mock",
-        .type = OpType::Recall,
-        .description = "mock",
-        .params = {},
-    };
-    register_operator_typed<StatsMockOp>(std::move(schema1));
+  OperatorSchema schema1{
+      .name = "test_stats_mock",
+      .type = OpType::Recall,
+      .description = "mock",
+      .params = {},
+  };
+  register_operator_typed<StatsMockOp>(std::move(schema1));
 
-    OperatorSchema schema2{
-        .name = "test_empty_stats_mock",
-        .type = OpType::Recall,
-        .description = "mock",
-        .params = {},
-    };
-    register_operator_typed<EmptyStatsMockOp>(std::move(schema2));
+  OperatorSchema schema2{
+      .name = "test_empty_stats_mock",
+      .type = OpType::Recall,
+      .description = "mock",
+      .params = {},
+  };
+  register_operator_typed<EmptyStatsMockOp>(std::move(schema2));
 }
 const bool _reg = (run_test(), true);
 
@@ -75,20 +83,20 @@ const char* kConfig = R"({
 }  // namespace
 
 TEST_CASE("stats_provider: engine collects custom stats") {
-    g_mock_op = nullptr;
-    auto cfg = load_config_from_json(kConfig);
-    pine::Engine engine(std::move(cfg));
+  g_mock_op = nullptr;
+  auto cfg = load_config_from_json(kConfig);
+  pine::Engine engine(std::move(cfg));
 
-    auto custom = engine.operator_custom_stats();
-    CHECK(custom.empty()); // initially empty because StatsMockOp has empty stats
+  auto custom = engine.operator_custom_stats();
+  CHECK(custom.empty());  // initially empty because StatsMockOp has empty stats
 
-    REQUIRE(g_mock_op != nullptr);
-    g_mock_op->stats["cache_hits"] = 42;
-    g_mock_op->stats["cache_misses"] = 7;
+  REQUIRE(g_mock_op != nullptr);
+  g_mock_op->stats["cache_hits"] = 42;
+  g_mock_op->stats["cache_misses"] = 7;
 
-    custom = engine.operator_custom_stats();
-    REQUIRE(custom.size() == 1);
-    CHECK(custom.count("mock1") == 1);
-    CHECK(custom["mock1"]["cache_hits"] == 42);
-    CHECK(custom["mock1"]["cache_misses"] == 7);
+  custom = engine.operator_custom_stats();
+  REQUIRE(custom.size() == 1);
+  CHECK(custom.count("mock1") == 1);
+  CHECK(custom["mock1"]["cache_hits"] == 42);
+  CHECK(custom["mock1"]["cache_misses"] == 7);
 }

--- a/pine-cpp/tests/test_trace.cpp
+++ b/pine-cpp/tests/test_trace.cpp
@@ -1,6 +1,6 @@
-#include <doctest/doctest.h>
-
 #include "pine/pine.hpp"
+
+#include <doctest/doctest.h>
 
 #include <chrono>
 
@@ -95,80 +95,80 @@ constexpr const char* kRootDebugConfig = R"({
 })";
 
 Request make_request() {
-    Request req;
-    req.common["x"] = JsonValue(1.0);
-    return req;
+  Request req;
+  req.common["x"] = JsonValue(1.0);
+  return req;
 }
 
 }  // namespace
 
 TEST_CASE("OpTrace: debug=false yields no snapshots, but start_time_us is populated") {
-    Engine engine(load_config_from_json(kBaseConfigNoDebug));
-    auto traced = engine.execute_traced(make_request(), {});
-    REQUIRE(traced.trace.size() == 1);
-    CHECK(traced.trace[0].name == "op");
-    CHECK_FALSE(traced.trace[0].has_input_snapshot);
-    CHECK_FALSE(traced.trace[0].has_output_snapshot);
-    CHECK(traced.trace[0].start_time_us > 0);
+  Engine engine(load_config_from_json(kBaseConfigNoDebug));
+  auto traced = engine.execute_traced(make_request(), {});
+  REQUIRE(traced.trace.size() == 1);
+  CHECK(traced.trace[0].name == "op");
+  CHECK_FALSE(traced.trace[0].has_input_snapshot);
+  CHECK_FALSE(traced.trace[0].has_output_snapshot);
+  CHECK(traced.trace[0].start_time_us > 0);
 }
 
 TEST_CASE("OpTrace: per-op debug=true populates InputSnapshot/OutputSnapshot") {
-    Engine engine(load_config_from_json(kPerOpDebugConfig));
-    auto traced = engine.execute_traced(make_request(), {});
-    REQUIRE(traced.trace.size() == 1);
-    CHECK(traced.trace[0].has_input_snapshot);
-    CHECK(traced.trace[0].has_output_snapshot);
+  Engine engine(load_config_from_json(kPerOpDebugConfig));
+  auto traced = engine.execute_traced(make_request(), {});
+  REQUIRE(traced.trace.size() == 1);
+  CHECK(traced.trace[0].has_input_snapshot);
+  CHECK(traced.trace[0].has_output_snapshot);
 
-    REQUIRE(traced.trace[0].input_snapshot.is_object());
-    const auto* common = traced.trace[0].input_snapshot.find("common");
-    REQUIRE(common != nullptr);
-    REQUIRE(common->is_object());
-    REQUIRE(common->find("x") != nullptr);
-    CHECK(common->find("x")->as_number() == 1.0);
+  REQUIRE(traced.trace[0].input_snapshot.is_object());
+  const auto* common = traced.trace[0].input_snapshot.find("common");
+  REQUIRE(common != nullptr);
+  REQUIRE(common->is_object());
+  REQUIRE(common->find("x") != nullptr);
+  CHECK(common->find("x")->as_number() == 1.0);
 
-    REQUIRE(traced.trace[0].output_snapshot.is_object());
-    const auto* cw = traced.trace[0].output_snapshot.find("common_writes");
-    REQUIRE(cw != nullptr);
-    REQUIRE(cw->is_object());
-    REQUIRE(cw->find("y") != nullptr);
-    CHECK(cw->find("y")->as_number() == 1.0);
+  REQUIRE(traced.trace[0].output_snapshot.is_object());
+  const auto* cw = traced.trace[0].output_snapshot.find("common_writes");
+  REQUIRE(cw != nullptr);
+  REQUIRE(cw->is_object());
+  REQUIRE(cw->find("y") != nullptr);
+  CHECK(cw->find("y")->as_number() == 1.0);
 }
 
 TEST_CASE("OpTrace: root-level debug=true enables snapshots for all ops") {
-    Engine engine(load_config_from_json(kRootDebugConfig));
-    auto traced = engine.execute_traced(make_request(), {});
-    REQUIRE(traced.trace.size() == 1);
-    CHECK(traced.trace[0].has_input_snapshot);
-    CHECK(traced.trace[0].has_output_snapshot);
+  Engine engine(load_config_from_json(kRootDebugConfig));
+  auto traced = engine.execute_traced(make_request(), {});
+  REQUIRE(traced.trace.size() == 1);
+  CHECK(traced.trace[0].has_input_snapshot);
+  CHECK(traced.trace[0].has_output_snapshot);
 }
 
 TEST_CASE("EngineOptions::debug=true overrides per-op default false") {
-    EngineOptions opts;
-    opts.debug = true;
-    Engine engine(load_config_from_json(kBaseConfigNoDebug), opts);
-    auto traced = engine.execute_traced(make_request(), {});
-    REQUIRE(traced.trace.size() == 1);
-    CHECK(traced.trace[0].has_input_snapshot);
-    CHECK(traced.trace[0].has_output_snapshot);
+  EngineOptions opts;
+  opts.debug = true;
+  Engine engine(load_config_from_json(kBaseConfigNoDebug), opts);
+  auto traced = engine.execute_traced(make_request(), {});
+  REQUIRE(traced.trace.size() == 1);
+  CHECK(traced.trace[0].has_input_snapshot);
+  CHECK(traced.trace[0].has_output_snapshot);
 }
 
 TEST_CASE("EngineOptions::debug=false suppresses root-level debug=true") {
-    EngineOptions opts;
-    opts.debug = false;
-    Engine engine(load_config_from_json(kRootDebugConfig), opts);
-    auto traced = engine.execute_traced(make_request(), {});
-    REQUIRE(traced.trace.size() == 1);
-    CHECK_FALSE(traced.trace[0].has_input_snapshot);
-    CHECK_FALSE(traced.trace[0].has_output_snapshot);
+  EngineOptions opts;
+  opts.debug = false;
+  Engine engine(load_config_from_json(kRootDebugConfig), opts);
+  auto traced = engine.execute_traced(make_request(), {});
+  REQUIRE(traced.trace.size() == 1);
+  CHECK_FALSE(traced.trace[0].has_input_snapshot);
+  CHECK_FALSE(traced.trace[0].has_output_snapshot);
 }
 
 TEST_CASE("OpTrace::start_time_us is close to wall-clock time") {
-    using namespace std::chrono;
-    int64_t before = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
-    Engine engine(load_config_from_json(kBaseConfigNoDebug));
-    auto traced = engine.execute_traced(make_request(), {});
-    int64_t after = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
-    REQUIRE(traced.trace.size() == 1);
-    CHECK(traced.trace[0].start_time_us >= before);
-    CHECK(traced.trace[0].start_time_us <= after);
+  using namespace std::chrono;
+  int64_t before = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+  Engine engine(load_config_from_json(kBaseConfigNoDebug));
+  auto traced = engine.execute_traced(make_request(), {});
+  int64_t after = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+  REQUIRE(traced.trace.size() == 1);
+  CHECK(traced.trace[0].start_time_us >= before);
+  CHECK(traced.trace[0].start_time_us <= after);
 }


### PR DESCRIPTION
## Summary

- Add `.clang-format` config for pine-cpp (Google style base, IndentWidth 2, ColumnLimit 110, InsertBraces true)
- Apply clang-format to all C++ source files (91 files)
- Extend `.githooks/pre-push` to cover pine-python (ruff), Java (mvn checkstyle), and C++ (clang-format) alongside existing apple and Go lint

## Test plan

- [x] `clang-format --dry-run --Werror` passes all C++ files
- [x] `pine_cpp_tests` — 145 passed after reformat
- [x] `bash .githooks/pre-push` exits 0