### PR TITLE
fix(hooks): tolerate GraphQL error envelopes and prevent silent tag moves

### DIFF
--- a/scripts/check-pr-ci.sh
+++ b/scripts/check-pr-ci.sh
@@ -161,24 +161,54 @@ activity_json="$(gh api graphql -f query='
   }' \
   -F owner="$owner" -F repo="$repo" -F pr="$pr_number" 2>/dev/null)"
 
+# Two kinds of "couldn't read activity":
+#   (a) gh produced no stdout at all (network down, gh broken, missing auth)
+#   (b) gh returned a GraphQL error envelope `{"errors":[...]}` and exit 0 — a
+#       common shape for auth expiry, transient 5xx, and schema mismatch. The
+#       envelope is non-empty, so a `[ -z ]` guard alone is not enough; without
+#       this branch the jq filters below would hit `.data == null` and die with
+#       "Cannot iterate over null", leaving the four counters as empty strings
+#       and leaking "integer expression expected" from the later `[ -eq ]` test.
+# Both paths must surface as "work remains" so the next-step block fires and
+# the operator looks at the PR by hand — silently treating a malformed
+# envelope as a clean terminal state would defeat the autonomous loop.
+activity_unreadable=0
 if [ -z "$activity_json" ]; then
+  activity_unreadable=1
+elif printf '%s' "$activity_json" \
+       | jq -e 'has("errors") or .data == null' >/dev/null 2>&1; then
+  activity_unreadable=1
+fi
+
+if [ "$activity_unreadable" -eq 1 ]; then
   log "  ! could not query PR activity — assuming work remains, see comments manually."
-  new_issue_comments=0
+  # Force the next-step block to fire (total_new > 0) so the operator must
+  # inspect the PR manually rather than the script silently exiting 0.
+  new_issue_comments=1
   new_review_submissions=0
   new_inline_comments=0
   unresolved_threads=0
 else
+  # `// []` collapses an absent or null `nodes` to an empty array so jq stays
+  # total even on partial responses; `?` on the inner inline-comments traversal
+  # tolerates a thread node missing its comments. `2>/dev/null` + `${var:-0}`
+  # keep the four counters numeric on any further surprise so the arithmetic
+  # and `[ -eq ]` tests below never hit an empty operand.
   new_issue_comments="$(printf '%s' "$activity_json" \
     | jq --arg t "$push_cutoff" \
-        '[.data.repository.pullRequest.comments.nodes[] | select(.createdAt > $t)] | length')"
+        '[(.data.repository.pullRequest.comments.nodes // [])[] | select(.createdAt > $t)] | length' 2>/dev/null)"
   new_review_submissions="$(printf '%s' "$activity_json" \
     | jq --arg t "$push_cutoff" \
-        '[.data.repository.pullRequest.reviews.nodes[] | select(.createdAt > $t)] | length')"
+        '[(.data.repository.pullRequest.reviews.nodes // [])[] | select(.createdAt > $t)] | length' 2>/dev/null)"
   new_inline_comments="$(printf '%s' "$activity_json" \
     | jq --arg t "$push_cutoff" \
-        '[.data.repository.pullRequest.reviewThreads.nodes[].comments.nodes[] | select(.createdAt > $t)] | length')"
+        '[(.data.repository.pullRequest.reviewThreads.nodes // [])[].comments.nodes[]? | select(.createdAt > $t)] | length' 2>/dev/null)"
   unresolved_threads="$(printf '%s' "$activity_json" \
-    | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length')"
+    | jq '[(.data.repository.pullRequest.reviewThreads.nodes // [])[] | select(.isResolved==false)] | length' 2>/dev/null)"
+  new_issue_comments="${new_issue_comments:-0}"
+  new_review_submissions="${new_review_submissions:-0}"
+  new_inline_comments="${new_inline_comments:-0}"
+  unresolved_threads="${unresolved_threads:-0}"
 fi
 
 total_new=$(( new_issue_comments + new_review_submissions + new_inline_comments ))

--- a/scripts/check-pr-ci.sh
+++ b/scripts/check-pr-ci.sh
@@ -175,6 +175,14 @@ activity_json="$(gh api graphql -f query='
 activity_unreadable=0
 if [ -z "$activity_json" ]; then
   activity_unreadable=1
+elif ! printf '%s' "$activity_json" | jq empty >/dev/null 2>&1; then
+  # gh produced non-empty stdout that is not valid JSON (auth interstitial,
+  # captive-portal HTML, transient gateway error page, etc.). Without this
+  # guard the next `jq -e has("errors")` would itself fail to parse, the
+  # elif would be false, and we would silently fall through to the readable
+  # branch where every counter collapses to 0 via `${var:-0}` — masquerading
+  # as a clean terminal "done" state.
+  activity_unreadable=1
 elif printf '%s' "$activity_json" \
        | jq -e 'has("errors") or .data == null' >/dev/null 2>&1; then
   activity_unreadable=1

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -56,16 +56,63 @@ create_tag "$TAG_ROOT"
 create_tag "$TAG_GO"
 
 # --- Push tags ---
