### PR TITLE
feat(bench): redesign cross-runtime benchmark + fix CI timeout issues

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -46,8 +46,8 @@ jobs:
 
       - name: Install system deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          timeout 300 sudo apt-get update
+          timeout 300 sudo apt-get install -y --no-install-recommends \
             cmake build-essential libluajit-5.1-dev libcurl4-openssl-dev
 
       - name: Install hey

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -7,7 +7,16 @@ on:
     inputs:
       sizes:
         description: "DAG sizes (comma-separated)"
-        default: "5,15,50,100,200,500"
+        default: "5,50,100,500"
+      modes:
+        description: "Storage modes (comma-separated)"
+        default: "row,column"
+      parallelism:
+        description: "DAG fan-out widths (comma-separated)"
+        default: ""
+      ops:
+        description: "Operator types (comma-separated)"
+        default: "cpu,io,mixed"
       skip:
         description: "Runtimes to skip (comma-separated)"
         default: ""
@@ -18,7 +27,7 @@ permissions:
 jobs:
   cross-runtime-benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -35,10 +44,6 @@ jobs:
           java-version: "21"
           cache: maven
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
       - name: Install system deps
         run: |
           sudo apt-get update
@@ -47,9 +52,6 @@ jobs:
 
       - name: Install hey
         run: go install github.com/rakyll/hey@latest
-
-      - name: Install pine-python
-        run: pip install -e pine-python/
 
       - name: Stop unneeded services for isolation
         run: |
@@ -76,7 +78,6 @@ jobs:
             fi
             if [ -f /tmp/bench_prev/report.txt ]; then
               echo "found=true" >> "$GITHUB_OUTPUT"
-              echo "run_id=$PREV_RUN_ID" >> "$GITHUB_OUTPUT"
             else
               echo "found=false" >> "$GITHUB_OUTPUT"
             fi
@@ -86,9 +87,15 @@ jobs:
 
       - name: Run cross-runtime benchmark
         run: |
-          SIZES="${{ inputs.sizes || '5,15,50,100,200,500' }}"
+          SIZES="${{ inputs.sizes || '5,50,100,500' }}"
+          MODES="${{ inputs.modes || 'row,column' }}"
+          PARALLELISM="${{ inputs.parallelism || '' }}"
+          OPS="${{ inputs.ops || 'cpu,io,mixed' }}"
           SKIP="${{ inputs.skip || '' }}"
-          ARGS="--sizes $SIZES"
+          ARGS="--sizes $SIZES --modes $MODES --ops $OPS"
+          if [ -n "$PARALLELISM" ]; then
+            ARGS="$ARGS --parallelism $PARALLELISM"
+          fi
           if [ -n "$SKIP" ]; then
             ARGS="$ARGS --skip $SKIP"
           fi
@@ -113,7 +120,7 @@ jobs:
             if [ -f /tmp/bench_cross_runtime/comparison.txt ]; then
               echo "#### Delta vs previous run"
               echo '```text'
-              cat /tmp/bench_cross_runtime/comparison.txt
+              head -50 /tmp/bench_cross_runtime/comparison.txt
               echo '```'
               echo ""
             fi
@@ -131,7 +138,7 @@ jobs:
           path: |
             /tmp/bench_cross_runtime/report.txt
             /tmp/bench_cross_runtime/comparison.txt
