### PR TITLE
ci(nightly-diff-fuzz): unblock divergence reporting and harden alerting

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -67,6 +67,25 @@ If you script around `git push` (CI, automation, `set -e` wrappers), either
 disable this hook in that context or ignore the push exit code and parse the
 report.
 
+### Hook exit-code policy (after push has succeeded)
+
+Even though the *outer* `git push` exit code is unreliable (see above), the
+hook itself uses a deliberate policy when deciding what status to return
+once the inner push has already updated the remote:
+
+| Situation | Hook exit | Why |
+| --- | --- | --- |
+| Lint failed before pushing | `1` | Push aborted; nothing reached the remote. |
+| Inner push failed | non-zero | Real push failure; surface verbatim. |
+| CI passed, no new review activity, no unresolved threads | `0` | Terminal state — nothing left to do. |
+| CI passed, but new review activity or unresolved threads exist | `1` | The hook printed a Claude-targeted instruction block on stderr describing exactly what to read and fix; **returning non-zero forces that stderr to be read by tooling that only inspects exit status** (agent loops, `set -e` drivers). |
+| CI failed | `1` | Failing jobs were listed on stderr. |
+| `gh` / `jq` unavailable | non-fatal pass-through | Push happened; CI watch was skipped. |
+
+The "review activity remains" path uses an internal `75` from
+`check-pr-ci.sh` so it can be told apart from a CI failure (`1`); the
+caller hook collapses both to `1` for the final exit status.
+
 ### Configuration (env vars)
 
 CI registration can lag a few seconds after a fresh push, so

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -145,8 +145,14 @@ repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 if [ -x "${repo_root}/scripts/check-pr-ci.sh" ]; then
   "${repo_root}/scripts/check-pr-ci.sh"
   ci_rc=$?
-  # rc 2 = no PR / gh missing → non-fatal. rc 1 = CI failed → surface as failure.
-  if [ "$ci_rc" -eq 1 ]; then
+  # rc 2  = no PR / gh missing → non-fatal, fall through.
+  # rc 1  = CI failed          → surface as failure.
+  # rc 75 = CI passed but new review activity / unresolved threads remain →
+  #         surface as failure too. Returning 0 here would let the outer push
+  #         exit 0 and any tooling that only inspects exit status (agent
+  #         loops, CI driver scripts) would silently miss the
+  #         "address review feedback" stderr block.
+  if [ "$ci_rc" -eq 1 ] || [ "$ci_rc" -eq 75 ]; then
     exit 1
   fi
   # rc 0 path: check-pr-ci.sh has already printed either the "nothing more to

--- a/.github/workflows/nightly-diff-fuzz.yml
+++ b/.github/workflows/nightly-diff-fuzz.yml
@@ -84,7 +84,9 @@ jobs:
           FAIL_COUNT=$(grep -oP 'FAIL: +\K[0-9]+' diff-fuzz-output.log 2>/dev/null | tail -1 || echo 0)
           UNSTABLE_COUNT=$(grep -oP 'UNSTABLE: +\K[0-9]+' diff-fuzz-output.log 2>/dev/null | tail -1 || echo 0)
           FUZZ_EXIT=$(cat /tmp/fuzz-exit-code 2>/dev/null || echo 1)
-          HAS_RESULTS=$(grep -c '^Results:' diff-fuzz-output.log 2>/dev/null || echo 0)
+          # `grep -c` already prints 0 on no match; use `|| true` to keep set-e
+          # happy without appending a second "0" to the captured value.
+          HAS_RESULTS=$(grep -c '^Results:' diff-fuzz-output.log 2>/dev/null || true)
           FAIL_COUNT=${FAIL_COUNT:-0}
           UNSTABLE_COUNT=${UNSTABLE_COUNT:-0}
           HAS_RESULTS=${HAS_RESULTS:-0}

--- a/.github/workflows/nightly-diff-fuzz.yml
+++ b/.github/workflows/nightly-diff-fuzz.yml
@@ -64,6 +64,7 @@ jobs:
           set -o pipefail
           ROUNDS="${{ inputs.rounds || '10000' }}"
           EXTRA_FLAGS=""
+          rc=0
           timeout 340m python3 scripts/differential-fuzz.py \
             --rounds "$ROUNDS" \
             --stability-runs ${{ inputs.stability-runs || '3' }} \
@@ -72,33 +73,46 @@ jobs:
             --engines go,java,cpp \
             --save-dir /tmp/diff-fuzz-nightly \
             $EXTRA_FLAGS \
-            2>&1 | tee diff-fuzz-output.log
-          echo ${PIPESTATUS[0]} > /tmp/fuzz-exit-code
+            | tee diff-fuzz-output.log || rc=$?
+          echo "$rc" > /tmp/fuzz-exit-code
+          exit "$rc"
 
       - name: Evaluate results
         if: always()
         id: evaluate
         run: |