+#
+# Release tags are immutable contracts: once pushed, downstream consumers
+# (pkg.go.dev, Maven Central, PyPI mirrors) cache the tag → commit mapping
+# by SHA. Silently moving a remote tag to a different commit is a
+# semantic break, even when it appears to "succeed".
+#
+# So we do NOT trust `git push`'s exit code as the only signal — the
+# pre-push hook in this repo can produce non-zero outer rc even on a
+# successful inner push, which would have made the old fallback to
+# `--force` fire on every release. Instead we inspect the remote state
+# first via `ls-remote` and decide deterministically.
 
 push_tag() {
   local tag="$1"
-  if git push origin "$tag" 2>/dev/null; then
-    echo "  pushed $tag"
-  else
-    echo "  [WARN] normal push failed for $tag, retrying with --force"
-    git push origin "$tag" --force
-    echo "  pushed $tag (force)"
+
+  # Resolve the local commit the tag points at. Use `^{commit}` so this
+  # also works if the tag is later switched to an annotated form.
+  local local_sha
+  local_sha="$(git rev-parse "${tag}^{commit}")"
+
+  # Look up the remote tag, preferring the dereferenced commit SHA
+  # (annotated tag) over the raw tag-object SHA (lightweight tag).
+  local remote_sha
+  remote_sha="$(git ls-remote origin "refs/tags/${tag}^{}" | awk '{print $1}')"
+  if [ -z "$remote_sha" ]; then
+    remote_sha="$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')"
   fi
+
+  if [ -z "$remote_sha" ]; then
+    echo "  pushing $tag (new)..."
+    git push origin "$tag"
+    echo "  pushed $tag"
+    return 0
+  fi
+
+  if [ "$remote_sha" = "$local_sha" ]; then
+    echo "  $tag already on remote at the same commit — skipping."
+    return 0
+  fi
+
+  cat >&2 <<EOF
+
+  [ERROR] tag $tag already exists on remote at a different commit:
+            local:  $local_sha
+            remote: $remote_sha
+
+          A release tag must not be moved silently — downstream consumers
+          (pkg.go.dev, Maven Central, PyPI mirrors) cache release artifacts
+          by SHA, and a force-push here will silently divert future fetches
+          to a different tree.
+
+          If this move is genuinely intended, delete the remote tag first
+          and re-run this script:
+            git push origin :refs/tags/$tag
+
+EOF
+  exit 1
 }
 
 echo "Pushing tags..."

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -86,9 +86,26 @@ push_tag() {
 
   if [ -z "$remote_sha" ]; then
     echo "  pushing $tag (new)..."
-    git push origin "$tag"
-    echo "  pushed $tag"
-    return 0
+    # The repo's pre-push hook self-wraps the push: an inner push performs
+    # the real ref update, after which the outer `git push` we run here can
+    # exit non-zero even though the ref landed (the OUTER push sees a stale
+    # zero→SHA expectation against a now-already-at-SHA remote). Under the
+    # script-level `set -e`, that non-zero rc would abort the script after
+    # the first tag, leaving TAG_GO unpushed and breaking the dual-tag
+    # contract. So tolerate non-zero rc and verify the actual remote state
+    # via ls-remote — same pattern the already-exists branch below uses.
+    git push origin "$tag" || true
+    local pushed_sha
+    pushed_sha="$(git ls-remote origin "refs/tags/${tag}^{}" | awk '{print $1}')"
+    if [ -z "$pushed_sha" ]; then
+      pushed_sha="$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')"
+    fi
+    if [ "$pushed_sha" = "$local_sha" ]; then
+      echo "  pushed $tag (remote verified at $local_sha)"
+      return 0
+    fi
+    echo "  [ERROR] $tag did not land on remote: expected $local_sha, got '${pushed_sha:-<none>}'" >&2
+    exit 1
   fi
 
   if [ "$remote_sha" = "$local_sha" ]; then


### PR DESCRIPTION
## Summary

Two unrelated-but-cohabiting hook-script bugs uncovered while triaging #88:

- **`scripts/check-pr-ci.sh` (#86):** `gh api graphql` returns its error envelope on stdout with exit 0, so the existing empty-string guard never fired on auth expiry / transient 5xx / schema mismatch. The four jq filters then died on `.data == null`, leaving counters empty and silently routing the script to "terminal state" instead of forcing a manual look at the PR.
  - Detect both empty stdout and GraphQL error envelopes (`has("errors")` or `.data == null`) up front
  - Force the next-step block to fire on the unreadable path (operator must inspect by hand)
  - Make the jq filters total: `// []` collapses absent/null nodes, `?` tolerates missing comments, `2>/dev/null` + `${var:-0}` keep counters numeric

- **`scripts/tag-release.sh` (#84):** the previous `push_tag` swallowed stderr and treated any non-zero `git push` exit as "retry with --force". This conflated real failures with the pre-push hook's expected non-zero on a successful inner push — meaning every release silently re-pushed each tag with `--force`. Today it's harmless only because local SHA happens to match remote SHA; on any future release where master has advanced and a stale tag still exists on remote, `--force` would silently move the remote tag pointer — overwriting the commit downstream consumers (pkg.go.dev, Maven Central, PyPI mirrors) have cached by SHA.
  - Replace exit-code fallback with a `ls-remote` driven decision (no remote → push; same SHA → no-op; different SHA → fail loud with `git push origin :refs/tags/<tag>` recovery instruction)
  - Never silently `--force`

## Test plan

- [x] `check-pr-ci.sh`: 7 routing cases covered (malformed envelope, empty, clean, active comments, unresolved threads, `data:null`, missing key) — all routed correctly
- [x] `tag-release.sh`: end-to-end against a temp local origin in all 3 cases (new / same-SHA / different-SHA)
- [ ] CI green
- [ ] Review pass

Closes #86
Closes #84