-            /tmp/bench_cross_runtime/phase*.csv
+            /tmp/bench_cross_runtime/*.csv
           retention-days: 30
 
       - name: Notify via Bark
@@ -147,8 +154,7 @@ jobs:
           if [ -f /tmp/bench_cross_runtime/comparison.txt ]; then
             BODY=$(head -20 /tmp/bench_cross_runtime/comparison.txt)
           elif [ -f /tmp/bench_cross_runtime/report.txt ]; then
-            BODY=$(grep -A 100 "Phase 3: Max throughput" /tmp/bench_cross_runtime/report.txt \
-              | grep -E "^\s+(go|java|python|cpp)" | head -8)
+            BODY=$(grep -E "^\s+(go|java|cpp)" /tmp/bench_cross_runtime/report.txt | head -12)
           else
             BODY="No report generated. Check logs."
           fi

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       sizes:
         description: "DAG sizes (comma-separated)"
-        default: "5,50,100,500"
+        default: "5,50,100,200"
       modes:
         description: "Storage modes (comma-separated)"
         default: "row,column"
@@ -87,7 +87,7 @@ jobs:
 
       - name: Run cross-runtime benchmark
         run: |
-          SIZES="${{ inputs.sizes || '5,50,100,500' }}"
+          SIZES="${{ inputs.sizes || '5,50,100,200' }}"
           MODES="${{ inputs.modes || 'row,column' }}"
           PARALLELISM="${{ inputs.parallelism || '' }}"
           OPS="${{ inputs.ops || 'cpu,io,mixed' }}"

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -120,7 +120,7 @@ jobs:
             if [ -f /tmp/bench_cross_runtime/comparison.txt ]; then
               echo "#### Delta vs previous run"
               echo '```text'
-              head -50 /tmp/bench_cross_runtime/comparison.txt
+              cat /tmp/bench_cross_runtime/comparison.txt
               echo '```'
               echo ""
             fi

--- a/.github/workflows/nightly-diff-fuzz.yml
+++ b/.github/workflows/nightly-diff-fuzz.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   differential-fuzz:
     runs-on: ubuntu-latest
-    timeout-minutes: 350
+    timeout-minutes: 355
     steps:
       - uses: actions/checkout@v6
 
@@ -59,26 +59,12 @@ jobs:
         working-directory: pine-cpp
 
       - name: Run differential fuzz
-        timeout-minutes: 355
+        timeout-minutes: 350
         run: |
           set -o pipefail
-          # Weekend (Saturday UTC) gets 100k rounds + shrink for deeper coverage;
-          # weekdays get 10k. Manual dispatch uses the input value as-is.
-          if [ -n "${{ inputs.rounds }}" ]; then
-            ROUNDS="${{ inputs.rounds }}"
-            EXTRA_FLAGS=""
-          elif [ "$(date -u +%u)" = "6" ]; then
-            ROUNDS=100000
-            EXTRA_FLAGS="--shrink"
-          else
-            ROUNDS=10000
-            EXTRA_FLAGS=""
-          fi
-          # Use shell timeout (350m) so the step exits with code 124 on
-          # timeout instead of being cancelled — allows subsequent steps
-          # (evaluate, issue creation) to run normally. The step-level
-          # timeout-minutes: 355 remains as a safety net.
-          timeout 350m python3 scripts/differential-fuzz.py \
+          ROUNDS="${{ inputs.rounds || '10000' }}"
+          EXTRA_FLAGS=""
+          timeout 340m python3 scripts/differential-fuzz.py \
             --rounds "$ROUNDS" \
             --stability-runs ${{ inputs.stability-runs || '3' }} \
             --go-bin pine-go/pineapple-run \

--- a/.github/workflows/nightly-diff-fuzz.yml
+++ b/.github/workflows/nightly-diff-fuzz.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Install C++ build deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          timeout 300 sudo apt-get update
+          timeout 300 sudo apt-get install -y --no-install-recommends \
             cmake ninja-build g++-13 libluajit-5.1-dev libcurl4-openssl-dev
 
       - name: Build Go binary
@@ -183,7 +183,7 @@ jobs:
           )"
 
       - name: Open issue on workflow failure
-        if: failure()
+        if: failure() || cancelled()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/nightly-diff-fuzz.yml
+++ b/.github/workflows/nightly-diff-fuzz.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Run differential fuzz
         timeout-minutes: 355
         run: |
+          set -o pipefail
           # Weekend (Saturday UTC) gets 100k rounds + shrink for deeper coverage;
           # weekdays get 10k. Manual dispatch uses the input value as-is.
           if [ -n "${{ inputs.rounds }}" ]; then
@@ -73,7 +74,11 @@ jobs:
             ROUNDS=10000
             EXTRA_FLAGS=""
           fi
-          python3 scripts/differential-fuzz.py \
+          # Use shell timeout (350m) so the step exits with code 124 on
+          # timeout instead of being cancelled — allows subsequent steps
+          # (evaluate, issue creation) to run normally. The step-level
+          # timeout-minutes: 355 remains as a safety net.
+          timeout 350m python3 scripts/differential-fuzz.py \
             --rounds "$ROUNDS" \
             --stability-runs ${{ inputs.stability-runs || '3' }} \
             --go-bin pine-go/pineapple-run \
@@ -81,7 +86,8 @@ jobs:
             --engines go,python,java,cpp \
             --save-dir /tmp/diff-fuzz-nightly \
             $EXTRA_FLAGS \
-            2>&1 | tee diff-fuzz-output.log; echo $? > /tmp/fuzz-exit-code
+            2>&1 | tee diff-fuzz-output.log
+          echo ${PIPESTATUS[0]} > /tmp/fuzz-exit-code
 
       - name: Evaluate results
         if: always()

--- a/apple_generated/__init__.py
+++ b/apple_generated/__init__.py
@@ -8,6 +8,8 @@ from .operators import RecallResourceOp
 from .operators import RecallStaticOp
 from .operators import ReorderShuffleBySaltOp
 from .operators import ReorderSortOp
+from .operators import TransformBenchCpuOp
+from .operators import TransformBenchSleepOp
 from .operators import TransformByLuaOp
 from .operators import TransformByRemotePineappleOp
 from .operators import TransformCopyOp
@@ -18,4 +20,4 @@ from .operators import TransformRedisSetOp
 from .operators import TransformResourceLookupOp
 from .operators import TransformSizeOp
 
-__all__ = ["FilterConditionOp", "FilterPaginateOp", "FilterTruncateOp", "MergeDedupOp", "ObserveLogOp", "RecallResourceOp", "RecallStaticOp", "ReorderShuffleBySaltOp", "ReorderSortOp", "TransformByLuaOp", "TransformByRemotePineappleOp", "TransformCopyOp", "TransformDispatchOp", "TransformNormalizeOp", "TransformRedisGetOp", "TransformRedisSetOp", "TransformResourceLookupOp", "TransformSizeOp", ]
+__all__ = ["FilterConditionOp", "FilterPaginateOp", "FilterTruncateOp", "MergeDedupOp", "ObserveLogOp", "RecallResourceOp", "RecallStaticOp", "ReorderShuffleBySaltOp", "ReorderSortOp", "TransformBenchCpuOp", "TransformBenchSleepOp", "TransformByLuaOp", "TransformByRemotePineappleOp", "TransformCopyOp", "TransformDispatchOp", "TransformNormalizeOp", "TransformRedisGetOp", "TransformRedisSetOp", "TransformResourceLookupOp", "TransformSizeOp", ]

--- a/apple_generated/operators.py
+++ b/apple_generated/operators.py
@@ -333,6 +333,80 @@ class ReorderSortOp(BaseOp):
             name=name or "",
         )
 
+class TransformBenchCpuOp(BaseOp):
+    """Operator: transform_bench_cpu"""
+    _name = "transform_bench_cpu"
+    _params_schema = {
+        "iterations": {"type": "int64", "required": False, "default": 100},
+    }
+
+    def __call__(
+        self,
+        *,
+        iterations: int = 100,
+        common_input: list[str] | None = None,
+        common_output: list[str] | None = None,
+        item_input: list[str] | None = None,
+        item_output: list[str] | None = None,
+        item_defaults: dict | None = None,
+        common_defaults: dict | None = None,
+        consumes_row_set: bool = False,
+        debug: bool = False,
+        name: str | None = None,
+    ) -> "TransformBenchCpuOp":
+        _params = {
+            "iterations": iterations,
+        }
+        return self._apply(
+            params=_params,
+            common_input=common_input,
+            common_output=common_output,
+            item_input=item_input,
+            item_output=item_output,
+            item_defaults=item_defaults,
+            common_defaults=common_defaults,
+            consumes_row_set=consumes_row_set,
+            debug=debug,
+            name=name or "",
+        )
+
+class TransformBenchSleepOp(BaseOp):
+    """Operator: transform_bench_sleep"""
+    _name = "transform_bench_sleep"
+    _params_schema = {
+        "delay_ms": {"type": "int64", "required": False, "default": 5},
+    }
+
+    def __call__(
+        self,
+        *,
+        delay_ms: int = 5,
+        common_input: list[str] | None = None,
+        common_output: list[str] | None = None,
+        item_input: list[str] | None = None,
+        item_output: list[str] | None = None,
+        item_defaults: dict | None = None,
+        common_defaults: dict | None = None,
+        consumes_row_set: bool = False,
+        debug: bool = False,
+        name: str | None = None,
+    ) -> "TransformBenchSleepOp":
+        _params = {
+            "delay_ms": delay_ms,
+        }
+        return self._apply(
+            params=_params,
+            common_input=common_input,
+            common_output=common_output,
+            item_input=item_input,
+            item_output=item_output,
+            item_defaults=item_defaults,
+            common_defaults=common_defaults,
+            consumes_row_set=consumes_row_set,
+            debug=debug,
+            name=name or "",
+        )
+
 class TransformByLuaOp(BaseOp):
     """Operator: transform_by_lua"""
     _name = "transform_by_lua"

--- a/doc/operators/README.md
+++ b/doc/operators/README.md
@@ -41,8 +41,8 @@
 
 | Operator | Description |
 |----------|-------------|
-| [transform_bench_cpu](transform_bench_cpu.md) | Benchmark-only CPU-bound operator. Computes iterative fib per item. |
-| [transform_bench_sleep](transform_bench_sleep.md) | Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation. |
+| [transform_bench_cpu](transform_bench_cpu.md) | Benchmark-only CPU-bound operator. Computes iterative fib per item. Not available in pine-python. |
+| [transform_bench_sleep](transform_bench_sleep.md) | Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation. Not available in pine-python. |
 | [transform_by_lua](transform_by_lua.md) | Executes a Lua script for per-item or per-common computation. |
 | [transform_by_remote_pineapple](transform_by_remote_pineapple.md) | Calls a downstream Pineapple service and maps response fields back to the local frame. |
 | [transform_copy](transform_copy.md) | Copies field values between common and item dimensions. |

--- a/doc/operators/README.md
+++ b/doc/operators/README.md
@@ -41,6 +41,8 @@
 
 | Operator | Description |
 |----------|-------------|
+| [transform_bench_cpu](transform_bench_cpu.md) | Benchmark-only CPU-bound operator. Computes iterative fib per item. |
+| [transform_bench_sleep](transform_bench_sleep.md) | Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation. |
 | [transform_by_lua](transform_by_lua.md) | Executes a Lua script for per-item or per-common computation. |
 | [transform_by_remote_pineapple](transform_by_remote_pineapple.md) | Calls a downstream Pineapple service and maps response fields back to the local frame. |
 | [transform_copy](transform_copy.md) | Copies field values between common and item dimensions. |

--- a/doc/operators/transform_bench_cpu.md
+++ b/doc/operators/transform_bench_cpu.md
@@ -1,0 +1,31 @@
+# transform_bench_cpu
+
+**Type**: Transform
+
+Benchmark-only CPU-bound operator. Computes iterative fib per item.
+
+## Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| iterations | int64 | No | `100` | Number of fib(32) computations per item. |
+
+## Metadata Contract
+
+| Field | Typical Usage |
+|-------|---------------|
+| CommonInput | - |
+| CommonOutput | - |
+| ItemInput | - |
+| ItemOutput | - |
+
+## DSL Usage
+
+```python
+flow.transform_bench_cpu(
+    iterations=...,
+    common_input=[...],
+    item_input=[...],
+    item_output=[...],
+)
+```

--- a/doc/operators/transform_bench_cpu.md
+++ b/doc/operators/transform_bench_cpu.md
@@ -2,7 +2,7 @@
 
 **Type**: Transform
 
-Benchmark-only CPU-bound operator. Computes iterative fib per item.
+Benchmark-only CPU-bound operator. Computes iterative fib per item. Not available in pine-python.
 
 ## Parameters
 

--- a/doc/operators/transform_bench_sleep.md
+++ b/doc/operators/transform_bench_sleep.md
@@ -1,0 +1,31 @@
+# transform_bench_sleep
+
+**Type**: Transform
+
+Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation.
+
+## Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| delay_ms | int64 | No | `5` | Milliseconds to sleep per operator invocation. |
+
+## Metadata Contract
+
+| Field | Typical Usage |
+|-------|---------------|
+| CommonInput | - |
+| CommonOutput | - |
+| ItemInput | - |
+| ItemOutput | - |
+
+## DSL Usage
+
+```python
+flow.transform_bench_sleep(
+    delay_ms=...,
+    common_input=[...],
+    item_input=[...],
+    item_output=[...],
+)
+```

--- a/doc/operators/transform_bench_sleep.md
+++ b/doc/operators/transform_bench_sleep.md
@@ -2,7 +2,7 @@
 
 **Type**: Transform
 
-Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation.
+Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation. Not available in pine-python.
 
 ## Parameters
 

--- a/pine-cpp/CMakeLists.txt
+++ b/pine-cpp/CMakeLists.txt
@@ -88,6 +88,8 @@ add_library(pine_cpp_core OBJECT
     operators/recall/recall_static.cpp
     operators/reorder/reorder_shuffle_by_salt.cpp
     operators/reorder/reorder_sort.cpp
+    operators/transform/transform_bench_cpu.cpp
+    operators/transform/transform_bench_sleep.cpp
     operators/transform/transform_by_lua.cpp
     operators/transform/transform_copy.cpp
     operators/transform/transform_dispatch.cpp

--- a/pine-cpp/operators/transform/transform_bench_cpu.cpp
+++ b/pine-cpp/operators/transform/transform_bench_cpu.cpp
@@ -39,7 +39,6 @@ class TransformBenchCpuOp : public Operator, public ConcurrentSafe {
     if (it != cfg.params.as_object().end() && it->second.is_number()) {
       iterations_ = static_cast<int>(it->second.as_number());
     }
-    item_output_ = cfg.metadata.item_output;
   }
 
   void execute(const OperatorInput& input, OperatorOutput& out) override {
@@ -51,13 +50,13 @@ class TransformBenchCpuOp : public Operator, public ConcurrentSafe {
 
  private:
   int iterations_ = 100;
-  std::vector<std::string> item_output_;
 };
 
 static const OperatorSchema k_transform_bench_cpu_schema{
     .name = "transform_bench_cpu",
     .type = OpType::Transform,
-    .description = "Benchmark-only CPU-bound operator. Computes iterative fib per item.",
+    .description =
+        "Benchmark-only CPU-bound operator. Computes iterative fib per item. Not available in pine-python.",
     .params =
         {
             {"iterations",

--- a/pine-cpp/operators/transform/transform_bench_cpu.cpp
+++ b/pine-cpp/operators/transform/transform_bench_cpu.cpp
@@ -1,0 +1,72 @@
+#include "pine/operator.hpp"
+
+#include <cstdint>
+
+#include "operators/_helpers.hpp"
+
+namespace pine {
+
+namespace {
+
+int64_t fib(int n) {
+  if (n <= 1) {
+    return n;
+  }
+  int64_t a = 0, b = 1;
+  for (int i = 2; i <= n; ++i) {
+    int64_t tmp = a + b;
+    a = b;
+    b = tmp;
+  }
+  return b;
+}
+
+double cpu_work(int iterations) {
+  double acc = 0;
+  for (int i = 0; i < iterations; ++i) {
+    acc += static_cast<double>(fib(32));
+    acc /= 1.000001;
+  }
+  return acc;
+}
+
+}  // namespace
+
+class TransformBenchCpuOp : public Operator, public ConcurrentSafe {
+ public:
+  void init(const OperatorConfig& cfg) override {
+    auto it = cfg.params.as_object().find("iterations");
+    if (it != cfg.params.as_object().end() && it->second.is_number()) {
+      iterations_ = static_cast<int>(it->second.as_number());
+    }
+    item_output_ = cfg.metadata.item_output;
+  }
+
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    for (std::size_t i = 0; i < input.item_count(); ++i) {
+      double result = cpu_work(iterations_);
+      out.set_item(static_cast<int>(i), "_bench_result", JsonValue(result));
+    }
+  }
+
+ private:
+  int iterations_ = 100;
+  std::vector<std::string> item_output_;
+};
+
+static const OperatorSchema k_transform_bench_cpu_schema{
+    .name = "transform_bench_cpu",
+    .type = OpType::Transform,
+    .description = "Benchmark-only CPU-bound operator. Computes iterative fib per item.",
+    .params =
+        {
+            {"iterations",
+             {.type = "int",
+              .required = false,
+              .default_value = JsonValue(100.0),
+              .description = "Number of fib(32) computations per item."}},
+        },
+};
+PINE_REGISTER_OPERATOR_T(TransformBenchCpuOp, k_transform_bench_cpu_schema)
+
+}  // namespace pine

--- a/pine-cpp/operators/transform/transform_bench_sleep.cpp
+++ b/pine-cpp/operators/transform/transform_bench_sleep.cpp
@@ -14,7 +14,6 @@ class TransformBenchSleepOp : public Operator, public ConcurrentSafe {
     if (it != cfg.params.as_object().end() && it->second.is_number()) {
       delay_ms_ = static_cast<int>(it->second.as_number());
     }
-    item_output_ = cfg.metadata.item_output;
   }
 
   void execute(const OperatorInput& input, OperatorOutput& out) override {
@@ -26,13 +25,14 @@ class TransformBenchSleepOp : public Operator, public ConcurrentSafe {
 
  private:
   int delay_ms_ = 5;
-  std::vector<std::string> item_output_;
 };
 
 static const OperatorSchema k_transform_bench_sleep_schema{
     .name = "transform_bench_sleep",
     .type = OpType::Transform,
-    .description = "Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation.",
+    .description =
+        "Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation. Not available in "
+        "pine-python.",
     .params =
         {
             {"delay_ms",

--- a/pine-cpp/operators/transform/transform_bench_sleep.cpp
+++ b/pine-cpp/operators/transform/transform_bench_sleep.cpp
@@ -1,0 +1,47 @@
+#include "pine/operator.hpp"
+
+#include <chrono>
+#include <thread>
+
+#include "operators/_helpers.hpp"
+
+namespace pine {
+
+class TransformBenchSleepOp : public Operator, public ConcurrentSafe {
+ public:
+  void init(const OperatorConfig& cfg) override {
+    auto it = cfg.params.as_object().find("delay_ms");
+    if (it != cfg.params.as_object().end() && it->second.is_number()) {
+      delay_ms_ = static_cast<int>(it->second.as_number());
+    }
+    item_output_ = cfg.metadata.item_output;
+  }
+
+  void execute(const OperatorInput& input, OperatorOutput& out) override {
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms_));
+    for (std::size_t i = 0; i < input.item_count(); ++i) {
+      out.set_item(static_cast<int>(i), "_bench_slept", JsonValue(true));
+    }
+  }
+
+ private:
+  int delay_ms_ = 5;
+  std::vector<std::string> item_output_;
+};
+
+static const OperatorSchema k_transform_bench_sleep_schema{
+    .name = "transform_bench_sleep",
+    .type = OpType::Transform,
+    .description = "Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation.",
+    .params =
+        {
+            {"delay_ms",
+             {.type = "int",
+              .required = false,
+              .default_value = JsonValue(5.0),
+              .description = "Milliseconds to sleep per operator invocation."}},
+        },
+};
+PINE_REGISTER_OPERATOR_T(TransformBenchSleepOp, k_transform_bench_sleep_schema)
+
+}  // namespace pine

--- a/pine-go/operators/all.go
+++ b/pine-go/operators/all.go
@@ -5,6 +5,7 @@
 package operators
 
 import (
+	_ "github.com/Liam0205/pineapple/pine-go/operators/bench"
 	_ "github.com/Liam0205/pineapple/pine-go/operators/transform"
 	_ "github.com/Liam0205/pineapple/pine-go/operators/filter"
 	_ "github.com/Liam0205/pineapple/pine-go/operators/lua"

--- a/pine-go/operators/bench/bench_cpu.go
+++ b/pine-go/operators/bench/bench_cpu.go
@@ -1,0 +1,71 @@
+package bench
+
+import (
+	"context"
+
+	pine "github.com/Liam0205/pineapple/pine-go"
+)
+
+func init() {
+	pine.Register(pine.OperatorSchema{
+		Name:        "transform_bench_cpu",
+		Type:        pine.OpTypeTransform,
+		Description: "Benchmark-only CPU-bound operator. Computes iterative fib per item.",
+		Params: map[string]pine.ParamSpec{
+			"iterations": {Type: "int64", Required: false, Default: int64(100), Description: "Number of fib(32) computations per item."},
+		},
+	}, func() pine.Operator {
+		return &BenchCPUOp{}
+	})
+}
+
+type BenchCPUOp struct {
+	pine.MetadataHolder
+	pine.ConcurrentSafeMarker
+	iterations int
+}
+
+func (o *BenchCPUOp) Init(params map[string]any) error {
+	if v, ok := params["iterations"]; ok {
+		switch n := v.(type) {
+		case int64:
+			o.iterations = int(n)
+		case float64:
+			o.iterations = int(n)
+		default:
+			o.iterations = 100
+		}
+	} else {
+		o.iterations = 100
+	}
+	return nil
+}
+
+func (o *BenchCPUOp) Execute(_ context.Context, in *pine.OperatorInput, out *pine.OperatorOutput) error {
+	n := in.ItemCount()
+	for i := 0; i < n; i++ {
+		result := cpuWork(o.iterations)
+		out.SetItem(i, "_bench_result", result)
+	}
+	return nil
+}
+
+func cpuWork(iterations int) float64 {
+	var acc float64
+	for i := 0; i < iterations; i++ {
+		acc += float64(fib(32))
+		acc /= 1.000001
+	}
+	return acc
+}
+
+func fib(n int) int64 {
+	if n <= 1 {
+		return int64(n)
+	}
+	var a, b int64 = 0, 1
+	for i := 2; i <= n; i++ {
+		a, b = b, a+b
+	}
+	return b
+}

--- a/pine-go/operators/bench/bench_cpu.go
+++ b/pine-go/operators/bench/bench_cpu.go
@@ -10,7 +10,7 @@ func init() {
 	pine.Register(pine.OperatorSchema{
 		Name:        "transform_bench_cpu",
 		Type:        pine.OpTypeTransform,
-		Description: "Benchmark-only CPU-bound operator. Computes iterative fib per item.",
+		Description: "Benchmark-only CPU-bound operator. Computes iterative fib per item. Not available in pine-python.",
 		Params: map[string]pine.ParamSpec{
 			"iterations": {Type: "int64", Required: false, Default: int64(100), Description: "Number of fib(32) computations per item."},
 		},

--- a/pine-go/operators/bench/bench_sleep.go
+++ b/pine-go/operators/bench/bench_sleep.go
@@ -11,7 +11,7 @@ func init() {
 	pine.Register(pine.OperatorSchema{
 		Name:        "transform_bench_sleep",
 		Type:        pine.OpTypeTransform,
-		Description: "Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation.",
+		Description: "Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation. Not available in pine-python.",
 		Params: map[string]pine.ParamSpec{
 			"delay_ms": {Type: "int64", Required: false, Default: int64(5), Description: "Milliseconds to sleep per operator invocation."},
 		},

--- a/pine-go/operators/bench/bench_sleep.go
+++ b/pine-go/operators/bench/bench_sleep.go
@@ -1,0 +1,56 @@
+package bench
+
+import (
+	"context"
+	"time"
+
+	pine "github.com/Liam0205/pineapple/pine-go"
+)
+
+func init() {
+	pine.Register(pine.OperatorSchema{
+		Name:        "transform_bench_sleep",
+		Type:        pine.OpTypeTransform,
+		Description: "Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation.",
+		Params: map[string]pine.ParamSpec{
+			"delay_ms": {Type: "int64", Required: false, Default: int64(5), Description: "Milliseconds to sleep per operator invocation."},
+		},
+	}, func() pine.Operator {
+		return &BenchSleepOp{}
+	})
+}
+
+type BenchSleepOp struct {
+	pine.MetadataHolder
+	pine.ConcurrentSafeMarker
+	delayMS int
+}
+
+func (o *BenchSleepOp) Init(params map[string]any) error {
+	if v, ok := params["delay_ms"]; ok {
+		switch n := v.(type) {
+		case int64:
+			o.delayMS = int(n)
+		case float64:
+			o.delayMS = int(n)
+		default:
+			o.delayMS = 5
+		}
+	} else {
+		o.delayMS = 5
+	}
+	return nil
+}
+
+func (o *BenchSleepOp) Execute(ctx context.Context, in *pine.OperatorInput, out *pine.OperatorOutput) error {
+	select {
+	case <-time.After(time.Duration(o.delayMS) * time.Millisecond):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	n := in.ItemCount()
+	for i := 0; i < n; i++ {
+		out.SetItem(i, "_bench_slept", true)
+	}
+	return nil
+}

--- a/pine-java/src/main/java/page/liam/pine/operators/AllOperators.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/AllOperators.java
@@ -278,5 +278,29 @@ public class AllOperators {
                                         "Prefix prepended to each log line.")
                         )),
                 ObserveLog::new);
+
+        // 19. transform_bench_cpu
+        Registry.registerGlobal(
+                new OperatorSchema(
+                        "transform_bench_cpu",
+                        OperatorType.TRANSFORM,
+                        "Benchmark-only CPU-bound operator. Computes iterative fib per item.",
+                        Map.of(
+                                "iterations", ParamSpec.optional("int", 100,
+                                        "Number of fib(32) computations per item.")
+                        )),
+                TransformBenchCpu::new);
+
+        // 20. transform_bench_sleep
+        Registry.registerGlobal(
+                new OperatorSchema(
+                        "transform_bench_sleep",
+                        OperatorType.TRANSFORM,
+                        "Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation.",
+                        Map.of(
+                                "delay_ms", ParamSpec.optional("int", 5,
+                                        "Milliseconds to sleep per operator invocation.")
+                        )),
+                TransformBenchSleep::new);
     }
 }

--- a/pine-java/src/main/java/page/liam/pine/operators/AllOperators.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/AllOperators.java
@@ -284,7 +284,7 @@ public class AllOperators {
                 new OperatorSchema(
                         "transform_bench_cpu",
                         OperatorType.TRANSFORM,
-                        "Benchmark-only CPU-bound operator. Computes iterative fib per item.",
+                        "Benchmark-only CPU-bound operator. Computes iterative fib per item. Not available in pine-python.",
                         Map.of(
                                 "iterations", ParamSpec.optional("int", 100,
                                         "Number of fib(32) computations per item.")
@@ -296,7 +296,7 @@ public class AllOperators {
                 new OperatorSchema(
                         "transform_bench_sleep",
                         OperatorType.TRANSFORM,
-                        "Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation.",
+                        "Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation. Not available in pine-python.",
                         Map.of(
                                 "delay_ms", ParamSpec.optional("int", 5,
                                         "Milliseconds to sleep per operator invocation.")

--- a/pine-java/src/main/java/page/liam/pine/operators/TransformBenchCpu.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/TransformBenchCpu.java
@@ -1,0 +1,49 @@
+package page.liam.pine.operators;
+
+import page.liam.pine.AbstractOperator;
+import page.liam.pine.CancellationToken;
+import page.liam.pine.ConcurrentSafe;
+import page.liam.pine.OperatorInput;
+import page.liam.pine.OperatorOutput;
+import page.liam.pine.OperatorParams;
+
+public class TransformBenchCpu extends AbstractOperator implements ConcurrentSafe {
+    private int iterations = 100;
+
+    @Override
+    public void init(OperatorParams params) {
+        Object v = params.get("iterations");
+        if (v instanceof Number) {
+            iterations = ((Number) v).intValue();
+        }
+    }
+
+    @Override
+    public void execute(CancellationToken token, OperatorInput input, OperatorOutput output) {
+        int n = input.itemCount();
+        for (int i = 0; i < n; i++) {
+            double result = cpuWork(iterations);
+            output.setItem(i, "_bench_result", result);
+        }
+    }
+
+    private static double cpuWork(int iterations) {
+        double acc = 0;
+        for (int i = 0; i < iterations; i++) {
+            acc += fib(32);
+            acc /= 1.000001;
+        }
+        return acc;
+    }
+
+    private static long fib(int n) {
+        if (n <= 1) return n;
+        long a = 0, b = 1;
+        for (int i = 2; i <= n; i++) {
+            long tmp = a + b;
+            a = b;
+            b = tmp;
+        }
+        return b;
+    }
+}

--- a/pine-java/src/main/java/page/liam/pine/operators/TransformBenchSleep.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/TransformBenchSleep.java
@@ -20,11 +20,14 @@ public class TransformBenchSleep extends AbstractOperator implements ConcurrentS
 
     @Override
     public void execute(CancellationToken token, OperatorInput input, OperatorOutput output) {
+        if (token.isCancelled()) return;
         try {
             Thread.sleep(delayMs);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            return;
         }
+        if (token.isCancelled()) return;
         int n = input.itemCount();
         for (int i = 0; i < n; i++) {
             output.setItem(i, "_bench_slept", true);

--- a/pine-java/src/main/java/page/liam/pine/operators/TransformBenchSleep.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/TransformBenchSleep.java
@@ -1,0 +1,33 @@
+package page.liam.pine.operators;
+
+import page.liam.pine.AbstractOperator;
+import page.liam.pine.CancellationToken;
+import page.liam.pine.ConcurrentSafe;
+import page.liam.pine.OperatorInput;
+import page.liam.pine.OperatorOutput;
+import page.liam.pine.OperatorParams;
+
+public class TransformBenchSleep extends AbstractOperator implements ConcurrentSafe {
+    private int delayMs = 5;
+
+    @Override
+    public void init(OperatorParams params) {
+        Object v = params.get("delay_ms");
+        if (v instanceof Number) {
+            delayMs = ((Number) v).intValue();
+        }
+    }
+
+    @Override
+    public void execute(CancellationToken token, OperatorInput input, OperatorOutput output) {
+        try {
+            Thread.sleep(delayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        int n = input.itemCount();
+        for (int i = 0; i < n; i++) {
+            output.setItem(i, "_bench_slept", true);
+        }
+    }
+}

--- a/scripts/bench-analyze.py
+++ b/scripts/bench-analyze.py
@@ -146,13 +146,9 @@ def section_summary(rows: list[dict]) -> str:
     lines = ["## Key Takeaways", ""]
     runtimes = sorted(set(r["runtime"] for r in rows))
     ops = sorted(set(r["op"] for r in rows))
-    nodes_list = sorted(set(r["nodes"] for r in rows))
 
     for op in ops:
         wins: dict[str, int] = defaultdict(int)
-        for r in rows:
-            if r["op"] != op:
-                continue
         by_config = defaultdict(list)
         for r in rows:
             if r["op"] != op:

--- a/scripts/bench-analyze.py
+++ b/scripts/bench-analyze.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Analyze a single cross-runtime benchmark report and produce a summary."""
+import argparse
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def parse_report(text: str) -> list[dict]:
+    rows = []
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) != 11:
+            continue
+        try:
+            rows.append({
+                "runtime": parts[0],
+                "nodes": int(parts[1]),
+                "storage": parts[2],
+                "par": int(parts[3]),
+                "op": parts[4],
+                "qps": float(parts[5]),
+                "mean": float(parts[6]),
+                "stddev": float(parts[7]),
+                "p50": float(parts[8]),
+                "p90": float(parts[9]),
+                "p99": float(parts[10]),
+            })
+        except (ValueError, IndexError):
+            continue
+    return rows
+
+
+def group_by(rows: list[dict], key: str) -> dict[str, list[dict]]:
+    groups: dict[str, list[dict]] = defaultdict(list)
+    for r in rows:
+        groups[r[key]].append(r)
+    return groups
+
+
+def avg(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def section_runtime_ranking(rows: list[dict]) -> str:
+    lines = ["## Runtime Ranking by Op Type + DAG Size", ""]
+    by_op = group_by(rows, "op")
+    for op in sorted(by_op):
+        by_nodes = group_by(by_op[op], "nodes")
+        for nodes in sorted(by_nodes):
+            by_rt = group_by(by_nodes[nodes], "runtime")
+            rt_qps = []
+            for rt, rt_rows in by_rt.items():
+                rt_qps.append((rt, avg([r["qps"] for r in rt_rows])))
+            rt_qps.sort(key=lambda x: -x[1])
+            ranking = " > ".join(f"{rt}({qps:.0f})" for rt, qps in rt_qps)
+            lines.append(f"  {op:>5} nodes={nodes:<4}  {ranking}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def section_parallelism_effect(rows: list[dict]) -> str:
+    lines = ["## Parallelism Effect (QPS at par=1 vs max par)", ""]
+    by_op = group_by(rows, "op")
+    for op in sorted(by_op):
+        by_nodes = group_by(by_op[op], "nodes")
+        for nodes in sorted(by_nodes):
+            by_rt = group_by(by_nodes[nodes], "runtime")
+            for rt in sorted(by_rt):
+                rt_rows = by_rt[rt]
+                by_par = group_by(rt_rows, "par")
+                pars = sorted(by_par.keys())
+                if len(pars) < 2:
+                    continue
+                qps_min_par = avg([r["qps"] for r in by_par[pars[0]]])
+                qps_max_par = avg([r["qps"] for r in by_par[pars[-1]]])
+                if qps_min_par == 0:
+                    continue
+                speedup = qps_max_par / qps_min_par
+                marker = " <<<" if speedup > 1.3 else (" !!!" if speedup < 0.8 else "")
+                lines.append(
+                    f"  {rt:<6} {op:>5} nodes={nodes:<4} "
+                    f"par={pars[0]}→{pars[-1]}  "
+                    f"{qps_min_par:>8.1f} → {qps_max_par:>8.1f} QPS  "
+                    f"({speedup:.2f}x){marker}"
+                )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def section_storage_effect(rows: list[dict]) -> str:
+    lines = ["## Storage Mode Effect (row vs column avg QPS)", ""]
+    by_storage = group_by(rows, "storage")
+    storages = sorted(by_storage.keys())
+    if len(storages) < 2:
+        lines.append("  Only one storage mode in data.")
+        lines.append("")
+        return "\n".join(lines)
+
+    by_rt = group_by(rows, "runtime")
+    for rt in sorted(by_rt):
+        for op in sorted(set(r["op"] for r in rows)):
+            row_qps = [r["qps"] for r in by_rt[rt] if r["storage"] == "row" and r["op"] == op]
+            col_qps = [r["qps"] for r in by_rt[rt] if r["storage"] == "column" and r["op"] == op]
+            if not row_qps or not col_qps:
+                continue
+            r_avg = avg(row_qps)
+            c_avg = avg(col_qps)
+            diff_pct = (c_avg - r_avg) / r_avg * 100 if r_avg else 0
+            marker = " *" if abs(diff_pct) > 5 else ""
+            lines.append(
+                f"  {rt:<6} {op:>5}  row={r_avg:>8.1f}  col={c_avg:>8.1f}  "
+                f"delta={diff_pct:+.1f}%{marker}"
+            )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def section_latency_outliers(rows: list[dict]) -> str:
+    lines = ["## Latency Outliers (high stddev/mean ratio or P99/P50 spread)", ""]
+    outliers = []
+    for r in rows:
+        cv = r["stddev"] / r["mean"] if r["mean"] > 0 else 0
+        tail_ratio = r["p99"] / r["p50"] if r["p50"] > 0 else 0
+        if cv > 0.3 or tail_ratio > 2.0:
+            outliers.append((cv, tail_ratio, r))
+
+    outliers.sort(key=lambda x: -x[0])
+    if not outliers:
+        lines.append("  No significant outliers detected.")
+    else:
+        lines.append(f"  {'Runtime':<6} {'Nodes':>5} {'Stor':>6} {'Par':>3} {'Op':>5}"
+                     f"  {'CV':>6}  {'P99/P50':>7}  {'Mean':>8}  {'Stddev':>8}")
+        lines.append(f"  {'------':<6} {'-----':>5} {'------':>6} {'---':>3} {'-----':>5}"
+                     f"  {'------':>6}  {'-------':>7}  {'--------':>8}  {'--------':>8}")
+        for cv, tail, r in outliers[:15]:
+            lines.append(
+                f"  {r['runtime']:<6} {r['nodes']:>5} {r['storage']:>6} {r['par']:>3} {r['op']:>5}"
+                f"  {cv:>6.2f}  {tail:>7.2f}  {r['mean']:>8.4f}  {r['stddev']:>8.4f}"
+            )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def section_summary(rows: list[dict]) -> str:
+    lines = ["## Key Takeaways", ""]
+    runtimes = sorted(set(r["runtime"] for r in rows))
+    ops = sorted(set(r["op"] for r in rows))
+    nodes_list = sorted(set(r["nodes"] for r in rows))
+
+    for op in ops:
+        wins: dict[str, int] = defaultdict(int)
+        for r in rows:
+            if r["op"] != op:
+                continue
+        by_config = defaultdict(list)
+        for r in rows:
+            if r["op"] != op:
+                continue
+            key = (r["nodes"], r["storage"], r["par"])
+            by_config[key].append(r)
+        for key, config_rows in by_config.items():
+            best = max(config_rows, key=lambda x: x["qps"])
+            wins[best["runtime"]] += 1
+        total = sum(wins.values())
+        win_str = ", ".join(f"{rt}={wins.get(rt, 0)}/{total}" for rt in runtimes)
+        lines.append(f"  {op}: wins by config → {win_str}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze a benchmark report")
+    parser.add_argument("report", help="Path to report.txt")
+    parser.add_argument("--output", "-o", help="Output file (default: stdout)")
+    args = parser.parse_args()
+
+    text = Path(args.report).read_text()
+    rows = parse_report(text)
+
+    if not rows:
+        print("No data rows found in report.", file=sys.stderr)
+        sys.exit(1)
+
+    header_lines = [l for l in text.splitlines() if l.startswith("═") or l.startswith(" ")]
+    meta = "\n".join(header_lines[:7])
+
+    sections = [
+        f"# Benchmark Analysis\n\n{meta}\n",
+        section_runtime_ranking(rows),
+        section_parallelism_effect(rows),
+        section_storage_effect(rows),
+        section_latency_outliers(rows),
+        section_summary(rows),
+    ]
+
+    output = "\n".join(sections)
+    if args.output:
+        Path(args.output).write_text(output)
+        print(f"Analysis written to {args.output}")
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench-compare.py
+++ b/scripts/bench-compare.py
@@ -6,44 +6,33 @@ import sys
 from pathlib import Path
 
 
-def parse_report(text: str) -> dict[str, dict[tuple[str, int], dict[str, float]]]:
-    """Parse report into {phase: {(runtime, nodes): {metric: value}}}."""
-    phases: dict[str, dict[tuple[str, int], dict[str, float]]] = {}
-    current_phase = None
+def parse_report(text: str) -> dict[tuple, dict[str, float]]:
+    """Parse report into {(runtime, nodes, storage, par, op): {metric: value}}."""
+    data: dict[tuple, dict[str, float]] = {}
 
     for line in text.splitlines():
-        if line.strip().startswith("── Phase"):
-            m = re.search(r"Phase (\d+):", line)
-            if m:
-                current_phase = f"phase{m.group(1)}"
-                phases[current_phase] = {}
-            continue
-
-        if current_phase is None:
-            continue
-
-        # Data lines: "  runtime  nodes  qps  mean  stddev  p50  p90  p99"
         parts = line.split()
-        if len(parts) == 8:
+        if len(parts) == 11:
             runtime = parts[0]
             try:
                 nodes = int(parts[1])
-                qps = float(parts[2])
-                mean = float(parts[3])
-                p50 = float(parts[5])
-                p90 = float(parts[6])
-                p99 = float(parts[7])
+                storage = parts[2]
+                par = int(parts[3])
+                op = parts[4]
+                qps = float(parts[5])
+                mean = float(parts[6])
+                stddev = float(parts[7])
+                p50 = float(parts[8])
+                p90 = float(parts[9])
+                p99 = float(parts[10])
             except (ValueError, IndexError):
                 continue
-            phases[current_phase][(runtime, nodes)] = {
-                "qps": qps,
-                "mean": mean,
-                "p50": p50,
-                "p90": p90,
-                "p99": p99,
+            data[(runtime, nodes, storage, par, op)] = {
+                "qps": qps, "mean": mean, "stddev": stddev,
+                "p50": p50, "p90": p90, "p99": p99,
             }
 
-    return phases
+    return data
 
 
 def pct_change(old: float, new: float) -> str:
@@ -56,37 +45,36 @@ def pct_change(old: float, new: float) -> str:
 
 def format_comparison(prev: dict, curr: dict) -> str:
     lines = []
-    phase_names = {"phase1": "Single-request latency", "phase2": "QPS=500 latency", "phase3": "Max throughput"}
+    common_keys = sorted(
+        set(prev.keys()) & set(curr.keys()),
+        key=lambda k: (k[4], k[1], k[3], k[2], k[0]),  # op, nodes, par, storage, runtime
+    )
 
-    for phase_key in sorted(set(prev.keys()) | set(curr.keys())):
-        phase_label = phase_names.get(phase_key, phase_key)
-        prev_data = prev.get(phase_key, {})
-        curr_data = curr.get(phase_key, {})
+    if not common_keys:
+        return "No comparable data found between runs."
 
-        all_keys = sorted(set(prev_data.keys()) | set(curr_data.keys()), key=lambda k: (k[0], k[1]))
-        if not all_keys:
-            continue
+    lines.append("── Delta: current vs previous (QPS: higher=better, latency: lower=better) ──")
+    lines.append(
+        f"  {'Runtime':<8} {'Nodes':>5} {'Stor':>6} {'Par':>4} {'Op':>6}"
+        f"  {'QPS Δ':>10}  {'Mean Δ':>10}  {'P50 Δ':>10}  {'P99 Δ':>10}"
+    )
+    lines.append(
+        f"  {'-------':<8} {'-----':>5} {'------':>6} {'---':>4} {'------':>6}"
+        f"  {'----------':>10}  {'----------':>10}  {'----------':>10}  {'----------':>10}"
+    )
 
-        lines.append(f"── {phase_label} (QPS: higher=better, latency: lower=better) ──")
-        lines.append(f"  {'Runtime':<8} {'Nodes':>5}  {'QPS Δ':>10}  {'Mean Δ':>10}  {'P50 Δ':>10}  {'P99 Δ':>10}")
-        lines.append(f"  {'-------':<8} {'-----':>5}  {'----------':>10}  {'----------':>10}  {'----------':>10}  {'----------':>10}")
-
-        for key in all_keys:
-            runtime, nodes = key
-            if key not in prev_data or key not in curr_data:
-                continue
-            p = prev_data[key]
-            c = curr_data[key]
-            qps_d = pct_change(p["qps"], c["qps"])
-            mean_d = pct_change(p["mean"], c["mean"])
-            p50_d = pct_change(p["p50"], c["p50"])
-            p99_d = pct_change(p["p99"], c["p99"])
-            lines.append(f"  {runtime:<8} {nodes:>5}  {qps_d:>10}  {mean_d:>10}  {p50_d:>10}  {p99_d:>10}")
-
-        lines.append("")
-
-    if not lines:
-        lines.append("No comparable data found between runs.")
+    for key in common_keys:
+        runtime, nodes, storage, par, op = key
+        p = prev[key]
+        c = curr[key]
+        qps_d = pct_change(p["qps"], c["qps"])
+        mean_d = pct_change(p["mean"], c["mean"])
+        p50_d = pct_change(p["p50"], c["p50"])
+        p99_d = pct_change(p["p99"], c["p99"])
+        lines.append(
+            f"  {runtime:<8} {nodes:>5} {storage:>6} {par:>4} {op:>6}"
+            f"  {qps_d:>10}  {mean_d:>10}  {p50_d:>10}  {p99_d:>10}"
+        )
 
     return "\n".join(lines)
 

--- a/scripts/bench-cross-runtime.sh
+++ b/scripts/bench-cross-runtime.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
-# Cross-runtime benchmark: pine-{go,java,python,cpp}
+# Cross-runtime benchmark: pine-{go,java,cpp}
 #
-# Compares all four runtimes across multiple DAG sizes on:
-#   1. Single-request latency (sequential, 1000 reqs per size)
-#   2. Fixed-QPS latency under load (QPS=500, 15000 reqs, ~30s per size)
-#   3. Max throughput (saturate with 50 concurrent connections)
+# Dimensions:
+#   - DAG size: 5, 50, 100, 500 nodes
+#   - Storage mode: row, column
+#   - Parallelism (DAG fan-out): 1, nproc/2, nproc, 2*nproc, 4*nproc
+#   - Operator type: cpu, io, mixed
 #
-# DAG sizes: 5, 15, 50, 100, 200, 500 nodes (observe_log no-ops)
+# Only runs max-throughput phase (50 concurrent, 10000 requests).
 #
 # Prerequisites:
-#   - hey (HTTP load generator): go install github.com/rakyll/hey@latest
-#   - Go, Java 21, Python 3.13, cmake + build-essential + libluajit
+#   - hey: go install github.com/rakyll/hey@latest
+#   - Go, Java 21, cmake + build-essential + libluajit
 #
 # Usage:
-#   ./scripts/bench-cross-runtime.sh [--skip go,python] [--sizes "5,50,200"]
+#   ./scripts/bench-cross-runtime.sh [--skip go] [--sizes "5,50"] [--modes "row"]
+#       [--parallelism "1,4,8"] [--ops "cpu,io"] [--requests 10000] [--concurrency 50]
 #
-# Output: /tmp/bench_cross_runtime/report.txt (+ raw hey output per phase)
+# Output: /tmp/bench_cross_runtime/report.txt
 
 set -euo pipefail
 
@@ -24,15 +26,26 @@ WORK_DIR="/tmp/bench_cross_runtime"
 FIXTURE_DIR="$WORK_DIR/fixtures"
 REPORT="$WORK_DIR/report.txt"
 
+NPROC=$(nproc)
 SKIP_RUNTIMES=""
-RUNTIMES=(go java python cpp)
-DAG_SIZES=(5 15 50 100 200 500)
+RUNTIMES=(go java cpp)
+DAG_SIZES=(5 50 100 500)
+STORAGE_MODES=(row column)
+PARALLELISMS=(1 $((NPROC / 2)) $NPROC $((NPROC * 2)) $((NPROC * 4)))
+OP_TYPES=(cpu io mixed)
+NUM_REQUESTS=10000
+CONCURRENCY=50
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --skip)  SKIP_RUNTIMES="$2"; shift 2 ;;
-    --sizes) IFS=',' read -ra DAG_SIZES <<< "$2"; shift 2 ;;
-    *)       echo "Unknown arg: $1" >&2; exit 1 ;;
+    --skip)        SKIP_RUNTIMES="$2"; shift 2 ;;
+    --sizes)       IFS=',' read -ra DAG_SIZES <<< "$2"; shift 2 ;;
+    --modes)       IFS=',' read -ra STORAGE_MODES <<< "$2"; shift 2 ;;
+    --parallelism) IFS=',' read -ra PARALLELISMS <<< "$2"; shift 2 ;;
+    --ops)         IFS=',' read -ra OP_TYPES <<< "$2"; shift 2 ;;
+    --requests)    NUM_REQUESTS="$2"; shift 2 ;;
+    --concurrency) CONCURRENCY="$2"; shift 2 ;;
+    *)             echo "Unknown arg: $1" >&2; exit 1 ;;
   esac
 done
 
@@ -52,15 +65,18 @@ if ! command -v hey >/dev/null 2>&1; then
   exit 1
 fi
 
-# ─── Generate synthetic DAG fixtures ──────────────────────────────────
-info "Generating synthetic DAG fixtures (sizes: ${DAG_SIZES[*]})..."
+# ─── Generate fixtures ────────────────────────────────────────────────
+info "Generating fixtures..."
+info "  Sizes: ${DAG_SIZES[*]}"
+info "  Storage: ${STORAGE_MODES[*]}"
+info "  Parallelism: ${PARALLELISMS[*]}"
+info "  Op types: ${OP_TYPES[*]}"
 
-python3 - "$FIXTURE_DIR" "${DAG_SIZES[@]}" << 'PYEOF'
-import json, math, sys
+python3 - "$FIXTURE_DIR" "${DAG_SIZES[*]}" "${STORAGE_MODES[*]}" "${PARALLELISMS[*]}" "${OP_TYPES[*]}" << 'PYEOF'
+import json, sys
 
-def gen_fixture(n_nodes, output_dir):
-    """Generate a diamond-shaped DAG of observe_log operators (true no-ops)."""
-    width = max(2, int(math.sqrt(n_nodes)))
+def gen_fixture(n_nodes, storage_mode, fan_out, op_type, output_dir):
+    """Generate a DAG with controlled fan-out width and operator type."""
     operators = {}
     all_names = []
 
@@ -78,34 +94,73 @@ def gen_fixture(n_nodes, output_dir):
     prev_layer = ["root_recall"]
     stage = 0
 
-    while node_count < n_nodes:
-        stage += 1
-        actual_width = min(width, n_nodes - node_count)
-        if actual_width <= 0:
-            break
-
-        layer = []
-        for i in range(actual_width):
-            if node_count >= n_nodes:
-                break
-            name = f"obs_s{stage}_{i}"
-            operators[name] = {
-                "type_name": "observe_log",
+    def make_op(name, op_type, stage_idx, node_idx):
+        """Create operator config based on type."""
+        if op_type == "cpu":
+            return {
+                "type_name": "transform_bench_cpu",
                 "sources": prev_layer,
+                "iterations": 100,
                 "$metadata": {
                     "common_input": [], "common_output": [],
                     "item_input": ["item_id", "score"],
-                    "item_output": ["item_id", "score"]
+                    "item_output": ["item_id", "score", "_bench_result"]
                 }
             }
+        elif op_type == "io":
+            return {
+                "type_name": "transform_bench_sleep",
+                "sources": prev_layer,
+                "delay_ms": 5,
+                "$metadata": {
+                    "common_input": [], "common_output": [],
+                    "item_input": ["item_id", "score"],
+                    "item_output": ["item_id", "score", "_bench_slept"]
+                }
+            }
+        else:  # mixed: alternate cpu and io
+            if (stage_idx + node_idx) % 2 == 0:
+                return {
+                    "type_name": "transform_bench_cpu",
+                    "sources": prev_layer,
+                    "iterations": 100,
+                    "$metadata": {
+                        "common_input": [], "common_output": [],
+                        "item_input": ["item_id", "score"],
+                        "item_output": ["item_id", "score", "_bench_result"]
+                    }
+                }
+            else:
+                return {
+                    "type_name": "transform_bench_sleep",
+                    "sources": prev_layer,
+                    "delay_ms": 5,
+                    "$metadata": {
+                        "common_input": [], "common_output": [],
+                        "item_input": ["item_id", "score"],
+                        "item_output": ["item_id", "score", "_bench_slept"]
+                    }
+                }
+
+    while node_count < n_nodes:
+        stage += 1
+        width = min(fan_out, n_nodes - node_count)
+        if width <= 0:
+            break
+        layer = []
+        for i in range(width):
+            if node_count >= n_nodes:
+                break
+            name = f"op_s{stage}_{i}"
+            operators[name] = make_op(name, op_type, stage, i)
             all_names.append(name)
             layer.append(name)
             node_count += 1
-
         prev_layer = layer
 
     config = {
-        "_PINEAPPLE_VERSION": "0.9.1",
+        "_PINEAPPLE_VERSION": "0.9.2",
+        "storage_mode": storage_mode,
         "pipeline_config": {
             "operators": operators,
             "pipeline_map": {"bench": {"pipeline": all_names}}
@@ -118,20 +173,31 @@ def gen_fixture(n_nodes, output_dir):
     }
     request = {"common": {}, "items": []}
 
-    with open(f"{output_dir}/dag_{n_nodes}_config.json", 'w') as f:
+    tag = f"n{n_nodes}_s{storage_mode}_p{fan_out}_{op_type}"
+    with open(f"{output_dir}/{tag}_config.json", 'w') as f:
         json.dump(config, f)
-    with open(f"{output_dir}/dag_{n_nodes}_request.json", 'w') as f:
+    with open(f"{output_dir}/{tag}_request.json", 'w') as f:
         json.dump(request, f)
-    print(f"    {n_nodes:>3} nodes ({len(operators)} ops, {stage} stages)")
 
 out_dir = sys.argv[1]
-for n_str in sys.argv[2:]:
-    gen_fixture(int(n_str), out_dir)
+sizes = [int(x) for x in sys.argv[2].split()]
+modes = sys.argv[3].split()
+pars = [int(x) for x in sys.argv[4].split()]
+ops = sys.argv[5].split()
+
+count = 0
+for n in sizes:
+    for mode in modes:
+        for p in pars:
+            for op in ops:
+                gen_fixture(n, mode, p, op, out_dir)
+                count += 1
+print(f"  Generated {count} fixture pairs")
 PYEOF
 
-ok "Fixtures generated in $FIXTURE_DIR"
+ok "Fixtures generated"
 
-# ─── Build all runtimes ───────────────────────────────────────────────
+# ─── Build runtimes ───────────────────────────────────────────────────
 info "Building runtimes..."
 
 JAVA_CP=""
@@ -149,23 +215,17 @@ if ! should_skip java; then
   ok "Java built"
 fi
 
-if ! should_skip python; then
-  info "  Installing Python deps..."
-  pip install -q -e "$REPO_ROOT/pine-python/" 2>/dev/null || true
-  ok "Python ready"
-fi
-
 if ! should_skip cpp; then
   info "  Building C++..."
   CPP_BUILD="$REPO_ROOT/pine-cpp/build"
   mkdir -p "$CPP_BUILD"
-  (cd "$CPP_BUILD" && cmake .. -DCMAKE_BUILD_TYPE=Release >/dev/null 2>&1 \
+  (cd "$CPP_BUILD" && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 >/dev/null 2>&1 \
     && cmake --build . -j2 --target pineapple-server 2>&1 | tail -1)
   cp "$CPP_BUILD/pineapple-server" "$WORK_DIR/server-cpp"
   ok "C++ built"
 fi
 
-# ─── Helper functions ─────────────────────────────────────────────────
+# ─── Server helpers ───────────────────────────────────────────────────
 BASE_PORT=19100
 PORT_IDX=0
 
@@ -174,31 +234,18 @@ next_port() { PORT_IDX=$((PORT_IDX + 1)); echo $((BASE_PORT + PORT_IDX)); }
 start_server() {
   local runtime="$1" port="$2" config="$3"
   local pid_file="$WORK_DIR/${runtime}.pid"
-
   case "$runtime" in
-    java)
-      java -cp "$JAVA_CP" -Dpine.config="$config" -Dpine.port="$port" \
-        page.liam.pine.PineServer >"$WORK_DIR/${runtime}.log" 2>&1 &
-      ;;
-    go)
-      "$WORK_DIR/server-go" -config "$config" -addr ":$port" >"$WORK_DIR/${runtime}.log" 2>&1 &
-      ;;
-    cpp)
-      "$WORK_DIR/server-cpp" -config "$config" -addr ":$port" >"$WORK_DIR/${runtime}.log" 2>&1 &
-      ;;
-    python)
-      python3 -m pine.cli.server -config "$config" -addr ":$port" >"$WORK_DIR/${runtime}.log" 2>&1 &
-      ;;
+    java) java -cp "$JAVA_CP" -Dpine.config="$config" -Dpine.port="$port" \
+      page.liam.pine.PineServer >"$WORK_DIR/${runtime}.log" 2>&1 & ;;
+    go) "$WORK_DIR/server-go" -config "$config" -addr ":$port" >"$WORK_DIR/${runtime}.log" 2>&1 & ;;
+    cpp) "$WORK_DIR/server-cpp" -config "$config" -addr ":$port" >"$WORK_DIR/${runtime}.log" 2>&1 & ;;
   esac
   echo $! > "$pid_file"
-
   for _ in $(seq 1 40); do
-    if curl -sf "http://localhost:$port/health" >/dev/null 2>&1; then
-      return 0
-    fi
+    curl -sf "http://localhost:$port/health" >/dev/null 2>&1 && return 0
     sleep 0.25
   done
-  err "$runtime server failed to start on :$port (config: $config)"
+  err "$runtime server failed to start on :$port"
   tail -20 "$WORK_DIR/${runtime}.log" >&2
   return 1
 }
@@ -206,25 +253,16 @@ start_server() {
 stop_server() {
   local runtime="$1"
   local pid_file="$WORK_DIR/${runtime}.pid"
-  if [[ -f "$pid_file" ]]; then
-    local pid
-    pid=$(cat "$pid_file")
-    kill -TERM "$pid" 2>/dev/null || true
-    for _ in 1 2 3 4 5; do
-      kill -0 "$pid" 2>/dev/null || break
-      sleep 0.5
-    done
-    kill -KILL "$pid" 2>/dev/null || true
-    wait "$pid" 2>/dev/null || true
-    rm -f "$pid_file"
-  fi
+  [[ -f "$pid_file" ]] || return 0
+  local pid; pid=$(cat "$pid_file")
+  kill -TERM "$pid" 2>/dev/null || true
+  for _ in 1 2 3 4 5; do kill -0 "$pid" 2>/dev/null || break; sleep 0.5; done
+  kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  rm -f "$pid_file"
 }
 
-cleanup() {
-  for rt in "${RUNTIMES[@]}"; do
-    stop_server "$rt"
-  done
-}
+cleanup() { for rt in "${RUNTIMES[@]}"; do stop_server "$rt"; done; }
 trap cleanup EXIT INT TERM
 
 parse_hey() {
@@ -253,148 +291,75 @@ print(f'{qps:.4f}|{mean:.6f}|{stddev:.6f}|{p50:.6f}|{p90:.6f}|{p99:.6f}')
 " "$csv_file" 2>/dev/null || echo "N/A|N/A|N/A|N/A|N/A|N/A"
 }
 
-TABLE_HEADER="  %-8s %6s %10s %10s %10s %10s %10s %10s\n"
-TABLE_SEP="  %-8s %6s %10s %10s %10s %10s %10s %10s\n"
-
-print_table_header() {
-  printf "$TABLE_HEADER" "Runtime" "Nodes" "QPS" "Mean" "Stddev" "P50" "P90" "P99"
-  printf "$TABLE_SEP" "-------" "-----" "----------" "----------" "----------" "----------" "----------" "----------"
-}
-
-# ─── Report header ───────────────────────────────────────────────────
+# ─── Report header ────────────────────────────────────────────────────
 {
   echo "═══════════════════════════════════════════════════════════════════"
-  echo " Cross-Runtime Benchmark: pine-{go,java,python,cpp}"
+  echo " Cross-Runtime Benchmark: pine-{go,java,cpp}"
   echo " Date: $(date -Iseconds)"
-  echo " DAG sizes: ${DAG_SIZES[*]}"
-  echo " Machine: $(uname -n) ($(nproc) cores)"
+  echo " Machine: $(uname -n) (${NPROC} cores)"
+  echo " Dimensions: sizes=${DAG_SIZES[*]} storage=${STORAGE_MODES[*]}"
+  echo "   parallelism=${PARALLELISMS[*]} ops=${OP_TYPES[*]}"
+  echo " Load: ${NUM_REQUESTS} requests, ${CONCURRENCY} concurrent"
   echo " Skipped: ${SKIP_RUNTIMES:-none}"
   echo "═══════════════════════════════════════════════════════════════════"
   echo
 } > "$REPORT"
 
-# PLACEHOLDER_PHASES
+# ─── Benchmark loop ──────────────────────────────────────────────────
+TOTAL_COMBOS=$(( ${#DAG_SIZES[@]} * ${#STORAGE_MODES[@]} * ${#PARALLELISMS[@]} * ${#OP_TYPES[@]} * ${#RUNTIMES[@]} ))
+COMBO_IDX=0
 
-# ─── Phase 1: Single-request latency (sequential, 1000 reqs) ─────────
-info "Phase 1: Single-request latency (1000 sequential requests per size)..."
+TABLE_HEADER="  %-8s %5s %7s %4s %6s %10s %10s %10s %10s %10s %10s\n"
+
 {
-  echo "── Phase 1: Single-request latency ──"
-  echo "   1000 sequential requests (concurrency=1) per DAG size"
-  echo
-  print_table_header
+  printf "$TABLE_HEADER" "Runtime" "Nodes" "Storage" "Par" "OpType" "QPS" "Mean" "Stddev" "P50" "P90" "P99"
+  printf "$TABLE_HEADER" "-------" "-----" "-------" "---" "------" "----------" "----------" "----------" "----------" "----------" "----------"
 } >> "$REPORT"
 
 for n in "${DAG_SIZES[@]}"; do
-  cfg="$FIXTURE_DIR/dag_${n}_config.json"
-  req="$FIXTURE_DIR/dag_${n}_request.json"
-  REQ_BODY=$(cat "$req")
+  for mode in "${STORAGE_MODES[@]}"; do
+    for par in "${PARALLELISMS[@]}"; do
+      for op in "${OP_TYPES[@]}"; do
+        tag="n${n}_s${mode}_p${par}_${op}"
+        cfg="$FIXTURE_DIR/${tag}_config.json"
+        req="$FIXTURE_DIR/${tag}_request.json"
+        [[ -f "$cfg" ]] || continue
+        REQ_BODY=$(cat "$req")
 
-  for rt in "${RUNTIMES[@]}"; do
-    should_skip "$rt" && continue
-    port=$(next_port)
-    echo "    $rt / $n nodes on :$port..."
+        for rt in "${RUNTIMES[@]}"; do
+          should_skip "$rt" && continue
+          COMBO_IDX=$((COMBO_IDX + 1))
+          port=$(next_port)
+          echo "  [$COMBO_IDX/$TOTAL_COMBOS] $rt $tag on :$port..."
 
-    if ! start_server "$rt" "$port" "$cfg"; then continue; fi
+          if ! start_server "$rt" "$port" "$cfg"; then continue; fi
 
-    HEY_OUT=$(hey -n 1000 -c 1 -m POST \
-      -H "Content-Type: application/json" \
-      -d "$REQ_BODY" \
-      -o csv \
-      "http://localhost:$port/execute" 2>&1)
+          # Warmup
+          hey -n 200 -c 10 -m POST -H "Content-Type: application/json" \
+            -d "$REQ_BODY" -o csv "http://localhost:$port/execute" > /dev/null 2>&1
 
-    echo "$HEY_OUT" > "$WORK_DIR/phase1_${rt}_${n}.csv"
-    METRICS=$(parse_hey "$WORK_DIR/phase1_${rt}_${n}.csv")
-    IFS='|' read -r qps mean stddev p50 p90 p99 <<< "$METRICS"
-    printf "  %-8s %6d %10s %10s %10s %10s %10s %10s\n" \
-      "$rt" "$n" "$qps" "$mean" "$stddev" "$p50" "$p90" "$p99" | tee -a "$REPORT"
+          # Benchmark
+          hey -n "$NUM_REQUESTS" -c "$CONCURRENCY" -m POST \
+            -H "Content-Type: application/json" \
+            -d "$REQ_BODY" -o csv \
+            "http://localhost:$port/execute" > "$WORK_DIR/${tag}_${rt}.csv" 2>&1
 
-    stop_server "$rt"
-    sleep 0.2
+          METRICS=$(parse_hey "$WORK_DIR/${tag}_${rt}.csv")
+          IFS='|' read -r qps mean stddev p50 p90 p99 <<< "$METRICS"
+          printf "  %-8s %5d %7s %4d %6s %10s %10s %10s %10s %10s %10s\n" \
+            "$rt" "$n" "$mode" "$par" "$op" "$qps" "$mean" "$stddev" "$p50" "$p90" "$p99" | tee -a "$REPORT"
+
+          stop_server "$rt"
+          sleep 0.2
+        done
+      done
+    done
   done
 done
+
 echo >> "$REPORT"
-
-# ─── Phase 2: Fixed QPS=500 latency (15000 reqs, ~30s) ───────────────
-info "Phase 2: Fixed QPS=500 latency (15000 requests per size, ~30s each)..."
 {
-  echo "── Phase 2: Fixed QPS=500 latency ──"
-  echo "   15000 requests at QPS=500 (~30s) per DAG size"
-  echo
-  print_table_header
-} >> "$REPORT"
-
-for n in "${DAG_SIZES[@]}"; do
-  cfg="$FIXTURE_DIR/dag_${n}_config.json"
-  req="$FIXTURE_DIR/dag_${n}_request.json"
-  REQ_BODY=$(cat "$req")
-
-  for rt in "${RUNTIMES[@]}"; do
-    should_skip "$rt" && continue
-    port=$(next_port)
-    echo "    $rt / $n nodes on :$port..."
-
-    if ! start_server "$rt" "$port" "$cfg"; then continue; fi
-
-    HEY_OUT=$(hey -n 15000 -q 10 -c 50 -m POST \
-      -H "Content-Type: application/json" \
-      -d "$REQ_BODY" \
-      -o csv \
-      "http://localhost:$port/execute" 2>&1)
-
-    echo "$HEY_OUT" > "$WORK_DIR/phase2_${rt}_${n}.csv"
-    METRICS=$(parse_hey "$WORK_DIR/phase2_${rt}_${n}.csv")
-    IFS='|' read -r qps mean stddev p50 p90 p99 <<< "$METRICS"
-    printf "  %-8s %6d %10s %10s %10s %10s %10s %10s\n" \
-      "$rt" "$n" "$qps" "$mean" "$stddev" "$p50" "$p90" "$p99" | tee -a "$REPORT"
-
-    stop_server "$rt"
-    sleep 0.2
-  done
-done
-echo >> "$REPORT"
-
-# ─── Phase 3: Max throughput (saturate) ───────────────────────────────
-info "Phase 3: Max throughput (50 concurrent, 10000 requests per size)..."
-{
-  echo "── Phase 3: Max throughput ──"
-  echo "   10000 requests, 50 concurrent connections per DAG size"
-  echo
-  print_table_header
-} >> "$REPORT"
-
-for n in "${DAG_SIZES[@]}"; do
-  cfg="$FIXTURE_DIR/dag_${n}_config.json"
-  req="$FIXTURE_DIR/dag_${n}_request.json"
-  REQ_BODY=$(cat "$req")
-
-  for rt in "${RUNTIMES[@]}"; do
-    should_skip "$rt" && continue
-    port=$(next_port)
-    echo "    $rt / $n nodes on :$port..."
-
-    if ! start_server "$rt" "$port" "$cfg"; then continue; fi
-
-    HEY_OUT=$(hey -n 10000 -c 50 -m POST \
-      -H "Content-Type: application/json" \
-      -d "$REQ_BODY" \
-      -o csv \
-      "http://localhost:$port/execute" 2>&1)
-
-    echo "$HEY_OUT" > "$WORK_DIR/phase3_${rt}_${n}.csv"
-    METRICS=$(parse_hey "$WORK_DIR/phase3_${rt}_${n}.csv")
-    IFS='|' read -r qps mean stddev p50 p90 p99 <<< "$METRICS"
-    printf "  %-8s %6d %10s %10s %10s %10s %10s %10s\n" \
-      "$rt" "$n" "$qps" "$mean" "$stddev" "$p50" "$p90" "$p99" | tee -a "$REPORT"
-
-    stop_server "$rt"
-    sleep 0.2
-  done
-done
-echo >> "$REPORT"
-
-# ─── Summary ──────────────────────────────────────────────────────────
-{
-  echo "Raw CSV data: $WORK_DIR/phase{1,2,3}_<runtime>_<nodes>.csv"
+  echo "Raw CSV data: $WORK_DIR/<tag>_<runtime>.csv"
 } >> "$REPORT"
 
 info "Done. Report:"

--- a/scripts/bench-cross-runtime.sh
+++ b/scripts/bench-cross-runtime.sh
@@ -33,8 +33,8 @@ DAG_SIZES=(5 50 100 500)
 STORAGE_MODES=(row column)
 PARALLELISMS=(1 $((NPROC / 2)) $NPROC $((NPROC * 2)) $((NPROC * 4)))
 OP_TYPES=(cpu io mixed)
-NUM_REQUESTS=10000
-CONCURRENCY=50
+NUM_REQUESTS=1000
+CONCURRENCY=20
 
 while [[ $# -gt 0 ]]; do
   case "$1" in


### PR DESCRIPTION
## Summary

- Redesign cross-runtime benchmark with multi-dimensional coverage: DAG size × storage mode × parallelism (fan-out) × operator type (CPU/IO/mixed)
- Add benchmark-only operators (`transform_bench_cpu`, `transform_bench_sleep`) to all 3 runtimes (Go, Java, C++)
- Add `bench-analyze.py` for single-run analysis (runtime ranking, parallelism effect, storage comparison, latency outliers)
- Fix nightly diff-fuzz not creating issues on timeout (cancelled ≠ failure)
- Fix timeout hierarchy: shell 340m < step 350m < job 355m
- Add `timeout 300` to apt-get steps to prevent stalled mirrors from consuming entire job budget
- Reduce benchmark defaults to fit CI 90-min timeout (1000 req, sizes=5,50,100,200)

## Key findings from local benchmark (4-core machine)

- CPU-bound small DAG: cpp > go >> java
- CPU-bound large DAG: java >> cpp > go (JIT advantage)
- I/O and Mixed: go > cpp > java (all sizes)
- Storage mode (row vs column): no significant difference
- DAG parallelism (fan-out): minimal effect under HTTP-level concurrency

## Test plan

- [x] Local full benchmark run (216 combinations, ~20 min)
- [x] `bench-analyze.py` produces correct analysis
- [x] All 3 runtimes compile and serve benchmark operators
- [ ] CI nightly-benchmark completes within 90 min timeout
- [ ] CI nightly-diff-fuzz creates issue on timeout