### PR TITLE
chore(pine-cpp): apply clang-format to remaining source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,13 +48,8 @@ java-pine/target/
 # Redis dump file from local testing
 dump.rdb
 
-# C++ build artifacts (sanitizer variants — keep main build/ ignored by default)
-pine-cpp/build/
-pine-cpp/build-asan/
-pine-cpp/build-gprof/
-pine-cpp/build-tests/
-pine-cpp/build-werror/
-pine-cpp/build-lint/
-pine-cpp/build/
+# C++ build artifacts (all build-* variants)
+pine-cpp/build*/
+Testing/
 .clang-format.preferred
 bench-results/

--- a/pine-cpp/include/pine/arena.hpp
+++ b/pine-cpp/include/pine/arena.hpp
@@ -16,8 +16,8 @@ namespace detail {
 // Individual threads grab chunks from here and sub-allocate locally (lock-free).
 class CentralArena {
  public:
-  explicit CentralArena(std::size_t initial_size)
-      : mono_(initial_size, std::pmr::new_delete_resource()) {}
+  explicit CentralArena(std::size_t initial_size) : mono_(initial_size, std::pmr::new_delete_resource()) {
+  }
 
   void* allocate(std::size_t bytes, std::size_t alignment) {
     std::lock_guard<std::mutex> lk(mu_);
@@ -35,7 +35,8 @@ class CentralArena {
 // Deallocation is a no-op (arena pattern).
 class ThreadLocalBump final : public std::pmr::memory_resource {
  public:
-  explicit ThreadLocalBump(CentralArena* central) : central_(central) {}
+  explicit ThreadLocalBump(CentralArena* central) : central_(central) {
+  }
 
  protected:
   void* do_allocate(std::size_t bytes, std::size_t alignment) override {
@@ -61,7 +62,8 @@ class ThreadLocalBump final : public std::pmr::memory_resource {
     return ptr;
   }
 
-  void do_deallocate(void*, std::size_t, std::size_t) noexcept override {}
+  void do_deallocate(void*, std::size_t, std::size_t) noexcept override {
+  }
 
   bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override {
     return this == &other;
@@ -102,7 +104,8 @@ class ArenaAllocator {
 
   ArenaAllocator() noexcept = default;
   template <typename U>
-  ArenaAllocator(const ArenaAllocator<U>&) noexcept {}
+  ArenaAllocator(const ArenaAllocator<U>&) noexcept {
+  }
 
   T* allocate(std::size_t n) {
     return static_cast<T*>(detail::tl_resource->allocate(n * sizeof(T), alignof(T)));
@@ -127,7 +130,9 @@ class ScopedInstall {
       : bump_(central), prev_(detail::tl_resource) {
     detail::tl_resource = &bump_;
   }
-  ~ScopedInstall() { detail::tl_resource = prev_; }
+  ~ScopedInstall() {
+    detail::tl_resource = prev_;
+  }
   ScopedInstall(const ScopedInstall&) = delete;
   ScopedInstall& operator=(const ScopedInstall&) = delete;
 
@@ -152,7 +157,10 @@ class ScopedInstall {
 class RequestArena {
  public:
   explicit RequestArena(std::size_t initial_size = 256 * 1024)
-      : central_(initial_size), bump_(&central_), prev_(detail::tl_resource), prev_central_(detail::tl_central) {
+      : central_(initial_size),
+        bump_(&central_),
+        prev_(detail::tl_resource),
+        prev_central_(detail::tl_central) {
     detail::tl_resource = &bump_;
     detail::tl_central = &central_;
   }
@@ -165,7 +173,9 @@ class RequestArena {
   RequestArena(const RequestArena&) = delete;
   RequestArena& operator=(const RequestArena&) = delete;
 
-  detail::CentralArena* central() noexcept { return &central_; }
+  detail::CentralArena* central() noexcept {
+    return &central_;
+  }
 
  private:
   detail::CentralArena central_;

--- a/pine-cpp/include/pine/operator_input.hpp
+++ b/pine-cpp/include/pine/operator_input.hpp
@@ -29,7 +29,9 @@ class OperatorInput {
   Variant common(const std::string& field) const;
 
   // item_count returns the number of items.
-  std::size_t item_count() const { return cached_item_count_; }
+  std::size_t item_count() const {
+    return cached_item_count_;
+  }
 
   // item returns the value for (index, field), or null if absent.
   // Substitutes defaults for nil values.

--- a/pine-cpp/include/pine/pine.hpp
+++ b/pine-cpp/include/pine/pine.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include "pine/metrics.hpp"
-
 #include "pine/arena.hpp"
 #include "pine/flat_map.hpp"
+#include "pine/metrics.hpp"
 
 #include <atomic>
 #include <exception>
@@ -258,7 +257,7 @@ struct FlowContract {
 struct ResourceEntry {
   std::string type;
   int interval = 0;  // seconds
-  Variant params;  // arbitrary object passed to the fetcher factory
+  Variant params;    // arbitrary object passed to the fetcher factory
 };
 
 struct Config {
@@ -467,8 +466,7 @@ class Engine {
   // Execute(ctx, req) where ctx.Done() is watched at every wait.
   Result execute(const Request& request, const std::map<std::string, Variant>& resources,
                  std::stop_token external_cancel) const;
-  TracedResult execute_traced(const Request& request,
-                              const std::map<std::string, Variant>& resources) const;
+  TracedResult execute_traced(const Request& request, const std::map<std::string, Variant>& resources) const;
   // Variant of execute_traced that writes the partial result/trace/warnings
   // into *out before re-throwing any execution error. Mirrors pine-go's
   // (*Result, error) return contract where partial results survive errors.

--- a/pine-cpp/operators/_helpers.cpp
+++ b/pine-cpp/operators/_helpers.cpp
@@ -64,7 +64,7 @@ Variant require_common(const Frame& frame, const OperatorConfig& op, const std::
 }
 
 Variant require_item(const Frame& frame, const OperatorConfig& op, std::size_t index,
-                       const std::string& field) {
+                     const std::string& field) {
   Variant v = frame.item(index, field);
   if (!v.is_null()) {
     return v;
@@ -76,7 +76,7 @@ Variant require_item(const Frame& frame, const OperatorConfig& op, std::size_t i
 }
 
 Variant require_common_by_name(const Frame& frame, const std::map<std::string, Variant>& defaults,
-                                 const std::string& field) {
+                               const std::string& field) {
   Variant v = frame.common(field);
   if (!v.is_null()) {
     return v;
@@ -88,7 +88,7 @@ Variant require_common_by_name(const Frame& frame, const std::map<std::string, V
 }
 
 Variant require_item_by_name(const Frame& frame, std::size_t index,
-                               const std::map<std::string, Variant>& defaults, const std::string& field) {
+                             const std::map<std::string, Variant>& defaults, const std::string& field) {
   Variant v = frame.item(index, field);
   if (!v.is_null()) {
     return v;

--- a/pine-cpp/operators/_helpers.hpp
+++ b/pine-cpp/operators/_helpers.hpp
@@ -30,7 +30,7 @@ std::string json_type_name(const Variant& value);
 
 Variant require_common(const Frame& frame, const OperatorConfig& op, const std::string& field);
 Variant require_item(const Frame& frame, const OperatorConfig& op, std::size_t index,
-                       const std::string& field);
+                     const std::string& field);
 
 // Variants that take the operator name + defaults map directly. Operators
 // that cached `op_name_` / `common_defaults_` / `item_defaults_` on `init`
@@ -38,9 +38,9 @@ Variant require_item(const Frame& frame, const OperatorConfig& op, std::size_t i
 // per-class copy of these helpers; consolidated to one place so future
 // error-message tweaks land once.
 Variant require_common_by_name(const Frame& frame, const std::map<std::string, Variant>& defaults,
-                                 const std::string& field);
+                               const std::string& field);
 Variant require_item_by_name(const Frame& frame, std::size_t index,
-                               const std::map<std::string, Variant>& defaults, const std::string& field);
+                             const std::map<std::string, Variant>& defaults, const std::string& field);
 
 std::string go_format_g(double d);
 // go_format_lookup_key mirrors pine-go transform/resource_lookup.go:91-96:

--- a/pine-cpp/src/config/json.cpp
+++ b/pine-cpp/src/config/json.cpp
@@ -1,7 +1,5 @@
 #include "pine/pine.hpp"
 
-#include "config/json_writer.hpp"
-
 #include <cctype>
 #include <charconv>
 #include <cmath>
@@ -9,6 +7,8 @@
 #include <fstream>
 #include <iomanip>
 #include <sstream>
+
+#include "config/json_writer.hpp"
 
 namespace pine {
 

--- a/pine-cpp/src/config/json_writer.cpp
+++ b/pine-cpp/src/config/json_writer.cpp
@@ -30,8 +30,7 @@ std::string result_common_to_json(const Variant::object_t& common) {
   for (const auto& [k, _] : common) {
     keys.push_back(&k);
   }
-  std::sort(keys.begin(), keys.end(),
-            [](const std::string* a, const std::string* b) { return *a < *b; });
+  std::sort(keys.begin(), keys.end(), [](const std::string* a, const std::string* b) { return *a < *b; });
   w.StartObject();
   for (const auto* key : keys) {
     w.Key(key->c_str(), static_cast<rapidjson::SizeType>(key->size()));
@@ -52,8 +51,7 @@ std::string result_items_to_json(const std::vector<Variant::object_t>& items) {
     for (const auto& [k, _] : row) {
       keys.push_back(&k);
     }
-    std::sort(keys.begin(), keys.end(),
-              [](const std::string* a, const std::string* b) { return *a < *b; });
+    std::sort(keys.begin(), keys.end(), [](const std::string* a, const std::string* b) { return *a < *b; });
     w.StartObject();
     for (const auto* key : keys) {
       w.Key(key->c_str(), static_cast<rapidjson::SizeType>(key->size()));

--- a/pine-cpp/src/dataframe/column.cpp
+++ b/pine-cpp/src/dataframe/column.cpp
@@ -46,7 +46,9 @@ void apply_remove(std::vector<bool>& validity, const std::set<int>& indices) {
   std::size_t write = 0;
   for (std::size_t i = 0; i < validity.size(); ++i) {
     if (!bitmap[i]) {
-      if (write != i) validity[write] = validity[i];
+      if (write != i) {
+        validity[write] = validity[i];
+      }
       ++write;
     }
   }
@@ -59,7 +61,9 @@ void apply_remove_data(std::vector<V>& data, const std::set<int>& indices) {
   std::size_t write = 0;
   for (std::size_t i = 0; i < data.size(); ++i) {
     if (!bitmap[i]) {
-      if (write != i) data[write] = std::move(data[i]);
+      if (write != i) {
+        data[write] = std::move(data[i]);
+      }
       ++write;
     }
   }

--- a/pine-cpp/src/dataframe/column_frame.cpp
+++ b/pine-cpp/src/dataframe/column_frame.cpp
@@ -36,8 +36,7 @@ std::string validate_value(const std::string& field, const Variant& value) {
 ColumnFrame::ColumnFrame() : items_(std::make_unique<TypedColumnStore>(0)) {
 }
 
-ColumnFrame::ColumnFrame(Variant::object_t common,
-                         std::vector<Variant::object_t> items)
+ColumnFrame::ColumnFrame(Variant::object_t common, std::vector<Variant::object_t> items)
     : common_(std::move(common)), items_(std::make_unique<TypedColumnStore>(items.size())) {
   // Collect the union of fields across items, preserving first-seen order.
   std::vector<std::string> field_order;

--- a/pine-cpp/src/dataframe/row_frame.cpp
+++ b/pine-cpp/src/dataframe/row_frame.cpp
@@ -26,8 +26,7 @@ std::string validate_value_row(const std::string& field, const Variant& value) {
 
 RowFrame::RowFrame() = default;
 
-RowFrame::RowFrame(Variant::object_t common,
-                   std::vector<Variant::object_t> items)
+RowFrame::RowFrame(Variant::object_t common, std::vector<Variant::object_t> items)
     : common_(std::move(common)) {
   items_.reserve(items.size());
   for (auto& row : items) {

--- a/pine-cpp/src/lua/lua_bridge.cpp
+++ b/pine-cpp/src/lua/lua_bridge.cpp
@@ -258,8 +258,7 @@ void LuaVM::set_global_table(const std::string& name, const Variant::array_t& va
   lua_setglobal(L_, name.c_str());
 }
 
-Variant::array_t LuaVM::call_function(const std::string& func_name, int nret,
-                                            const std::string& op_name) {
+Variant::array_t LuaVM::call_function(const std::string& func_name, int nret, const std::string& op_name) {
   lua_getglobal(L_, func_name.c_str());
   if (lua_type(L_, -1) != LUA_TFUNCTION) {
     lua_pop(L_, 1);

--- a/pine-cpp/src/server/server.cpp
+++ b/pine-cpp/src/server/server.cpp
@@ -1,6 +1,5 @@
 #include "server/server.hpp"
 
-#include "config/json_writer.hpp"
 #include "pine/resource.hpp"
 
 #include <sys/stat.h>
@@ -14,6 +13,7 @@
 #include <sstream>
 #include <thread>
 
+#include "config/json_writer.hpp"
 #include "server/http_stats.hpp"
 
 // POSIX socket headers
@@ -577,75 +577,75 @@ void Server::handle_execute(int client_fd, const std::string& method, const std:
     // Execute (R10-2: pass client_fd so engine sees client-disconnect cancel)
     auto exec_result = execute_with_trace(req, return_trace, client_fd);
 
-  // Build response JSON — match Go's executeResponse structure.
-  // Go writes resp.Common/Items from result only when result != nil; an
-  // engine-level error leaves them as nil maps → JSON `null`. A successful
-  // run that produces an empty common/items still serializes as `{}`/`[]`.
-  response = "{";
+    // Build response JSON — match Go's executeResponse structure.
+    // Go writes resp.Common/Items from result only when result != nil; an
+    // engine-level error leaves them as nil maps → JSON `null`. A successful
+    // run that produces an empty common/items still serializes as `{}`/`[]`.
+    response = "{";
 
-  if (!exec_result.has_result) {
-    response += "\"common\":null";
-    response += ",\"items\":null";
-  } else {
-    response += "\"common\":" + result_common_to_json(exec_result.result.common);
-    response += ",\"items\":" + result_items_to_json(exec_result.result.items);
-  }
-
-  // Warnings
-  if (!exec_result.warnings.empty()) {
-    response += ",\"warnings\":[";
-    for (size_t i = 0; i < exec_result.warnings.size(); ++i) {
-      if (i > 0) {
-        response += ",";
-      }
-      response += "\"" + json_escape(exec_result.warnings[i]) + "\"";
+    if (!exec_result.has_result) {
+      response += "\"common\":null";
+      response += ",\"items\":null";
+    } else {
+      response += "\"common\":" + result_common_to_json(exec_result.result.common);
+      response += ",\"items\":" + result_items_to_json(exec_result.result.items);
     }
-    response += "]";
-  }
 
-  // Trace
-  if (!exec_result.trace.empty()) {
-    response += ",\"trace\":[";
-    for (size_t i = 0; i < exec_result.trace.size(); ++i) {
-      if (i > 0) {
-        response += ",";
+    // Warnings
+    if (!exec_result.warnings.empty()) {
+      response += ",\"warnings\":[";
+      for (size_t i = 0; i < exec_result.warnings.size(); ++i) {
+        if (i > 0) {
+          response += ",";
+        }
+        response += "\"" + json_escape(exec_result.warnings[i]) + "\"";
       }
-      const auto& t = exec_result.trace[i];
-      response += "{\"name\":\"" + json_escape(t.name) + "\"";
-      response += ",\"duration_ms\":";
-      // Format duration_ms to match Go's encoding:
-      // Go uses float64 → json.Encoder which outputs minimal representation.
-      char dur_buf[64];
-      if (t.duration_ms == 0.0) {
-        response += "0";
-      } else {
-        int n = snprintf(dur_buf, sizeof(dur_buf), "%g", t.duration_ms);
-        response.append(dur_buf, static_cast<size_t>(n));
-      }
-      if (t.skipped) {
-        response += ",\"skipped\":true";
-      }
-      if (t.has_input_snapshot) {
-        response += ",\"input_snapshot\":" + dump_json_fast(t.input_snapshot, 0);
-      }
-      if (t.has_output_snapshot) {
-        response += ",\"output_snapshot\":" + dump_json_fast(t.output_snapshot, 0);
-      }
-      response += "}";
+      response += "]";
     }
-    response += "]";
-  }
 
-  // Error
-  if (exec_result.has_error) {
-    response += ",\"error\":\"" + json_escape(exec_result.error) + "\"";
-  }
+    // Trace
+    if (!exec_result.trace.empty()) {
+      response += ",\"trace\":[";
+      for (size_t i = 0; i < exec_result.trace.size(); ++i) {
+        if (i > 0) {
+          response += ",";
+        }
+        const auto& t = exec_result.trace[i];
+        response += "{\"name\":\"" + json_escape(t.name) + "\"";
+        response += ",\"duration_ms\":";
+        // Format duration_ms to match Go's encoding:
+        // Go uses float64 → json.Encoder which outputs minimal representation.
+        char dur_buf[64];
+        if (t.duration_ms == 0.0) {
+          response += "0";
+        } else {
+          int n = snprintf(dur_buf, sizeof(dur_buf), "%g", t.duration_ms);
+          response.append(dur_buf, static_cast<size_t>(n));
+        }
+        if (t.skipped) {
+          response += ",\"skipped\":true";
+        }
+        if (t.has_input_snapshot) {
+          response += ",\"input_snapshot\":" + dump_json_fast(t.input_snapshot, 0);
+        }
+        if (t.has_output_snapshot) {
+          response += ",\"output_snapshot\":" + dump_json_fast(t.output_snapshot, 0);
+        }
+        response += "}";
+      }
+      response += "]";
+    }
 
-  response += "}\n";
+    // Error
+    if (exec_result.has_error) {
+      response += ",\"error\":\"" + json_escape(exec_result.error) + "\"";
+    }
 
-  if (exec_result.has_error) {
-    status = exec_result.is_validation_error ? 400 : 500;
-  }
+    response += "}\n";
+
+    if (exec_result.has_error) {
+      status = exec_result.is_validation_error ? 400 : 500;
+    }
   }  // arena scope ends — all arena-allocated Variants freed
 
   send_json(client_fd, status, response);


### PR DESCRIPTION
## Summary

- Apply clang-format to 13 files in `pine-cpp/{include,src,operators}` that were missed during the PR #55 lint fix pass
- Update `.gitignore` to use `pine-cpp/build*/` glob (covers all build variant dirs) and add `Testing/` (CTest output)

Pure formatting, no behavior change.