### PR TITLE
fix(ci): enforce cross-validate as a blocking gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,13 @@ jobs:
           redis-server --version
       - name: Cross-validate Go vs Java vs Python vs C++
         run: bash scripts/cross-validate.sh | tee cross-validate-output.txt
+      - name: Fail on any divergence
+        run: |
+          if grep -q "^FAIL:" cross-validate-output.txt; then
+            echo "Cross-validation failures detected:"
+            grep "^FAIL:" cross-validate-output.txt
+            exit 1
+          fi
       - name: Write summary
         if: always()
         shell: bash

--- a/apple_generated/operators.py
+++ b/apple_generated/operators.py
@@ -337,7 +337,7 @@ class TransformBenchCpuOp(BaseOp):
     """Operator: transform_bench_cpu"""
     _name = "transform_bench_cpu"
     _params_schema = {
-        "iterations": {"type": "int64", "required": False, "default": 100},
+        "iterations": {"type": "int", "required": False, "default": 100},
     }
 
     def __call__(
@@ -374,7 +374,7 @@ class TransformBenchSleepOp(BaseOp):
     """Operator: transform_bench_sleep"""
     _name = "transform_bench_sleep"
     _params_schema = {
-        "delay_ms": {"type": "int64", "required": False, "default": 5},
+        "delay_ms": {"type": "int", "required": False, "default": 5},
     }
 
     def __call__(

--- a/doc/operators/transform_bench_cpu.md
+++ b/doc/operators/transform_bench_cpu.md
@@ -8,7 +8,7 @@ Benchmark-only CPU-bound operator. Computes iterative fib per item. Not availabl
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| iterations | int64 | No | `100` | Number of fib(32) computations per item. |
+| iterations | int | No | `100` | Number of fib(32) computations per item. |
 
 ## Metadata Contract
 

--- a/doc/operators/transform_bench_sleep.md
+++ b/doc/operators/transform_bench_sleep.md
@@ -8,7 +8,7 @@ Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation. Not 
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| delay_ms | int64 | No | `5` | Milliseconds to sleep per operator invocation. |
+| delay_ms | int | No | `5` | Milliseconds to sleep per operator invocation. |
 
 ## Metadata Contract
 

--- a/pine-go/operators/bench/bench_cpu.go
+++ b/pine-go/operators/bench/bench_cpu.go
@@ -12,7 +12,7 @@ func init() {
 		Type:        pine.OpTypeTransform,
 		Description: "Benchmark-only CPU-bound operator. Computes iterative fib per item. Not available in pine-python.",
 		Params: map[string]pine.ParamSpec{
-			"iterations": {Type: "int64", Required: false, Default: int64(100), Description: "Number of fib(32) computations per item."},
+			"iterations": {Type: "int", Required: false, Default: int(100), Description: "Number of fib(32) computations per item."},
 		},
 	}, func() pine.Operator {
 		return &BenchCPUOp{}
@@ -28,6 +28,8 @@ type BenchCPUOp struct {
 func (o *BenchCPUOp) Init(params map[string]any) error {
 	if v, ok := params["iterations"]; ok {
 		switch n := v.(type) {
+		case int:
+			o.iterations = n
 		case int64:
 			o.iterations = int(n)
 		case float64:

--- a/pine-go/operators/bench/bench_sleep.go
+++ b/pine-go/operators/bench/bench_sleep.go
@@ -13,7 +13,7 @@ func init() {
 		Type:        pine.OpTypeTransform,
 		Description: "Benchmark-only I/O-simulating operator. Sleeps for delay_ms per invocation. Not available in pine-python.",
 		Params: map[string]pine.ParamSpec{
-			"delay_ms": {Type: "int64", Required: false, Default: int64(5), Description: "Milliseconds to sleep per operator invocation."},
+			"delay_ms": {Type: "int", Required: false, Default: int(5), Description: "Milliseconds to sleep per operator invocation."},
 		},
 	}, func() pine.Operator {
 		return &BenchSleepOp{}
@@ -29,6 +29,8 @@ type BenchSleepOp struct {
 func (o *BenchSleepOp) Init(params map[string]any) error {
 	if v, ok := params["delay_ms"]; ok {
 		switch n := v.(type) {
+		case int:
+			o.delayMS = n
 		case int64:
 			o.delayMS = int(n)
 		case float64:

--- a/scripts/cross-validate/01-codegen-schema.sh
+++ b/scripts/cross-validate/01-codegen-schema.sh
@@ -128,9 +128,9 @@ echo "    Comparing Go vs Python schema structure..."
 if python3 -c "
 import json, sys
 
-# Operators intentionally absent from pine-python (Go-only).
-# Add here when a new Go-only operator is registered.
-GO_ONLY_OPERATORS = {
+# Operators intentionally absent from pine-python.
+# Add here when a new operator is registered in Go/Java/C++ but not pine-python.
+PYTHON_UNAVAILABLE_OPERATORS = {
     'transform_bench_cpu',
     'transform_bench_sleep',
 }
@@ -159,7 +159,7 @@ def extract_structure(schemas, skip=set()):
 go_data = json.load(open('$WORK_DIR/schema-go.json'))
 py_data = json.load(open('$WORK_DIR/schema-python.json'))
 
-go_struct = extract_structure(go_data, skip=GO_ONLY_OPERATORS)
+go_struct = extract_structure(go_data, skip=PYTHON_UNAVAILABLE_OPERATORS)
 py_struct = extract_structure(py_data)
 
 if go_struct == py_struct:
@@ -170,7 +170,7 @@ else:
         if op not in go_struct:
             print(f'  Python-only operator: {op}', file=sys.stderr)
         elif op not in py_struct:
-            print(f'  Go-only operator (unexpected — add to GO_ONLY_OPERATORS if intentional): {op}', file=sys.stderr)
+            print(f'  Go-only operator (unexpected — add to PYTHON_UNAVAILABLE_OPERATORS if intentional): {op}', file=sys.stderr)
         elif go_struct[op] != py_struct[op]:
             print(f'  Divergence in {op}:', file=sys.stderr)
             for p in sorted(set(go_struct[op]) | set(py_struct[op])):

--- a/scripts/cross-validate/01-codegen-schema.sh
+++ b/scripts/cross-validate/01-codegen-schema.sh
@@ -128,15 +128,24 @@ echo "    Comparing Go vs Python schema structure..."
 if python3 -c "
 import json, sys
 
+# Operators intentionally absent from pine-python (Go-only).
+# Add here when a new Go-only operator is registered.
+GO_ONLY_OPERATORS = {
+    'transform_bench_cpu',
+    'transform_bench_sleep',
+}
+
 def normalize_value(v):
     if isinstance(v, (int, float)):
         return float(v)
     return v
 
-def extract_structure(schemas):
+def extract_structure(schemas, skip=set()):
     result = {}
     for op in schemas:
         name = op.get('Name', '')
+        if name in skip:
+            continue
         params = {}
         for pname, pspec in op.get('Params', {}).items():
             params[pname] = {
@@ -150,7 +159,7 @@ def extract_structure(schemas):
 go_data = json.load(open('$WORK_DIR/schema-go.json'))
 py_data = json.load(open('$WORK_DIR/schema-python.json'))
 
-go_struct = extract_structure(go_data)
+go_struct = extract_structure(go_data, skip=GO_ONLY_OPERATORS)
 py_struct = extract_structure(py_data)
 
 if go_struct == py_struct:
@@ -161,7 +170,7 @@ else:
         if op not in go_struct:
             print(f'  Python-only operator: {op}', file=sys.stderr)
         elif op not in py_struct:
-            print(f'  Go-only operator: {op}', file=sys.stderr)
+            print(f'  Go-only operator (unexpected — add to GO_ONLY_OPERATORS if intentional): {op}', file=sys.stderr)
         elif go_struct[op] != py_struct[op]:
             print(f'  Divergence in {op}:', file=sys.stderr)
             for p in sorted(set(go_struct[op]) | set(py_struct[op])):


### PR DESCRIPTION
## Summary

- **CI**: Add a \"Fail on any divergence\" step after `cross-validate.sh` that exits 1 if any `FAIL:` line is present. Previously the step only wrote a summary table — divergences were visible but never blocked merges.
- **Go schema**: Fix `transform_bench_cpu.iterations` and `transform_bench_sleep.delay_ms` declared as `int64` in Go but `int` in Java/C++/Python, causing 4 pre-existing FAILs on master. Changed Go schema type to `"int"` and added `case int:` to `Init()`.
- **cross-validate script**: Add `PYTHON_UNAVAILABLE_OPERATORS` allowlist in the Go vs Python schema comparison. `transform_bench_cpu` and `transform_bench_sleep` are intentionally absent from pine-python (documented as "Not available in pine-python") — the script was treating their absence as a failure. Unexpected Go-only operators still fail with a clear message.

## Test plan

- [ ] Local `bash scripts/cross-validate/01-codegen-schema.sh` passes 4/4 checks (verified)
- [ ] CI cross-validation job passes with 0 FAILs
- [ ] CI `cross-validation` job now fails the build if any new divergence is introduced