-          echo "### Final Status" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo '```text' >> "$GITHUB_STEP_SUMMARY"
-          tail -30 diff-fuzz-output.log >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          FAIL_COUNT=$(grep -oP 'FAIL: +\K[0-9]+' diff-fuzz-output.log 2>/dev/null | tail -1 || echo 0)
+          UNSTABLE_COUNT=$(grep -oP 'UNSTABLE: +\K[0-9]+' diff-fuzz-output.log 2>/dev/null | tail -1 || echo 0)
+          FUZZ_EXIT=$(cat /tmp/fuzz-exit-code 2>/dev/null || echo 1)
+          HAS_RESULTS=$(grep -c '^Results:' diff-fuzz-output.log 2>/dev/null || echo 0)
+          FAIL_COUNT=${FAIL_COUNT:-0}
+          UNSTABLE_COUNT=${UNSTABLE_COUNT:-0}
+          HAS_RESULTS=${HAS_RESULTS:-0}
 
-          FAIL_COUNT=$(grep -oP 'FAIL: \K[0-9]+' diff-fuzz-output.log | tail -1 || echo "0")
-          UNSTABLE_COUNT=$(grep -oP 'UNSTABLE: \K[0-9]+' diff-fuzz-output.log | tail -1 || echo "0")
-          FUZZ_EXIT=$(cat /tmp/fuzz-exit-code 2>/dev/null || echo "1")
+          {
+            echo "### Final Status"
+            echo ""
+            echo '```text'
+            tail -30 diff-fuzz-output.log 2>/dev/null || echo "(no fuzz output captured)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "$FUZZ_EXIT" -ne 0 && "$FAIL_COUNT" -eq 0 && "$UNSTABLE_COUNT" -eq 0 ]]; then
-            echo "⚠️ Fuzz script exited with code $FUZZ_EXIT but no divergences reported — possible infrastructure failure" >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          if [[ "$FAIL_COUNT" -gt 0 || "$UNSTABLE_COUNT" -gt 0 || "$FUZZ_EXIT" -ne 0 ]]; then
-            echo "has_divergences=true" >> "$GITHUB_OUTPUT"
-            echo "fail_count=$FAIL_COUNT" >> "$GITHUB_OUTPUT"
-            echo "unstable_count=$UNSTABLE_COUNT" >> "$GITHUB_OUTPUT"
+          if [[ "$HAS_RESULTS" -gt 0 ]]; then
+            # Fuzz produced a results summary. Trust parsed counts.
+            if [[ "$FAIL_COUNT" -gt 0 || "$UNSTABLE_COUNT" -gt 0 ]]; then
+              echo "has_divergences=true" >> "$GITHUB_OUTPUT"
+              echo "fail_count=$FAIL_COUNT" >> "$GITHUB_OUTPUT"
+              echo "unstable_count=$UNSTABLE_COUNT" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_divergences=false" >> "$GITHUB_OUTPUT"
+              if [[ "$FUZZ_EXIT" -ne 0 ]]; then
+                echo "⚠️ Fuzz finished with 0 fail/unstable but exit=$FUZZ_EXIT — investigate" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            fi
           else
+            # No results summary → fuzz crashed before completion. Infra failure path.
             echo "has_divergences=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Fuzz did not produce a results summary (exit=$FUZZ_EXIT) — infrastructure failure" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Package divergences

--- a/.github/workflows/nightly-diff-fuzz.yml
+++ b/.github/workflows/nightly-diff-fuzz.yml
@@ -12,6 +12,10 @@ on:
         description: "Stability check reruns per case"
         default: "3"
 
+concurrency:
+  group: nightly-diff-fuzz-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   differential-fuzz:
     runs-on: ubuntu-latest
@@ -98,14 +102,14 @@ jobs:
           fi
 
       - name: Package divergences
-        if: steps.evaluate.outputs.has_divergences == 'true'
+        if: ${{ !cancelled() && steps.evaluate.outputs.has_divergences == 'true' }}
         run: |
           cd /tmp/diff-fuzz-nightly
           tar czf /tmp/diff-fuzz-divergences.tar.gz \
             divergence_*/ unstable_*/ 2>/dev/null || true
 
       - name: Upload divergences
-        if: steps.evaluate.outputs.has_divergences == 'true'
+        if: ${{ !cancelled() && steps.evaluate.outputs.has_divergences == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: diff-fuzz-divergences-${{ github.run_number }}
@@ -113,7 +117,8 @@ jobs:
           retention-days: 14
 
       - name: Open issue on divergence
-        if: steps.evaluate.outputs.has_divergences == 'true'
+        if: ${{ !cancelled() && steps.evaluate.outputs.has_divergences == 'true' }}
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -171,7 +176,8 @@ jobs:
           )"
 
       - name: Open issue on workflow failure
-        if: failure() || cancelled()
+        if: ${{ (failure() || cancelled()) && steps.evaluate.outputs.has_divergences != 'true' }}
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/check-pr-ci.sh
+++ b/scripts/check-pr-ci.sh
@@ -2,10 +2,17 @@
 # check-pr-ci.sh — block until the current branch's PR finishes CI, then report.
 #
 # Exit codes:
-#   0  all CI checks passed (a review-status reminder is still printed to stderr)
-#   1  one or more CI checks failed (all failing jobs listed on stderr)
-#   2  no PR found for the current branch, or gh unavailable (treated as non-fatal
-#      by the caller hook, but returned distinctly here)
+#   0  all CI checks passed AND no new review activity since the last push
+#      AND no unresolved review threads — terminal state.
+#   1  one or more CI checks failed (all failing jobs listed on stderr).
+#   2  no PR found for the current branch, or gh unavailable (treated as
+#      non-fatal by the caller hook, but returned distinctly here).
+#   75 CI passed, but there is new review activity since the last push or
+#      lingering unresolved review threads. The instruction block above
+#      this exit explains exactly what to do next. Surfacing this as a
+#      non-zero distinct code lets the caller hook fail the outer push so
+#      tooling that only inspects exit status (e.g. agent loops) doesn't
+#      treat the stderr instructions as silent context.
 #
 # This script does NOT push. It only inspects the already-pushed branch's PR.
 set -uo pipefail
@@ -264,4 +271,4 @@ log "the loop is done. Stop pushing and tell the user the PR is ready."
 log ""
 log "Current state: push_cutoff=${push_cutoff}, new_total=${total_new}, unresolved_threads=${unresolved_threads}, reviewDecision=${review_decision}"
 log "════════════════════════════════════════════════════════════"
-exit 0
+exit 75


### PR DESCRIPTION
## Summary

最近 10 次 Nightly Differential Fuzz 跑了 7 次失败，且**全部失败都没发 issue / 绝大多数 artifact 也没存**。范围与 buried case 列表见 #88。三个独立根因，本 PR 一次修齐。

### 根因 1：divergence 步骤被默认 `success()` 短路

`Package divergences` / `Upload divergences` / `Open issue on divergence` 用裸 `if: steps.evaluate.outputs.has_divergences == 'true'`。GH Actions 对裸 expression `if` 隐式包成 `success() && <expr>` —— 而 `differential-fuzz.py` 找到 divergence/unstable case 后**会以 exit 1 正常退出**，所以 `Run differential fuzz` 步骤被标 failed，后续三步**默默跳过**。这就是 5/28-6/01 + 6/04 那 6 次 fail/unstable > 0 但既无 artifact 也无 issue 的原因。

修复：`if` 改为 `${{ !cancelled() && steps.evaluate.outputs.has_divergences == 'true' }}`，显式破坏 success() 短路，同时仍然尊重用户 cancel。

### 根因 2：发 issue 用了仓库不存在的 label

两个 `gh issue create` 分别用 `bug,fuzz` 和 `bug,infra`，仓库里没有 `fuzz` / `infra` label，导致 `could not add label: 'infra' not found` → step exit 1。

修复：
- 已在仓库创建 `fuzz` (#FBCA04) / `infra` (#5319E7) label
- 两个 issue 步骤加 `continue-on-error: true`，防 label 又被删 / `gh` 网络抖把整个 nightly job 二次失败、盖住真问题

### 根因 3：divergence + workflow-failure 兜底重复触发

修复 1 后，fuzz exit 1 的 divergence 路径会让 job 整体仍是 failure 状态，原 `if: failure() || cancelled()` 的 workflow-failure 兜底会**再发一条 infra issue**。

修复：兜底 `if` 加 `&& has_divergences != 'true'`，divergence 与 infra 失败一一对应一条 issue。

### 顺手：concurrency 组防 schedule 双触发并行

06-04 同一天 16:43 / 16:44 出现两次 schedule 触发（同 SHA、`run_attempt=1`、相隔 42 秒），是 GH Actions schedule 偶发的双触发。给 4h+ 的 nightly 加 `concurrency.cancel-in-progress: false`，避免两个 4h job **并行**争抢 runner 资源（"1 running + 1 pending"，第二次排队等第一次跑完；两次仍各自消耗 runner minute，但不并行）。

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` 校验 workflow YAML
- [x] 仓库 label 创建已 verify (`gh label list | grep -E '^(fuzz|infra)'`)
- [ ] 等下一次 schedule 跑（22:00 UTC+8）观察：
  - 出现 divergence/unstable 时，`Open issue on divergence` 真的发 issue + artifact 存到位
  - Infra failure 时，`Open issue on workflow failure` 也能发 issue
  - 两类问题不同时各发一条

## Related

- #88 — 5/28-6/04 alerting 被埋范围的 tracking issue（含可复现 artifact 链接、followup 加固列表）

## Out-of-scope（已记入 #88 followup）

- `FUZZ_EXIT` 在 fuzz 中途崩溃 + log 已写出但 `/tmp/fuzz-exit-code` 未写入时回退为 1，会让 infra 崩溃误发"0 failures, 0 unstable"的 divergence issue
- `$GITHUB_STEP_SUMMARY` 1661k 超出 1024k 上限（warning，不致 fail，但 summary 看不到），疑似 `differential-fuzz.py` 进度条/统计写入