### PR TITLE
refactor(apple): unify {{field}} syntax helpers (closes #76)

### DIFF
--- a/apple/_template_syntax.py
+++ b/apple/_template_syntax.py
@@ -1,0 +1,27 @@
+"""Shared `{{field}}` syntax primitives for the Apple compiler (issue #76).
+
+Both `apple/control.py` (if_/elseif_ predicates) and `apple/template.py`
+(operator-param interpolation) need to recognize the same `{{field}}` marker.
+This module centralizes the regex and the two extraction primitives so the
+two consumers stay byte-identical without coupling their downstream paths
+(Lua emission vs. pre-Execute value substitution).
+
+Private module: no public API surface — callers re-export selectively.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+TEMPLATE_PATTERN = re.compile(r"\{\{(\w+)\}\}")
+BARE_TEMPLATE_PATTERN = re.compile(r"^\{\{(\w+)\}\}$")
+
+
+def extract_fields(value: str) -> list[str]:
+    """Return ordered, deduped field names referenced inside ``{{...}}`` markers."""
+    return list(dict.fromkeys(TEMPLATE_PATTERN.findall(value)))
+
+
+def is_bare_template(value: Any) -> bool:
+    """Return True iff ``value`` is exactly ``{{field}}`` with no surrounding text."""
+    return isinstance(value, str) and bool(BARE_TEMPLATE_PATTERN.fullmatch(value))

--- a/apple/control.py
+++ b/apple/control.py
@@ -5,9 +5,10 @@ operators + skip fields, per design_doc/06_json_config.md.
 """
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field
 
+from apple._template_syntax import TEMPLATE_PATTERN as _TEMPLATE_PATTERN
+from apple._template_syntax import extract_fields as _extract_fields
 from apple.base import OpCall
 
 
@@ -28,20 +29,19 @@ class ControlBranch:
     ctrl_index: int  # global control op counter
 
 
-# NOTE: extract_fields / _strip_template here duplicate the {{field}} syntax
-# implemented by apple/template.py for operator-param interpolation (issue #74).
-# Kept separate for now because the if_/elseif_ path emits Lua and bakes the
-# field reference into the condition AST, while the param path is a pure
-# pre-Execute value substitution. Unification tracked in issue #76.
+# `{{field}}` syntax primitives are shared with apple/template.py via
+# apple/_template_syntax (issue #76). The control path keeps its own thin
+# wrappers because the downstream contracts differ: control emits Lua and
+# bakes field refs into the condition AST, while the param path is a pure
+# pre-Execute value substitution.
 def extract_fields(condition: str) -> list[str]:
     """Extract field names from ``{{field}}`` template markers in a condition."""
-    fields = re.findall(r"\{\{(\w+)\}\}", condition)
-    return list(dict.fromkeys(fields))
+    return _extract_fields(condition)
 
 
 def _strip_template(condition: str) -> str:
     """Replace ``{{field}}`` markers with bare field names for Lua emission."""
-    return re.sub(r"\{\{(\w+)\}\}", r"\1", condition)
+    return _TEMPLATE_PATTERN.sub(r"\1", condition)
 
 
 def make_control_op(

--- a/apple/control.py
+++ b/apple/control.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from apple._template_syntax import TEMPLATE_PATTERN as _TEMPLATE_PATTERN
-from apple._template_syntax import extract_fields as _extract_fields
+from apple._template_syntax import TEMPLATE_PATTERN, extract_fields
 from apple.base import OpCall
 
 
@@ -30,18 +29,12 @@ class ControlBranch:
 
 
 # `{{field}}` syntax primitives are shared with apple/template.py via
-# apple/_template_syntax (issue #76). The control path keeps its own thin
-# wrappers because the downstream contracts differ: control emits Lua and
-# bakes field refs into the condition AST, while the param path is a pure
-# pre-Execute value substitution.
-def extract_fields(condition: str) -> list[str]:
-    """Extract field names from ``{{field}}`` template markers in a condition."""
-    return _extract_fields(condition)
-
-
+# apple/_template_syntax (issue #76). `extract_fields` is re-exported as-is
+# so `from apple.control import extract_fields` callers keep working;
+# `_strip_template` stays here because Lua emission is control-only.
 def _strip_template(condition: str) -> str:
     """Replace ``{{field}}`` markers with bare field names for Lua emission."""
-    return _TEMPLATE_PATTERN.sub(r"\1", condition)
+    return TEMPLATE_PATTERN.sub(r"\1", condition)
 
 
 def make_control_op(

--- a/apple/template.py
+++ b/apple/template.py
@@ -18,9 +18,7 @@ from __future__ import annotations
 from typing import Any
 
 from apple._template_syntax import (
-    TEMPLATE_PATTERN as _TEMPLATE_PATTERN,
-)
-from apple._template_syntax import (
+    TEMPLATE_PATTERN,
     extract_fields,
     is_bare_template,
 )
@@ -35,7 +33,7 @@ __all__ = [
 
 def is_templated(value: Any) -> bool:
     """Return True iff ``value`` is a string containing at least one ``{{field}}`` marker."""
-    return isinstance(value, str) and bool(_TEMPLATE_PATTERN.search(value))
+    return isinstance(value, str) and bool(TEMPLATE_PATTERN.search(value))
 
 
 def extract_fields_from_params(params: dict[str, Any]) -> list[str]:

--- a/apple/template.py
+++ b/apple/template.py
@@ -3,47 +3,39 @@
 The Apple DSL supports per-request `{{field_name}}` interpolation in two places:
 
 1. `if_() / elseif_()` control predicates — extraction and Lua emission live
-   in `apple/control.py`. That mechanism is unchanged.
+   in `apple/control.py`.
 2. Operator params declared as `templatable` in their codegen schema. When a
    user passes a string value containing `{{...}}` for such a param, the
    compiler auto-injects the referenced common fields into the operator's
    common_input, and the runtime resolves the values per request via the
    TemplatedParamsAware hook.
 
-This module is the shared helper layer for case (2). It is intentionally
-distinct from `apple/control.py` for now — see issue #74 discussion — but we
-expect to unify the two paths in a follow-up once the operator-param path
-has stabilized.
+The shared regex + extraction primitives live in ``apple/_template_syntax``
+(issue #76 unification). This module exposes the param-path public API.
 """
 from __future__ import annotations
 
-import re
 from typing import Any
 
-_TEMPLATE_PATTERN = re.compile(r"\{\{(\w+)\}\}")
-_BARE_TEMPLATE_PATTERN = re.compile(r"^\{\{(\w+)\}\}$")
+from apple._template_syntax import (
+    TEMPLATE_PATTERN as _TEMPLATE_PATTERN,
+)
+from apple._template_syntax import (
+    extract_fields,
+    is_bare_template,
+)
+
+__all__ = [
+    "extract_fields",
+    "extract_fields_from_params",
+    "is_bare_template",
+    "is_templated",
+]
 
 
 def is_templated(value: Any) -> bool:
     """Return True iff ``value`` is a string containing at least one ``{{field}}`` marker."""
     return isinstance(value, str) and bool(_TEMPLATE_PATTERN.search(value))
-
-
-def is_bare_template(value: Any) -> bool:
-    """Return True iff ``value`` is exactly ``{{field}}`` with no surrounding text.
-
-    L0 contract: a templated param value must consist of a single bare
-    ``{{field}}`` marker — no literal prefix, suffix, or multiple markers.
-    Mixed forms like ``"prefix_{{x}}"`` are rejected so the model stays
-    "the template binds a common-field value to a named param" rather than
-    "the template builds a string by concatenation".
-    """
-    return isinstance(value, str) and bool(_BARE_TEMPLATE_PATTERN.fullmatch(value))
-
-
-def extract_fields(value: str) -> list[str]:
-    """Return ordered, deduped field names referenced inside ``{{...}}`` markers."""
-    return list(dict.fromkeys(_TEMPLATE_PATTERN.findall(value)))
 
 
 def extract_fields_from_params(params: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## Summary

- Extract shared `{{field}}` regex + primitives into private `apple/_template_syntax` module (`TEMPLATE_PATTERN`, `BARE_TEMPLATE_PATTERN`, `extract_fields`, `is_bare_template`).
- `apple/control.py` (Lua predicate path) and `apple/template.py` (operator-param interpolation path) both import from it. No public API change — `is_templated`, `is_bare_template`, `extract_fields`, `extract_fields_from_params` still re-exported from `apple.template`; `extract_fields`, `_strip_template` still exposed on `apple.control`.
- Removes the duplicate regex literal called out by the issue #74 TODO comment.
- Apple-only change; cross-runtime regex contract in pine-go / pine-java / pine-cpp is untouched.

## Test plan

- [x] `pytest apple/` — 211 passed
- [x] `ruff check apple/_template_syntax.py apple/template.py apple/control.py` — clean
- [ ] CI: full lint + test matrix
- [ ] CI: cross-validate section 17 (templated params) still green

Closes #76