### PR TITLE
fix: goToLua/luaToGo support slice/map across all runtimes

### DIFF
--- a/fixtures/errors/runtime_lua_non_string_table_key.json
+++ b/fixtures/errors/runtime_lua_non_string_table_key.json
@@ -1,0 +1,34 @@
+{
+  "name": "Lua fromLua rejects non-string table keys across all engines",
+  "description": "When a Lua function returns a table with non-string keys (e.g. {[10]=1}), all engines must raise an execution error containing the diagnostic message. This locks the cross-runtime convention that only string-keyed tables are valid maps.",
+  "config": {
+    "pipeline_config": {
+      "operators": {
+        "lua_mixed_key": {
+          "type_name": "transform_by_lua",
+          "lua_script": "function f() local t = {}; t[true] = 'bad'; return t end",
+          "function_for_item": "f",
+          "function_for_common": "",
+          "$metadata": {
+            "common_input": [],
+            "common_output": [],
+            "item_input": ["x"],
+            "item_output": ["result"]
+          }
+        }
+      }
+    },
+    "pipeline_group": {"main": {"pipeline": ["lua_mixed_key"]}},
+    "flow_contract": {
+      "common_input": [],
+      "item_input": ["x"],
+      "common_output": [],
+      "item_output": ["result"]
+    }
+  },
+  "request": {"common": {}, "items": [{"x": 1}]},
+  "expected_error": {
+    "type": "ExecutionError",
+    "message_contains": "lua: table has non-string key of type \"boolean\""
+  }
+}

--- a/fixtures/operators/transform_by_lua_tables.json
+++ b/fixtures/operators/transform_by_lua_tables.json
@@ -1,0 +1,157 @@
+{
+  "operator": "transform_by_lua",
+  "cases": [
+    {
+      "name": "item function receives array and returns its length",
+      "params": {
+        "lua_script": "function f() return #tags end",
+        "function_for_item": "f",
+        "function_for_common": ""
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["tags"],
+        "common_output": [],
+        "item_output": ["tag_count"]
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "tags": ["a", "b", "c"] },
+          { "tags": ["x"] },
+          { "tags": [] }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "tag_count": 3 },
+          { "tag_count": 1 },
+          { "tag_count": 0 }
+        ]
+      }
+    },
+    {
+      "name": "item function indexes into array",
+      "params": {
+        "lua_script": "function f() return scores[2] end",
+        "function_for_item": "f",
+        "function_for_common": ""
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["scores"],
+        "common_output": [],
+        "item_output": ["second_score"]
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "scores": [10.0, 20.0, 30.0] }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "second_score": 20.0 }
+        ]
+      }
+    },
+    {
+      "name": "item function receives map and accesses field",
+      "params": {
+        "lua_script": "function f() return meta.color end",
+        "function_for_item": "f",
+        "function_for_common": ""
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["meta"],
+        "common_output": [],
+        "item_output": ["color"]
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "meta": {"color": "red", "size": "large"} }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "color": "red" }
+        ]
+      }
+    },
+    {
+      "name": "item function returns a constructed array",
+      "params": {
+        "lua_script": "function f() return {item_x * 2, item_x * 3} end",
+        "function_for_item": "f",
+        "function_for_common": ""
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["item_x"],
+        "common_output": [],
+        "item_output": ["multiples"]
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_x": 5.0 }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "multiples": [10, 15] }
+        ]
+      }
+    },
+    {
+      "name": "common function receives array via common_input",
+      "params": {
+        "lua_script": "function f()\n  local sum = 0\n  for i = 1, #weights do sum = sum + weights[i] end\n  return sum\nend",
+        "function_for_item": "",
+        "function_for_common": "f"
+      },
+      "metadata": {
+        "common_input": ["weights"],
+        "item_input": [],
+        "common_output": ["total_weight"],
+        "item_output": []
+      },
+      "input": {
+        "common": { "weights": [1.5, 2.5, 3.0] },
+        "items": []
+      },
+      "expected": {
+        "common": {
+          "total_weight": 7.0
+        }
+      }
+    },
+    {
+      "name": "item function returns a map",
+      "params": {
+        "lua_script": "function f() return {name=item_name, len=string.len(item_name)} end",
+        "function_for_item": "f",
+        "function_for_common": ""
+      },
+      "metadata": {
+        "common_input": [],
+        "item_input": ["item_name"],
+        "common_output": [],
+        "item_output": ["info"]
+      },
+      "input": {
+        "common": {},
+        "items": [
+          { "item_name": "hello" }
+        ]
+      },
+      "expected": {
+        "items": [
+          { "info": {"name": "hello", "len": 5} }
+        ]
+      }
+    }
+  ]
+}

--- a/pine-cpp/src/lua/lua_bridge.cpp
+++ b/pine-cpp/src/lua/lua_bridge.cpp
@@ -207,6 +207,33 @@ JsonValue LuaVM::to_value(int index) {
       const char* s = lua_tolstring(L_, index, &len);
       return JsonValue(std::string(s, len));
     }
