### PR TITLE
docs: 自动更新 llmdoc 文档 (2026-05-29)

### DIFF
--- a/llmdoc/guides/ci-quality-baseline.md
+++ b/llmdoc/guides/ci-quality-baseline.md
@@ -159,6 +159,8 @@ fuzz 通用策略分两步推进：
 
 `scripts/cross-validate.sh` 运行多 section 跨运行时校验。具体 section 列表以 `scripts/cross-validate/` 目录为准，禁止在本指南中硬编码层数。sections 默认并行执行（`scripts/cross-validate/_parallel.sh` 调度），`--serial` 可回退串行；单 section 内各运行时也并行运行。
 
+CI 中 `cross-validate.sh` 的输出会被捕获到 `cross-validate-output.txt`，随后由独立的 `Fail on any divergence` step 在出现以 `FAIL:` 开头的行时显式 `exit 1`，使 CI job 失败。新增 section 输出格式时若使用其他失败标记，需确认能被该 grep 捕获，避免分歧被静默吞掉。
+
 C++ 端是否参与某次比对取决于该 section 中对 `CPP_RUN` / `CPP_DAG` / `CPP_SERVER` / `CPP_CODEGEN` 的引用，以及 `scripts/cross-validate/_prebuild.sh` 是否成功构建 pine-cpp 二进制（输出到 `$WORK_DIR/pineapple-*-cpp`）。
 
 ### 端口隔离

--- a/llmdoc/reference/operator-contract.md
+++ b/llmdoc/reference/operator-contract.md
@@ -29,6 +29,8 @@ Java 侧为独立 Schema 源，拥有完整的 schema-based 注册：`Registry.r
 
 `AllOperators.java` 中的注册清单含两个 benchmark 专用算子（`transform_bench_cpu` / `transform_bench_sleep`），与 pine-go `pine-go/operators/bench/` 对齐；pine-python 不实现这两个算子（其 `Description` 显式标注 "Not available in pine-python"）。
 
+新增 Python 不实现的算子时，必须同步把算子名加入 `scripts/cross-validate/01-codegen-schema.sh` 中的 `PYTHON_UNAVAILABLE_OPERATORS` 集合，否则 Go vs Python schema 结构比对会因 "Go-only operator" 在 CI 失败。错误信息会显式提示 `add to PYTHON_UNAVAILABLE_OPERATORS if intentional`。
+
 ## 算子生命周期
 
 算子实例经历两个阶段。


### PR DESCRIPTION
## llmdoc 文档自动更新

由 GitHub Actions 定时任务自动生成，基于过去 24 hours 合并到 `master` 分支的代码变更。

### 触发该次更新的提交

- `2bbb794` fix(ci): enforce cross-validate failures as CI errors
- `3cc1290` fix(cross-validate): skip Go-only operators in Go vs Python schema check
- `3431399` fix(cross-validate): rename GO_ONLY_OPERATORS to PYTHON_UNAVAILABLE_OPERATORS
- `80b5a21` chore(codegen): regenerate after int64→int schema fix for bench operators

### 主要更新点

- **operator-contract**: 在 `transform_bench_cpu` / `transform_bench_sleep` 说明后补充 `PYTHON_UNAVAILABLE_OPERATORS` 白名单约定 — 新增 Python 不实现的算子时必须同步 `scripts/cross-validate/01-codegen-schema.sh` 中的集合，否则 Go vs Python schema 比对会以 "Go-only operator" 失败。
- **ci-quality-baseline**: cross-validate 章节新增 "Fail on any divergence" step 说明 — CI 捕获 `cross-validate-output.txt` 中以 `FAIL:` 开头的行并显式 `exit 1`，新增 section 输出格式时需确保失败信号能被该 grep 捕获，避免分歧被静默吞掉。

### 未触发文档更新的变更

- `int64 → int` schema 类型修正属于纯 codegen 修复，不改变外部行为，且 `operator-contract.md` 既有 `pythonType()` 映射表已声明 `"int"` / `"int64"` 均映射为 `int`，无需变更。
- `GO_ONLY_OPERATORS → PYTHON_UNAVAILABLE_OPERATORS` 是脚本内部变量重命名，已纳入白名单约定段落，不再单独描述。

**请检查文档内容是否准确后合并。**