+    case LUA_TTABLE: {
+      int abs_idx = (index > 0) ? index : lua_gettop(L_) + index + 1;
+      int len = static_cast<int>(lua_objlen(L_, abs_idx));
+      if (len > 0) {
+        std::vector<JsonValue> arr;
+        arr.reserve(static_cast<std::size_t>(len));
+        for (int i = 1; i <= len; ++i) {
+          lua_rawgeti(L_, abs_idx, i);
+          arr.push_back(to_value(-1));
+          lua_pop(L_, 1);
+        }
+        return JsonValue(std::move(arr));
+      }
+      std::map<std::string, JsonValue> obj;
+      lua_pushnil(L_);
+      while (lua_next(L_, abs_idx) != 0) {
+        if (lua_type(L_, -2) == LUA_TSTRING) {
+          std::string key = lua_tostring(L_, -2);
+          obj[key] = to_value(-1);
+        }
+        lua_pop(L_, 1);
+      }
+      if (obj.empty()) {
+        return JsonValue(std::vector<JsonValue>{});
+      }
+      return JsonValue(std::move(obj));
+    }
     default:
       return JsonValue();
   }

--- a/pine-cpp/src/lua/lua_bridge.cpp
+++ b/pine-cpp/src/lua/lua_bridge.cpp
@@ -223,10 +223,14 @@ JsonValue LuaVM::from_lua(int index) {
       std::map<std::string, JsonValue> obj;
       lua_pushnil(L_);
       while (lua_next(L_, abs_idx) != 0) {
-        if (lua_type(L_, -2) == LUA_TSTRING) {
-          std::string key = lua_tostring(L_, -2);
-          obj[key] = from_lua(-1);
+        if (lua_type(L_, -2) != LUA_TSTRING) {
+          const char* key_type = lua_typename(L_, lua_type(L_, -2));
+          lua_pop(L_, 2);
+          throw ExecutionError(std::string("lua: table has non-string key of type \"") + key_type + "\"");
         }
+        std::size_t klen;
+        const char* ks = lua_tolstring(L_, -2, &klen);
+        obj[std::string(ks, klen)] = from_lua(-1);
         lua_pop(L_, 1);
       }
       if (obj.empty()) {

--- a/pine-cpp/src/lua/lua_bridge.cpp
+++ b/pine-cpp/src/lua/lua_bridge.cpp
@@ -234,6 +234,7 @@ JsonValue LuaVM::from_lua(int index) {
         lua_pop(L_, 1);
       }
       if (obj.empty()) {
+        // Lua empty table → empty array (cross-runtime convention)
         return JsonValue(std::vector<JsonValue>{});
       }
       return JsonValue(std::move(obj));

--- a/pine-cpp/src/lua/lua_bridge.cpp
+++ b/pine-cpp/src/lua/lua_bridge.cpp
@@ -165,7 +165,7 @@ void LuaVM::load_script(const std::string& code, const std::string& op_name) {
   }
 }
 
-void LuaVM::push_value(const JsonValue& value) {
+void LuaVM::to_lua(const JsonValue& value) {
   if (value.is_null()) {
     lua_pushnil(L_);
   } else if (value.is_bool()) {
@@ -179,7 +179,7 @@ void LuaVM::push_value(const JsonValue& value) {
     const auto& arr = value.as_array();
     lua_createtable(L_, static_cast<int>(arr.size()), 0);
     for (std::size_t i = 0; i < arr.size(); ++i) {
-      push_value(arr[i]);
+      to_lua(arr[i]);
       lua_rawseti(L_, -2, static_cast<int>(i + 1));
     }
   } else if (value.is_object()) {
@@ -187,13 +187,13 @@ void LuaVM::push_value(const JsonValue& value) {
     lua_createtable(L_, 0, static_cast<int>(obj.size()));
     for (const auto& [k, v] : obj) {
       lua_pushlstring(L_, k.c_str(), k.size());
-      push_value(v);
+      to_lua(v);
       lua_rawset(L_, -3);
     }
   }
 }
 
-JsonValue LuaVM::to_value(int index) {
+JsonValue LuaVM::from_lua(int index) {
   int t = lua_type(L_, index);
   switch (t) {
     case LUA_TNIL:
@@ -215,7 +215,7 @@ JsonValue LuaVM::to_value(int index) {
         arr.reserve(static_cast<std::size_t>(len));
         for (int i = 1; i <= len; ++i) {
           lua_rawgeti(L_, abs_idx, i);
-          arr.push_back(to_value(-1));
+          arr.push_back(from_lua(-1));
           lua_pop(L_, 1);
         }
         return JsonValue(std::move(arr));
@@ -225,7 +225,7 @@ JsonValue LuaVM::to_value(int index) {
       while (lua_next(L_, abs_idx) != 0) {
         if (lua_type(L_, -2) == LUA_TSTRING) {
           std::string key = lua_tostring(L_, -2);
-          obj[key] = to_value(-1);
+          obj[key] = from_lua(-1);
         }
         lua_pop(L_, 1);
       }
@@ -240,14 +240,14 @@ JsonValue LuaVM::to_value(int index) {
 }
 
 void LuaVM::set_global(const std::string& name, const JsonValue& value) {
-  push_value(value);
+  to_lua(value);
   lua_setglobal(L_, name.c_str());
 }
 
 void LuaVM::set_global_table(const std::string& name, const std::vector<JsonValue>& values) {
   lua_createtable(L_, static_cast<int>(values.size()), 0);
   for (std::size_t i = 0; i < values.size(); ++i) {
-    push_value(values[i]);
+    to_lua(values[i]);
     lua_rawseti(L_, -2, static_cast<int>(i + 1));
   }
   lua_setglobal(L_, name.c_str());
@@ -276,7 +276,7 @@ std::vector<JsonValue> LuaVM::call_function(const std::string& func_name, int nr
         throw ExecutionError(op_name, "lua returned NaN");
       }
     }
-    results.push_back(to_value(idx));
+    results.push_back(from_lua(idx));
   }
   lua_pop(L_, nret);
   return results;

--- a/pine-cpp/src/lua/lua_bridge.hpp
+++ b/pine-cpp/src/lua/lua_bridge.hpp
@@ -41,8 +41,8 @@ class LuaVM {
   }
 
  private:
-  void push_value(const JsonValue& value);
-  JsonValue to_value(int index);
+  void to_lua(const JsonValue& value);
+  JsonValue from_lua(int index);
   lua_State* L_;
 };
 

--- a/pine-go/operators/lua/lua.go
+++ b/pine-go/operators/lua/lua.go
@@ -129,7 +129,7 @@ func (o *LuaOp) Execute(ctx context.Context, in *pine.OperatorInput, out *pine.O
 func (o *LuaOp) executeForItem(L *glua.LState, in *pine.OperatorInput, out *pine.OperatorOutput) error {
 	// Set common globals once
 	for _, field := range o.CommonInput {
-		L.SetGlobal(field, goToLua(L, in.Common(field)))
+		L.SetGlobal(field, toLua(L, in.Common(field)))
 	}
 
 	fn := L.GetGlobal(o.funcName)
@@ -143,7 +143,7 @@ func (o *LuaOp) executeForItem(L *glua.LState, in *pine.OperatorInput, out *pine
 	for i := 0; i < n; i++ {
 		// Set item globals for this item
 		for _, field := range o.ItemInput {
-			L.SetGlobal(field, goToLua(L, in.Item(i, field)))
+			L.SetGlobal(field, toLua(L, in.Item(i, field)))
 		}
 
 		if err := L.CallByParam(glua.P{Fn: fn, NRet: nret, Protect: true}); err != nil {
@@ -152,7 +152,7 @@ func (o *LuaOp) executeForItem(L *glua.LState, in *pine.OperatorInput, out *pine
 
 		// Collect return values (stack has them in order, first return at bottom)
 		for j := 0; j < nret; j++ {
-			val := luaToGo(L.Get(-(nret - j)))
+			val := fromLua(L.Get(-(nret - j)))
 			out.SetItem(i, o.ItemOutput[j], val)
 		}
 		L.Pop(nret)
@@ -167,7 +167,7 @@ func (o *LuaOp) executeForItem(L *glua.LState, in *pine.OperatorInput, out *pine
 func (o *LuaOp) executeForCommon(L *glua.LState, in *pine.OperatorInput, out *pine.OperatorOutput) error {
 	// Set common globals as scalars
 	for _, field := range o.CommonInput {
-		L.SetGlobal(field, goToLua(L, in.Common(field)))
+		L.SetGlobal(field, toLua(L, in.Common(field)))
 	}
 
 	// Set item fields as Lua tables (1-indexed arrays)
@@ -175,7 +175,7 @@ func (o *LuaOp) executeForCommon(L *glua.LState, in *pine.OperatorInput, out *pi
 	for _, field := range o.ItemInput {
 		tbl := L.NewTable()
 		for i := 0; i < n; i++ {
-			tbl.Append(goToLua(L, in.Item(i, field)))
+			tbl.Append(toLua(L, in.Item(i, field)))
 		}
 		L.SetGlobal(field, tbl)
 	}
@@ -192,7 +192,7 @@ func (o *LuaOp) executeForCommon(L *glua.LState, in *pine.OperatorInput, out *pi
 
 	// Collect return values positionally
 	for j := 0; j < nret; j++ {
-		val := luaToGo(L.Get(-(nret - j)))
+		val := fromLua(L.Get(-(nret - j)))
 		out.SetCommon(o.CommonOutput[j], val)
 	}
 	L.Pop(nret)
@@ -200,8 +200,7 @@ func (o *LuaOp) executeForCommon(L *glua.LState, in *pine.OperatorInput, out *pi
 	return nil
 }
 
-// goToLua converts a Go value to a Lua value.
-func goToLua(L *glua.LState, v any) glua.LValue {
+func toLua(L *glua.LState, v any) glua.LValue {
 	if v == nil {
 		return glua.LNil
 	}
@@ -219,13 +218,13 @@ func goToLua(L *glua.LState, v any) glua.LValue {
 	case []any:
 		tbl := L.NewTable()
 		for _, elem := range x {
-			tbl.Append(goToLua(L, elem))
+			tbl.Append(toLua(L, elem))
 		}
 		return tbl
 	case map[string]any:
 		tbl := L.NewTable()
 		for k, val := range x {
-			L.SetField(tbl, k, goToLua(L, val))
+			L.SetField(tbl, k, toLua(L, val))
 		}
 		return tbl
 	default:
@@ -234,13 +233,13 @@ func goToLua(L *glua.LState, v any) glua.LValue {
 		case reflect.Slice, reflect.Array:
 			tbl := L.NewTable()
 			for i := 0; i < rv.Len(); i++ {
-				tbl.Append(goToLua(L, rv.Index(i).Interface()))
+				tbl.Append(toLua(L, rv.Index(i).Interface()))
 			}
 			return tbl
 		case reflect.Map:
 			tbl := L.NewTable()
 			for _, k := range rv.MapKeys() {
-				L.SetField(tbl, fmt.Sprint(k.Interface()), goToLua(L, rv.MapIndex(k).Interface()))
+				L.SetField(tbl, fmt.Sprint(k.Interface()), toLua(L, rv.MapIndex(k).Interface()))
 			}
 			return tbl
 		}
@@ -248,8 +247,7 @@ func goToLua(L *glua.LState, v any) glua.LValue {
 	}
 }
 
-// luaToGo converts a Lua value to a Go value.
-func luaToGo(v glua.LValue) any {
+func fromLua(v glua.LValue) any {
 	switch x := v.(type) {
 	case *glua.LNilType:
 		return nil
@@ -264,13 +262,13 @@ func luaToGo(v glua.LValue) any {
 		if maxN > 0 {
 			arr := make([]any, 0, maxN)
 			for i := 1; i <= maxN; i++ {
-				arr = append(arr, luaToGo(x.RawGetInt(i)))
+				arr = append(arr, fromLua(x.RawGetInt(i)))
 			}
 			return arr
 		}
 		m := make(map[string]any)
 		x.ForEach(func(key, val glua.LValue) {
-			m[fmt.Sprint(luaToGo(key))] = luaToGo(val)
+			m[fmt.Sprint(fromLua(key))] = fromLua(val)
 		})
 		if len(m) == 0 {
 			return []any{}

--- a/pine-go/operators/lua/lua.go
+++ b/pine-go/operators/lua/lua.go
@@ -268,15 +268,25 @@ func fromLua(v glua.LValue) (any, error) {
 	case *glua.LTable:
 		maxN := x.MaxN()
 		if maxN > 0 {
-			arr := make([]any, 0, maxN)
+			// Verify it's a contiguous sequence 1..maxN (no holes)
+			contiguous := true
 			for i := 1; i <= maxN; i++ {
-				elem, err := fromLua(x.RawGetInt(i))
-				if err != nil {
-					return nil, err
+				if x.RawGetInt(i) == glua.LNil {
+					contiguous = false
+					break
 				}
-				arr = append(arr, elem)
 			}
-			return arr, nil
+			if contiguous {
+				arr := make([]any, 0, maxN)
+				for i := 1; i <= maxN; i++ {
+					elem, err := fromLua(x.RawGetInt(i))
+					if err != nil {
+						return nil, err
+					}
+					arr = append(arr, elem)
+				}
+				return arr, nil
+			}
 		}
 		m := make(map[string]any)
 		var iterErr error

--- a/pine-go/operators/lua/lua.go
+++ b/pine-go/operators/lua/lua.go
@@ -23,6 +23,7 @@ package lua
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	pine "github.com/Liam0205/pineapple/pine-go"
 	"github.com/Liam0205/pineapple/pine-go/pkg/metrics"
@@ -215,8 +216,35 @@ func goToLua(L *glua.LState, v any) glua.LValue {
 		return glua.LNumber(float64(x))
 	case string:
 		return glua.LString(x)
+	case []any:
+		tbl := L.NewTable()
+		for _, elem := range x {
+			tbl.Append(goToLua(L, elem))
+		}
+		return tbl
+	case map[string]any:
+		tbl := L.NewTable()
+		for k, val := range x {
+			L.SetField(tbl, k, goToLua(L, val))
+		}
+		return tbl
 	default:
-		return glua.LString(fmt.Sprintf("%v", x))
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Slice, reflect.Array:
+			tbl := L.NewTable()
+			for i := 0; i < rv.Len(); i++ {
+				tbl.Append(goToLua(L, rv.Index(i).Interface()))
+			}
+			return tbl
+		case reflect.Map:
+			tbl := L.NewTable()
+			for _, k := range rv.MapKeys() {
+				L.SetField(tbl, fmt.Sprint(k.Interface()), goToLua(L, rv.MapIndex(k).Interface()))
+			}
+			return tbl
+		}
+		return glua.LString(fmt.Sprintf("%v", v))
 	}
 }
 
@@ -231,6 +259,23 @@ func luaToGo(v glua.LValue) any {
 		return float64(x)
 	case glua.LString:
 		return string(x)
+	case *glua.LTable:
+		maxN := x.MaxN()
+		if maxN > 0 {
+			arr := make([]any, 0, maxN)
+			for i := 1; i <= maxN; i++ {
+				arr = append(arr, luaToGo(x.RawGetInt(i)))
+			}
+			return arr
+		}
+		m := make(map[string]any)
+		x.ForEach(func(key, val glua.LValue) {
+			m[fmt.Sprint(luaToGo(key))] = luaToGo(val)
+		})
+		if len(m) == 0 {
+			return []any{}
+		}
+		return m
 	default:
 		return v.String()
 	}

--- a/pine-go/operators/lua/lua.go
+++ b/pine-go/operators/lua/lua.go
@@ -155,7 +155,7 @@ func (o *LuaOp) executeForItem(L *glua.LState, in *pine.OperatorInput, out *pine
 			val, err := fromLua(L.Get(-(nret - j)))
 			if err != nil {
 				L.Pop(nret)
-				return fmt.Errorf("lua: item[%d]: %w", i, err)
+				return fmt.Errorf("item[%d]: %w", i, err)
 			}
 			out.SetItem(i, o.ItemOutput[j], val)
 		}

--- a/pine-go/operators/lua/lua.go
+++ b/pine-go/operators/lua/lua.go
@@ -300,10 +300,12 @@ func fromLua(v glua.LValue) (any, error) {
 			return nil, iterErr
 		}
 		if len(m) == 0 {
+			// Lua empty table → empty array (cross-runtime convention)
 			return []any{}, nil
 		}
 		return m, nil
 	default:
+		// reflect.Kind not supported (struct, chan, func, etc.), fallback to string
 		return v.String(), nil
 	}
 }

--- a/pine-go/operators/lua/lua.go
+++ b/pine-go/operators/lua/lua.go
@@ -152,7 +152,11 @@ func (o *LuaOp) executeForItem(L *glua.LState, in *pine.OperatorInput, out *pine
 
 		// Collect return values (stack has them in order, first return at bottom)
 		for j := 0; j < nret; j++ {
-			val := fromLua(L.Get(-(nret - j)))
+			val, err := fromLua(L.Get(-(nret - j)))
+			if err != nil {
+				L.Pop(nret)
+				return fmt.Errorf("lua: item[%d]: %w", i, err)
+			}
 			out.SetItem(i, o.ItemOutput[j], val)
 		}
 		L.Pop(nret)
@@ -192,7 +196,11 @@ func (o *LuaOp) executeForCommon(L *glua.LState, in *pine.OperatorInput, out *pi
 
 	// Collect return values positionally
 	for j := 0; j < nret; j++ {
-		val := fromLua(L.Get(-(nret - j)))
+		val, err := fromLua(L.Get(-(nret - j)))
+		if err != nil {
+			L.Pop(nret)
+			return err
+		}
 		out.SetCommon(o.CommonOutput[j], val)
 	}
 	L.Pop(nret)
@@ -247,35 +255,56 @@ func toLua(L *glua.LState, v any) glua.LValue {
 	}
 }
 
-func fromLua(v glua.LValue) any {
+func fromLua(v glua.LValue) (any, error) {
 	switch x := v.(type) {
 	case *glua.LNilType:
-		return nil
+		return nil, nil
 	case glua.LBool:
-		return bool(x)
+		return bool(x), nil
 	case glua.LNumber:
-		return float64(x)
+		return float64(x), nil
 	case glua.LString:
-		return string(x)
+		return string(x), nil
 	case *glua.LTable:
 		maxN := x.MaxN()
 		if maxN > 0 {
 			arr := make([]any, 0, maxN)
 			for i := 1; i <= maxN; i++ {
-				arr = append(arr, fromLua(x.RawGetInt(i)))
+				elem, err := fromLua(x.RawGetInt(i))
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, elem)
 			}
-			return arr
+			return arr, nil
 		}
 		m := make(map[string]any)
+		var iterErr error
 		x.ForEach(func(key, val glua.LValue) {
-			m[fmt.Sprint(fromLua(key))] = fromLua(val)
+			if iterErr != nil {
+				return
+			}
+			strKey, ok := key.(glua.LString)
+			if !ok {
+				iterErr = fmt.Errorf("lua: table has non-string key of type %q", key.Type().String())
+				return
+			}
+			converted, err := fromLua(val)
+			if err != nil {
+				iterErr = err
+				return
+			}
+			m[string(strKey)] = converted
 		})
-		if len(m) == 0 {
-			return []any{}
+		if iterErr != nil {
+			return nil, iterErr
 		}
-		return m
+		if len(m) == 0 {
+			return []any{}, nil
+		}
+		return m, nil
 	default:
-		return v.String()
+		return v.String(), nil
 	}
 }
 

--- a/pine-go/operators/lua/lua.go
+++ b/pine-go/operators/lua/lua.go
@@ -268,23 +268,21 @@ func fromLua(v glua.LValue) (any, error) {
 	case *glua.LTable:
 		maxN := x.MaxN()
 		if maxN > 0 {
-			// Verify it's a contiguous sequence 1..maxN (no holes)
+			arr := make([]any, 0, maxN)
 			contiguous := true
 			for i := 1; i <= maxN; i++ {
-				if x.RawGetInt(i) == glua.LNil {
+				raw := x.RawGetInt(i)
+				if raw == glua.LNil {
 					contiguous = false
 					break
 				}
+				elem, err := fromLua(raw)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, elem)
 			}
 			if contiguous {
-				arr := make([]any, 0, maxN)
-				for i := 1; i <= maxN; i++ {
-					elem, err := fromLua(x.RawGetInt(i))
-					if err != nil {
-						return nil, err
-					}
-					arr = append(arr, elem)
-				}
 				return arr, nil
 			}
 		}

--- a/pine-java/src/main/java/page/liam/pine/operators/TransformByLua.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/TransformByLua.java
@@ -256,7 +256,7 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
             while (true) {
                 Varargs n = tbl.next(k);
                 if ((k = n.arg1()).isnil()) break;
-                if (!k.isstring()) {
+                if (k.type() != LuaValue.TSTRING) {
                     throw new PineErrors.OperatorException(
                             "lua: table has non-string key of type \"" + k.typename() + "\"");
                 }

--- a/pine-java/src/main/java/page/liam/pine/operators/TransformByLua.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/TransformByLua.java
@@ -262,6 +262,7 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
                 }
                 map.put(k.tojstring(), fromLua(n.arg(2)));
             }
+            // Lua empty table → empty array (cross-runtime convention)
             if (map.isEmpty()) return new ArrayList<>();
             return map;
         }

--- a/pine-java/src/main/java/page/liam/pine/operators/TransformByLua.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/TransformByLua.java
@@ -213,6 +213,20 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
         if (v instanceof Boolean) return LuaValue.valueOf((Boolean) v);
         if (v instanceof Number) return LuaValue.valueOf(((Number) v).doubleValue());
         if (v instanceof String) return LuaValue.valueOf((String) v);
+        if (v instanceof List<?> list) {
+            LuaTable tbl = new LuaTable();
+            for (int i = 0; i < list.size(); i++) {
+                tbl.set(i + 1, toLua(list.get(i)));
+            }
+            return tbl;
+        }
+        if (v instanceof Map<?, ?> map) {
+            LuaTable tbl = new LuaTable();
+            for (Map.Entry<?, ?> e : map.entrySet()) {
+                tbl.set(String.valueOf(e.getKey()), toLua(e.getValue()));
+            }
+            return tbl;
+        }
         return LuaValue.valueOf(String.valueOf(v));
     }
 
@@ -227,6 +241,26 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
             return d;
         }
         if (v.isstring()) return v.tojstring();
+        if (v.istable()) {
+            LuaTable tbl = v.checktable();
+            int len = tbl.length();
+            if (len > 0) {
+                List<Object> arr = new ArrayList<>(len);
+                for (int i = 1; i <= len; i++) {
+                    arr.add(toJava(tbl.get(i)));
+                }
+                return arr;
+            }
+            Map<String, Object> map = new LinkedHashMap<>();
+            LuaValue k = LuaValue.NIL;
+            while (true) {
+                Varargs n = tbl.next(k);
+                if ((k = n.arg1()).isnil()) break;
+                map.put(k.tojstring(), toJava(n.arg(2)));
+            }
+            if (map.isEmpty()) return new ArrayList<>();
+            return map;
+        }
         return v.tojstring();
     }
 

--- a/pine-java/src/main/java/page/liam/pine/operators/TransformByLua.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/TransformByLua.java
@@ -156,7 +156,7 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
                 throw new Exception("lua: item[" + i + "]: " + e.getMessage(), e);
             }
             for (int j = 0; j < nret; j++) {
-                Object val = toJava(results.arg(j + 1));
+                Object val = fromLua(results.arg(j + 1));
                 output.setItem(i, itemOutput().get(j), val);
             }
         }
@@ -188,7 +188,7 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
         int nret = commonOutput().size();
         Varargs results = fn.invoke(LuaValue.NONE);
         for (int j = 0; j < nret; j++) {
-            Object val = toJava(results.arg(j + 1));
+            Object val = fromLua(results.arg(j + 1));
             output.setCommon(commonOutput().get(j), val);
         }
     }
@@ -230,7 +230,7 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
         return LuaValue.valueOf(String.valueOf(v));
     }
 
-    private static Object toJava(LuaValue v) {
+    private static Object fromLua(LuaValue v) {
         if (v.isnil()) return null;
         if (v.isboolean()) return v.toboolean();
         if (v.isnumber()) {
@@ -247,7 +247,7 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
             if (len > 0) {
                 List<Object> arr = new ArrayList<>(len);
                 for (int i = 1; i <= len; i++) {
-                    arr.add(toJava(tbl.get(i)));
+                    arr.add(fromLua(tbl.get(i)));
                 }
                 return arr;
             }
@@ -256,7 +256,7 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
             while (true) {
                 Varargs n = tbl.next(k);
                 if ((k = n.arg1()).isnil()) break;
-                map.put(k.tojstring(), toJava(n.arg(2)));
+                map.put(k.tojstring(), fromLua(n.arg(2)));
             }
             if (map.isEmpty()) return new ArrayList<>();
             return map;

--- a/pine-java/src/main/java/page/liam/pine/operators/TransformByLua.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/TransformByLua.java
@@ -230,7 +230,7 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
         return LuaValue.valueOf(String.valueOf(v));
     }
 
-    private static Object fromLua(LuaValue v) {
+    private static Object fromLua(LuaValue v) throws PineErrors.OperatorException {
         if (v.isnil()) return null;
         if (v.isboolean()) return v.toboolean();
         if (v.isnumber()) {
@@ -256,6 +256,10 @@ public class TransformByLua extends AbstractOperator implements ConcurrentSafe, 
             while (true) {
                 Varargs n = tbl.next(k);
                 if ((k = n.arg1()).isnil()) break;
+                if (!k.isstring()) {
+                    throw new PineErrors.OperatorException(
+                            "lua: table has non-string key of type \"" + k.typename() + "\"");
+                }
                 map.put(k.tojstring(), fromLua(n.arg(2)));
             }
             if (map.isEmpty()) return new ArrayList<>();

--- a/pine-python/pine/operators/transform_by_lua.py
+++ b/pine-python/pine/operators/transform_by_lua.py
@@ -153,18 +153,18 @@ class TransformByLua(
                 raise OperatorException(f"lua: item[{i}]: {e}") from e
 
             if nret == 1:
-                val = _to_python(results)
+                val = _from_lua(results)
                 if val is not None:
                     output.set_item(i, self.item_output()[0], val)
             elif nret > 1:
                 # Multiple returns come as a tuple
                 if isinstance(results, tuple):
                     for j in range(min(nret, len(results))):
-                        val = _to_python(results[j])
+                        val = _from_lua(results[j])
                         if val is not None:
                             output.set_item(i, self.item_output()[j], val)
                 else:
-                    val = _to_python(results)
+                    val = _from_lua(results)
                     if val is not None:
                         output.set_item(i, self.item_output()[0], val)
 
@@ -200,13 +200,13 @@ class TransformByLua(
         results = fn()
 
         if nret == 1:
-            output.set_common(self.common_output()[0], _to_python(results))
+            output.set_common(self.common_output()[0], _from_lua(results))
         elif nret > 1:
             if isinstance(results, tuple):
                 for j in range(min(nret, len(results))):
-                    output.set_common(self.common_output()[j], _to_python(results[j]))
+                    output.set_common(self.common_output()[j], _from_lua(results[j]))
             else:
-                output.set_common(self.common_output()[0], _to_python(results))
+                output.set_common(self.common_output()[0], _from_lua(results))
 
 
 def _create_lua_runtime() -> "LuaRuntime":
@@ -246,7 +246,7 @@ def _to_lua(runtime: "LuaRuntime", v: Any) -> Any:
     return str(v)
 
 
-def _to_python(v: Any) -> Any:
+def _from_lua(v: Any) -> Any:
     """Convert Lua value to Python value."""
     if v is None:
         return None
@@ -272,13 +272,13 @@ def _to_python(v: Any) -> Any:
         if length > 0:
             arr = []
             for i in range(1, length + 1):
-                arr.append(_to_python(v[i]))
+                arr.append(_from_lua(v[i]))
             return arr
         # String-keyed table
         m: dict[str, Any] = {}
         try:
             for k, val in v.items():
-                m[str(_to_python(k))] = _to_python(val)
+                m[str(_from_lua(k))] = _from_lua(val)
         except Exception:
             pass
         if not m:

--- a/pine-python/pine/operators/transform_by_lua.py
+++ b/pine-python/pine/operators/transform_by_lua.py
@@ -233,6 +233,16 @@ def _to_lua(runtime: "LuaRuntime", v: Any) -> Any:
         return float(v)
     if isinstance(v, str):
         return v
+    if isinstance(v, (list, tuple)):
+        tbl = runtime.table()
+        for i, elem in enumerate(v, 1):
+            tbl[i] = _to_lua(runtime, elem)
+        return tbl
+    if isinstance(v, dict):
+        tbl = runtime.table()
+        for k, val in v.items():
+            tbl[str(k)] = _to_lua(runtime, val)
+        return tbl
     return str(v)
 
 
@@ -253,7 +263,27 @@ def _to_python(v: Any) -> Any:
         return v
     if isinstance(v, str):
         return v
-    # lupa table objects
+    # lupa table objects — check for table-like interface
+    if hasattr(v, "__len__") and hasattr(v, "__getitem__"):
+        try:
+            length = len(v)
+        except Exception:
+            length = 0
+        if length > 0:
+            arr = []
+            for i in range(1, length + 1):
+                arr.append(_to_python(v[i]))
+            return arr
+        # String-keyed table
+        m: dict[str, Any] = {}
+        try:
+            for k, val in v.items():
+                m[str(_to_python(k))] = _to_python(val)
+        except Exception:
+            pass
+        if not m:
+            return []
+        return m
     return str(v)
 
 

--- a/pine-python/pine/operators/transform_by_lua.py
+++ b/pine-python/pine/operators/transform_by_lua.py
@@ -295,6 +295,7 @@ def _from_lua(v: Any) -> Any:
                 )
             m[k] = _from_lua(val)
         if not m:
+            # Lua empty table → empty array (cross-runtime convention)
             return []
         return m
     return str(v)

--- a/pine-python/pine/operators/transform_by_lua.py
+++ b/pine-python/pine/operators/transform_by_lua.py
@@ -246,6 +246,17 @@ def _to_lua(runtime: "LuaRuntime", v: Any) -> Any:
     return str(v)
 
 
+def _lua_type_name(v: Any) -> str:
+    """Map a lupa-returned key to its Lua type name."""
+    if isinstance(v, bool):
+        return "boolean"
+    if isinstance(v, (int, float)):
+        return "number"
+    if hasattr(v, "__len__") and hasattr(v, "__getitem__"):
+        return "table"
+    return "userdata"
+
+
 def _from_lua(v: Any) -> Any:
     """Convert Lua value to Python value."""
     if v is None:
@@ -276,11 +287,13 @@ def _from_lua(v: Any) -> Any:
             return arr
         # String-keyed table
         m: dict[str, Any] = {}
-        try:
-            for k, val in v.items():
-                m[str(_from_lua(k))] = _from_lua(val)
-        except Exception:
-            pass
+        for k, val in v.items():
+            if not isinstance(k, str):
+                lua_type_name = _lua_type_name(k)
+                raise OperatorException(
+                    f'lua: table has non-string key of type "{lua_type_name}"'
+                )
+            m[k] = _from_lua(val)
         if not m:
             return []
         return m

--- a/scripts/differential-fuzz.py
+++ b/scripts/differential-fuzz.py
@@ -91,6 +91,10 @@ LUA_ITEM_FUNCTIONS = [
     ("function compute()\n  return item_score * 1e-10 + 1e-10\nend", ["item_score"], ["item_result"]),
     ("function compute()\n  return item_score * item_score * item_score\nend", ["item_score"], ["item_result"]),
     ("function compute()\n  return (item_score - 0.3) * 1000000\nend", ["item_score"], ["item_result"]),
+    # Table input/output cases
+    ("function compute()\n  return #item_tags\nend", ["item_tags"], ["item_result"]),
+    ("function compute()\n  local s = 0\n  for i = 1, #item_vals do s = s + item_vals[i] end\n  return s\nend", ["item_vals"], ["item_result"]),
+    ("function compute()\n  return {item_score * 2, item_score * 3}\nend", ["item_score"], ["item_result"]),
 ]
 
 LUA_COMMON_FUNCTIONS = [
@@ -154,6 +158,12 @@ def random_items(rng: random.Random, fields: list[str], count: int, edge_weight:
                 item[f] = random_numeric(rng, edge_weight)
             elif "count" in f or "level" in f:
                 item[f] = rng.randint(0, 100)
+            elif f == "item_tags":
+                n = rng.randint(0, 5)
+                item[f] = [rng.choice(["a", "b", "c", "d", "e"]) for _ in range(n)]
+            elif f == "item_vals":
+                n = rng.randint(1, 5)
+                item[f] = [random_numeric(rng, edge_weight) for _ in range(n)]
             elif "tag" in f or "name" in f:
                 if rng.random() < edge_weight:
                     item[f] = rng.choice(["", "café", "🎉", "a\"b", "x\ny", None])


### PR DESCRIPTION
## Summary

Closes #46.

- **Go**: `goToLua` now converts `[]any`, `map[string]any`, and arbitrary typed slices/maps (via reflect) to Lua tables. `luaToGo` converts `*LTable` back to `[]any` or `map[string]any`.
- **C++**: `to_value` handles `LUA_TTABLE` — sequence tables (lua_objlen > 0) become JsonValue arrays, string-keyed tables become JsonValue objects.
- **Java**: `toLua` handles `List<?>` and `Map<?,?>`. `toJava` handles `v.istable()` with length-based array/map discrimination.
- **Python**: `_to_lua` handles list/tuple/dict. `_to_python` detects lupa table objects via `hasattr(v, "__len__")`.

All conversions are recursive (nested structures handled correctly).

## Test coverage

- New fixture: `fixtures/operators/transform_by_lua_tables.json` (6 cases covering array length, array indexing, map field access, returning arrays, common_input arrays, returning maps)
- Differential fuzz: 3 table-aware Lua functions added to fuzz corpus with corresponding field generators

## Test plan

- [ ] All 4 runtimes pass the new fixture (6/6 cases each)
- [ ] Existing transform_by_lua fixtures still pass (no regression)
- [ ] cross-validate passes
- [ ] differential-fuzz 50-round smoke test with table functions