### PR TITLE
test: close v0.9.0..HEAD test-coverage audit (38 items)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,22 @@ jobs:
       - name: Run ASan/UBSan smoke
         run: bash scripts/cpp-sanitizer-smoke.sh
 
+  cpp-tsan:
+    runs-on: ubuntu-latest
+    needs: cpp-build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install LuaJIT and build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake build-essential libluajit-5.1-dev libcurl4-openssl-dev util-linux
+      - name: Run TSan smoke (high-fanout DAG stress)
+        run: bash scripts/cpp-tsan-smoke.sh
+
   cpp-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly-diff-fuzz.yml
+++ b/.github/workflows/nightly-diff-fuzz.yml
@@ -52,11 +52,19 @@ jobs:
         run: mvn package -B -q -DskipTests
         working-directory: pine-java
 
-      - name: Build C++ engine
-        run: |
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-13
-          cmake --build build --target pineapple-run
-        working-directory: pine-cpp
+      - name: Codegen schema parity gate (also builds C++ binaries)
+        # Runs cross-validate Section 1 (schema + apple_generated/ byte-level
+        # diff across Go/Java/C++). PR-time CI also runs this, but nightly
+        # picks it up as a low-cost guard against three-way drift in
+        # operators.py / markers.py / resources.py / __init__.py landing
+        # silently between PR runs (audit gap H5).
+        #
+        # Side effect we deliberately rely on: _prebuild.sh builds the full
+        # set of pine-cpp binaries (pineapple-run, codegen, server, dag,
+        # cause-chain-probe) into pine-cpp/build/. That covers the C++
+        # binary used by the differential-fuzz step below, so no separate
+        # "Build C++ engine" step is needed.
+        run: bash scripts/cross-validate.sh 1
 
       - name: Run differential fuzz
         timeout-minutes: 350

--- a/apple/compiler.py
+++ b/apple/compiler.py
@@ -22,6 +22,7 @@ from apple.validator import (
     detect_dead_code,
     detect_subflow_dead_code,
     validate_data_parallel,
+    validate_explicit_null_params,
     validate_field_coverage,
     validate_no_underscore_output,
     validate_param_metadata_consistency,
@@ -82,6 +83,7 @@ def compile_flow(flow: Any) -> dict[str, Any]:
     validate_sources_references(named_ops)
     validate_param_metadata_consistency(named_ops)
     validate_templated_params(named_ops)
+    validate_explicit_null_params(named_ops)
     dead = detect_dead_code(
         named_ops,
         flow._common_output,

--- a/apple/tests/test_compiler.py
+++ b/apple/tests/test_compiler.py
@@ -6,6 +6,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
+from apple.base import OpCall
 from apple.compiler import compile_flow
 from apple.flow import Flow, SubFlow
 
@@ -1505,6 +1506,155 @@ class TestSubFlowTemplateInteraction:
         )
         cfg = compile_flow(flow)
         assert "pipeline_config" in cfg
+
+
+class TestSubFlowContractThreeBucketUnion:
+    """validator.py:288-292 unions all three common_input buckets
+    (common_input + common_input_skip + common_input_template) against
+    the SubFlow contract. M1 covers the template bucket alone; M2 covers
+    the skip bucket alone via underscore filtering. Neither pins down
+    the case where a single op activates all three buckets at once with
+    a SubFlow contract that selectively declares only some fields.
+
+    Without this test, a regression that, e.g., dropped the skip bucket
+    from the union (line 290) while the template bucket still resolves
+    would still pass M1 and M2 but break the contract check for any op
+    that declares both a template *and* a non-control skip field. PR #78
+    commit message named this combination but never asserted it.
+
+    These cases drive `validate_subflow_field_coverage` directly with
+    hand-built OpCalls so all three buckets can be populated indepen-
+    dently — the public DSL surface (`flow.py`) does not expose a knob
+    for non-underscore `common_input_skip` entries.
+
+    Audit gap L8.
+    """
+
+    @staticmethod
+    def _make_op(
+        type_name: str = "synthetic_op",
+        *,
+        common_input=None,
+        common_input_skip=None,
+        common_input_template=None,
+        common_output=None,
+    ) -> OpCall:
+        return OpCall(
+            type_name=type_name,
+            params={},
+            common_input=list(common_input or []),
+            common_input_skip=list(common_input_skip or []),
+            common_input_template=list(common_input_template or []),
+            common_output=list(common_output or []),
+        )
+
+    def test_three_buckets_all_covered_by_subflow_contract(self):
+        """Single op activates all three buckets at once. Contract lists
+        every field. Union path must accept — no exception."""
+        from apple.validator import validate_subflow_field_coverage
+
+        op = self._make_op(
+            common_input=["regular"],
+            common_input_skip=["bookkeeping"],
+            common_input_template=["user_id"],
+        )
+        validate_subflow_field_coverage(
+            sf_path="sf",
+            sf_ops=[("synthetic_op_1", op)],
+            sf_common_input=["regular", "bookkeeping", "user_id"],
+            sf_item_input=None,
+        )
+
+    def test_three_buckets_only_template_missing_from_contract_raises(self):
+        """Contract covers regular + bookkeeping but NOT user_id. The
+        op activates all three buckets. A regression that dropped the
+        common_input_template entry from the union would silently pass
+        — this test fires."""
+        from apple.validator import (
+            ValidationError,
+            validate_subflow_field_coverage,
+        )
+
+        op = self._make_op(
+            common_input=["regular"],
+            common_input_skip=["bookkeeping"],
+            common_input_template=["user_id"],
+        )
+        with pytest.raises(ValidationError, match=r"'user_id'.*SubFlow 'sf' contract"):
+            validate_subflow_field_coverage(
+                sf_path="sf",
+                sf_ops=[("synthetic_op_1", op)],
+                sf_common_input=["regular", "bookkeeping"],
+                sf_item_input=None,
+            )
+
+    def test_three_buckets_only_skip_missing_from_contract_raises(self):
+        """Symmetric: contract covers regular + user_id but omits the
+        non-underscore skip-bucket entry. Locks the skip bucket's
+        contribution to the union. Underscore-prefixed entries are
+        filtered out (M2); plain identifiers are NOT and must surface
+        contract gaps here."""
+        from apple.validator import (
+            ValidationError,
+            validate_subflow_field_coverage,
+        )
+
+        op = self._make_op(
+            common_input=["regular"],
+            common_input_skip=["bookkeeping"],
+            common_input_template=["user_id"],
+        )
+        with pytest.raises(ValidationError, match=r"'bookkeeping'.*SubFlow 'sf' contract"):
+            validate_subflow_field_coverage(
+                sf_path="sf",
+                sf_ops=[("synthetic_op_1", op)],
+                sf_common_input=["regular", "user_id"],
+                sf_item_input=None,
+            )
+
+    def test_three_buckets_only_common_input_missing_from_contract_raises(self):
+        """Contract covers bookkeeping + user_id but omits the plain
+        common_input field. Pins the common_input bucket's contribution
+        — without it, a regression that swapped the union to only
+        skip+template would silently accept the op."""
+        from apple.validator import (
+            ValidationError,
+            validate_subflow_field_coverage,
+        )
+
+        op = self._make_op(
+            common_input=["regular"],
+            common_input_skip=["bookkeeping"],
+            common_input_template=["user_id"],
+        )
+        with pytest.raises(ValidationError, match=r"'regular'.*SubFlow 'sf' contract"):
+            validate_subflow_field_coverage(
+                sf_path="sf",
+                sf_ops=[("synthetic_op_1", op)],
+                sf_common_input=["bookkeeping", "user_id"],
+                sf_item_input=None,
+            )
+
+    def test_underscore_skip_bypasses_contract_with_other_buckets_active(self):
+        """Mix the M2-style underscore-filtered skip (`_if_1`) with a
+        non-underscore common_input and template. Contract covers only
+        regular + user_id; the underscore skip must be filtered before
+        the contract check. Combined with the other two buckets being
+        contract-covered, validation passes — pinning the M2 filter
+        survives the three-bucket union path."""
+        from apple.validator import validate_subflow_field_coverage
+
+        op = self._make_op(
+            common_input=["regular"],
+            common_input_skip=["_if_1"],
+            common_input_template=["user_id"],
+        )
+        validate_subflow_field_coverage(
+            sf_path="sf",
+            sf_ops=[("synthetic_op_1", op)],
+            sf_common_input=["regular", "user_id"],
+            sf_item_input=None,
+        )
 
 
 class TestSubFlowMultiSkipContractInteraction:

--- a/apple/tests/test_compiler.py
+++ b/apple/tests/test_compiler.py
@@ -1677,4 +1677,95 @@ class TestSubFlowMultiSkipContractInteraction:
             compile_flow(flow)
 
 
+class TestExplicitNullScalarParamRejection:
+    """Audit M5: scalar ``param=None`` must be rejected at compile time.
+
+    The Java/C++ runtime ``Init`` paths reject explicit JSON ``null`` for
+    typed scalar params (commits 1fa18b3 / 452aee4). Apple compiles
+    ``ttl=None`` straight to JSON ``null`` and used to defer the failure to
+    runtime — meaning a DSL author would only see the divergence after a
+    load attempt against any one of the three engines. Pulling the check
+    forward into the validator gives a line-anchored ValidationError at
+    compile time.
+    """
+
+    def test_redis_set_ttl_none_rejected(self):
+        from apple.validator import ValidationError
+
+        flow = Flow(
+            name="ttl_none",
+            common_input=["uid"],
+            item_input=["x"],
+            item_output=["x"],
+        )
+        flow.transform_redis_set(
+            common_input=["uid"],
+            item_input=["x"],
+            item_output=["x"],
+            key_prefix="{{uid}}",
+            resource_name="cache",
+            ttl=None,
+        )
+        with pytest.raises(ValidationError, match=r"param 'ttl'.*explicitly None"):
+            compile_flow(flow)
+
+    def test_redis_set_key_prefix_none_rejected(self):
+        from apple.validator import ValidationError
+
+        flow = Flow(
+            name="kp_none",
+            common_input=["uid"],
+            item_input=["x"],
+            item_output=["x"],
+        )
+        flow.transform_redis_set(
+            common_input=["uid"],
+            item_input=["x"],
+            item_output=["x"],
+            key_prefix=None,
+            resource_name="cache",
+        )
+        with pytest.raises(ValidationError, match=r"param 'key_prefix'.*explicitly None"):
+            compile_flow(flow)
+
+    def test_redis_set_fail_on_error_none_rejected(self):
+        from apple.validator import ValidationError
+
+        flow = Flow(
+            name="foe_none",
+            common_input=["uid"],
+            item_input=["x"],
+            item_output=["x"],
+        )
+        flow.transform_redis_set(
+            common_input=["uid"],
+            item_input=["x"],
+            item_output=["x"],
+            key_prefix="{{uid}}",
+            resource_name="cache",
+            fail_on_error=None,
+        )
+        with pytest.raises(ValidationError, match=r"param 'fail_on_error'.*explicitly None"):
+            compile_flow(flow)
+
+    def test_any_type_param_none_tolerated(self):
+        """``type: "any"`` params (filter_condition.value) are not gated.
+
+        Container/any-typed params have no clean "missing vs explicit null"
+        contract, so the validator skips them — the runtime is the source
+        of truth there.
+        """
+        flow = Flow(
+            name="any_none_ok",
+            item_input=["score"],
+            item_output=["score"],
+        )
+        flow.filter_condition(
+            item_input=["score"],
+            item_output=["score"],
+            value=None,
+        )
+        compile_flow(flow)
+
+
 

--- a/apple/tests/test_compiler.py
+++ b/apple/tests/test_compiler.py
@@ -1362,3 +1362,148 @@ class TestMarkerWidenSemantics:
         op = next(iter(cfg["pipeline_config"]["operators"].values()))
         assert op.get("consumes_row_set") is True
 
+
+class TestSubFlowTemplateInteraction:
+    """Combinations of #74 (common_input_template bucket) and #78 (SubFlow
+    field-list contracts).
+
+    The two features cross at validator.py:288-292: SubFlow-scoped coverage
+    unions all three common_input buckets (common_input + _skip + _template)
+    against the SubFlow's declared common_input contract. Each individual
+    feature has its own test class but the UNION path was uncovered — a
+    template field referenced inside a SubFlow that declares a contract
+    must either be in that contract or come from an internal upstream op.
+
+    Audit gap M1.
+    """
+
+    def _add_lua(self, node, *, common_input=None, common_output=None,
+                 item_input=None, item_output=None, name=None, **extra):
+        kwargs = {
+            "common_input": common_input or [],
+            "common_output": common_output or [],
+            "item_input": item_input or [],
+            "item_output": item_output or [],
+            "lua_script": "function f() return 0 end",
+            "function_for_item": "f",
+            "function_for_common": "",
+        }
+        if name:
+            kwargs["name"] = name
+        kwargs.update(extra)
+        node._add_op("transform_by_lua", **kwargs)
+
+    def test_template_field_in_subflow_contract_passes(self):
+        """A SubFlow declares `user_id` in its common_input contract. An
+        internal op references {{user_id}} via a template marker. Pass 0
+        routes user_id into common_input_template; the SubFlow validator
+        unions all three buckets and finds it covered. Compiles cleanly."""
+        sf = SubFlow(
+            name="sf",
+            common_input=["user_id"],
+            item_input=["x"],
+            common_output=["greeting"],
+            item_output=["z"],
+        )
+        sf._add_op(
+            "synthetic_templated_op",
+            common_input=[],
+            common_output=["greeting"],
+            item_input=[],
+            item_output=[],
+            key_template="hi {{user_id}}",
+        )
+        self._add_lua(sf, item_input=["x"], item_output=["z"])
+
+        flow = Flow(
+            name="parent",
+            common_input=["user_id"],
+            item_input=["x"],
+            common_output=["greeting"],
+            item_output=["z"],
+            sub_flows=[sf],
+        )
+        cfg = compile_flow(flow)
+        op = next(
+            o for o in cfg["pipeline_config"]["operators"].values()
+            if o.get("type_name") == "synthetic_templated_op"
+        )
+        assert "user_id" in op["$metadata"].get("common_input_template", [])
+
+    def test_template_field_missing_from_subflow_contract_raises(self):
+        """SubFlow declares `user_id` but the template references {{other_id}}.
+        Even though the parent flow provides other_id, the SubFlow-scoped
+        check fires first and raises against the declared SubFlow contract."""
+        from apple.validator import ValidationError
+
+        sf = SubFlow(
+            name="sf",
+            common_input=["user_id"],
+            item_input=["x"],
+            common_output=["greeting"],
+            item_output=["z"],
+        )
+        sf._add_op(
+            "synthetic_templated_op",
+            common_input=[],
+            common_output=["greeting"],
+            item_input=[],
+            item_output=[],
+            key_template="hi {{other_id}}",
+        )
+        self._add_lua(sf, item_input=["x"], item_output=["z"])
+
+        flow = Flow(
+            name="parent",
+            common_input=["user_id", "other_id"],
+            item_input=["x"],
+            common_output=["greeting"],
+            item_output=["z"],
+            sub_flows=[sf],
+        )
+        with pytest.raises(ValidationError, match=r"SubFlow 'sf' contract"):
+            compile_flow(flow)
+
+    def test_template_field_from_internal_subflow_op_passes(self):
+        """Internal upstream op produces `user_id` as common_output; a
+        downstream op inside the same SubFlow references {{user_id}}.
+        The SubFlow validator walks ops in order and sees user_id become
+        available before the templated op, mirroring flow-level coverage
+        but scoped to the SubFlow subtree.
+
+        SubFlow declares only an input contract (no output contract) — the
+        dead-code check fires only when item_output / common_output is
+        declared, and we want to isolate the input-bucket-union path here.
+        """
+        sf = SubFlow(name="sf", item_input=["x"])
+        # Internal upstream op produces user_id via common_output.
+        self._add_lua(
+            sf,
+            common_input=[],
+            common_output=["user_id"],
+            lua_script="function f() return 'u' end",
+            function_for_common="f",
+            function_for_item="",
+        )
+        # Downstream op consumes user_id only via the template marker.
+        sf._add_op(
+            "synthetic_templated_op",
+            common_input=[],
+            common_output=["greeting"],
+            item_input=[],
+            item_output=[],
+            key_template="hi {{user_id}}",
+        )
+        self._add_lua(sf, item_input=["x"], item_output=["z"])
+
+        flow = Flow(
+            name="parent",
+            item_input=["x"],
+            common_output=["greeting"],
+            item_output=["z"],
+            sub_flows=[sf],
+        )
+        cfg = compile_flow(flow)
+        assert "pipeline_config" in cfg
+
+

--- a/apple/tests/test_compiler.py
+++ b/apple/tests/test_compiler.py
@@ -1248,3 +1248,117 @@ class TestSubFlowContractEnforcement:
         )
         with pytest.raises(ValidationError, match=r"common_input field 'missing_common'"):
             compile_flow(flow_bad_common)
+
+
+class TestMarkerWidenSemantics:
+    """Row-set marker merge between the codegen registry and caller overrides
+    on `_FlowBase._add_op` (see flow.py:138-145).
+
+    The contract is True-OR: the effective marker is `registry OR caller`. This
+    means a caller can only widen a marker (False→True), never narrow one
+    (True→False). The registry stays the source of truth — it mirrors the Go
+    interface assertions (ConsumesRowSet / AdditiveWritesRowSet /
+    MutatesRowSet), and DSL callsites must not be able to lie about an
+    operator's row-set semantics. `_add_op` accepts overrides on all three
+    markers because it is the back-channel dynamic-dispatch path used when an
+    operator has not yet declared the matching marker interface on the Go
+    side. `BaseOp._apply` only exposes consumes_row_set as a widen-knob (see
+    base.py:151-161) — additive/mutates are taken purely from the registry.
+
+    Audit gaps M3 + M4.
+    """
+
+    def _add_lua_with_overrides(self, flow, **overrides):
+        flow._add_op(
+            "transform_by_lua",
+            item_input=["x"], item_output=["y"],
+            lua_script="function f() return 0 end",
+            function_for_item="f", function_for_common="",
+            **overrides,
+        )
+
+    def test_registry_false_caller_widens_all_three_markers(self):
+        """transform_by_lua is all-False in the registry. _add_op accepts
+        override=True for all three markers and the compiled JSON reflects
+        the widened values."""
+        flow = Flow(name="t", item_input=["x"], item_output=["y"])
+        self._add_lua_with_overrides(
+            flow,
+            consumes_row_set=True,
+            additive_writes_row_set=True,
+            mutates_row_set=True,
+        )
+        cfg = compile_flow(flow)
+        op = next(iter(cfg["pipeline_config"]["operators"].values()))
+        assert op.get("consumes_row_set") is True
+        assert op.get("additive_writes_row_set") is True
+        assert op.get("mutates_row_set") is True
+
+    def test_registry_false_no_override_keeps_all_false(self):
+        """Without overrides, transform_by_lua's compiled JSON omits the
+        markers (False is the default and is not emitted)."""
+        flow = Flow(name="t", item_input=["x"], item_output=["y"])
+        self._add_lua_with_overrides(flow)
+        cfg = compile_flow(flow)
+        op = next(iter(cfg["pipeline_config"]["operators"].values()))
+        assert "consumes_row_set" not in op
+        assert "additive_writes_row_set" not in op
+        assert "mutates_row_set" not in op
+
+    def test_registry_true_caller_false_does_not_narrow(self):
+        """filter_truncate has consumes=True, mutates=True in the registry.
+        A caller passing override=False MUST NOT downgrade the effective
+        markers — the registry wins under True-OR. This is the protection
+        flow.py:138-145 documents: DSL callsites cannot narrow a marker the
+        Go interface assertion has set."""
+        flow = Flow(name="t", common_input=["top_n"], item_input=["x"], item_output=["x"])
+        flow._add_op(
+            "filter_truncate",
+            common_input=["top_n"], item_input=["x"], item_output=["x"],
+            top_n=10,
+            consumes_row_set=False,
+            mutates_row_set=False,
+        )
+        cfg = compile_flow(flow)
+        op = next(iter(cfg["pipeline_config"]["operators"].values()))
+        assert op.get("consumes_row_set") is True
+        assert op.get("mutates_row_set") is True
+
+    def test_registry_true_caller_true_idempotent(self):
+        """True OR True is True — caller restating the registry value must
+        not flip the marker or duplicate-emit anything."""
+        flow = Flow(name="t", common_input=["top_n"], item_input=["x"], item_output=["x"])
+        flow._add_op(
+            "filter_truncate",
+            common_input=["top_n"], item_input=["x"], item_output=["x"],
+            top_n=10,
+            consumes_row_set=True,
+            mutates_row_set=True,
+        )
+        cfg = compile_flow(flow)
+        op = next(iter(cfg["pipeline_config"]["operators"].values()))
+        assert op.get("consumes_row_set") is True
+        assert op.get("mutates_row_set") is True
+
+    def test_caller_partial_override_independent_per_marker(self):
+        """The three markers are merged independently. Widening one must
+        not affect the others."""
+        flow = Flow(name="t", item_input=["x"], item_output=["y"])
+        self._add_lua_with_overrides(flow, additive_writes_row_set=True)
+        cfg = compile_flow(flow)
+        op = next(iter(cfg["pipeline_config"]["operators"].values()))
+        assert "consumes_row_set" not in op
+        assert op.get("additive_writes_row_set") is True
+        assert "mutates_row_set" not in op
+
+    def test_truthy_override_coerced_to_bool(self):
+        """flow.py:127 `bool(v)` — non-bool truthy values widen the marker
+        through the same True-OR path. This is the documented coercion
+        contract; without it a caller passing 1 / "yes" / a non-empty list
+        could silently no-op against a registry-False marker."""
+        flow = Flow(name="t", item_input=["x"], item_output=["y"])
+        self._add_lua_with_overrides(flow, consumes_row_set=1)
+        cfg = compile_flow(flow)
+        op = next(iter(cfg["pipeline_config"]["operators"].values()))
+        assert op.get("consumes_row_set") is True
+

--- a/apple/tests/test_compiler.py
+++ b/apple/tests/test_compiler.py
@@ -1507,3 +1507,174 @@ class TestSubFlowTemplateInteraction:
         assert "pipeline_config" in cfg
 
 
+class TestSubFlowMultiSkipContractInteraction:
+    """SubFlow declared with an input contract while wrapping nested
+    if/elseif/else control flow.
+
+    Two compiler passes meet here:
+      * compiler.py:308-329 (`_inject_inherited_skips`) — every op inside an
+        active control block has its branch's renamed skip-control field
+        appended to `common_input_skip`.
+      * validator.py:288-294 — SubFlow-scoped coverage unions the three
+        common_input buckets but filters underscore-prefixed fields (skip
+        controls live there by convention) before checking against the
+        SubFlow's declared common_input contract.
+
+    Without the underscore filter, a SubFlow that wraps an `if_` block and
+    declares a `common_input` contract would always fail because the
+    auto-injected `_…::if_N` field is never in the SubFlow contract. The
+    audit reflection at llmdoc/memory/reflections/nested-subflow-multi-skip-
+    design-gaps.md called out this cross as untested.
+
+    Audit gap M2.
+    """
+
+    def _add_lua(self, node, *, common_input=None, common_output=None,
+                 item_input=None, item_output=None, name=None):
+        kwargs = {
+            "common_input": common_input or [],
+            "common_output": common_output or [],
+            "item_input": item_input or [],
+            "item_output": item_output or [],
+            "lua_script": "function f() return 0 end",
+            "function_for_item": "f",
+            "function_for_common": "",
+        }
+        if name:
+            kwargs["name"] = name
+        node._add_op("transform_by_lua", **kwargs)
+
+    def test_subflow_contract_with_if_block_compiles(self):
+        """SubFlow declares a contract AND wraps an if_ block. The branch
+        injects _<sf>::if_1 into the inner op's common_input_skip; the
+        underscore filter at validator.py:294 lets the SubFlow check pass."""
+        sf = SubFlow(name="sf", common_input=["enabled"], item_input=["x"], item_output=["x"])
+        sf.if_("{{enabled}} ~= nil") \
+          ._add_op(
+              "transform_by_lua",
+              item_input=["x"], item_output=["x"],
+              lua_script="function f() return x end",
+              function_for_item="f", function_for_common="",
+          ) \
+          .end_if_()
+        flow = Flow(
+            name="parent",
+            common_input=["enabled"],
+            item_input=["x"],
+            item_output=["x"],
+            sub_flows=[sf],
+        )
+        cfg = compile_flow(flow)
+        ctrl_op = next(
+            op for op in cfg["pipeline_config"]["operators"].values()
+            if op.get("for_branch_control")
+        )
+        # Skip key is renamed to "_<sf>::if_N" inside the SubFlow.
+        renamed = ctrl_op["$metadata"]["common_output"][0]
+        assert renamed == "_sf::if_1"
+        # Inner op carries the renamed skip in its common_input_skip bucket.
+        inner_op = next(
+            op for op in cfg["pipeline_config"]["operators"].values()
+            if op["type_name"] == "transform_by_lua" and op.get("skip")
+        )
+        assert renamed in inner_op["$metadata"]["common_input_skip"]
+
+    def test_subflow_contract_with_if_else_multi_skip_compiles(self):
+        """If + else inside a SubFlow injects two distinct skip fields
+        across the branches; each branch's ops only carry the skip for
+        their own branch, and the SubFlow contract still passes."""
+        sf = SubFlow(name="sf", common_input=["mode"], item_input=["x"], item_output=["x"])
+        sf.if_("{{mode}} == 1") \
+          ._add_op(
+              "transform_by_lua",
+              item_input=["x"], item_output=["x"], name="if_branch_op",
+              lua_script="function f() return x end",
+              function_for_item="f", function_for_common="",
+          ) \
+          .else_() \
+          ._add_op(
+              "transform_by_lua",
+              item_input=["x"], item_output=["x"], name="else_branch_op",
+              lua_script="function g() return x end",
+              function_for_item="g", function_for_common="",
+          ) \
+          .end_if_()
+        flow = Flow(
+            name="parent",
+            common_input=["mode"],
+            item_input=["x"],
+            item_output=["x"],
+            sub_flows=[sf],
+        )
+        cfg = compile_flow(flow)
+        ops = cfg["pipeline_config"]["operators"]
+        if_op = ops["if_branch_op"]
+        else_op = ops["else_branch_op"]
+        # Each branch has its own skip control; the two skips are siblings
+        # under the same parent if_ block, both inside the SubFlow scope.
+        assert if_op.get("skip") and else_op.get("skip")
+        assert if_op["skip"] != else_op["skip"]
+        # Underscore filter at validator.py:294 means the SubFlow contract
+        # ("mode") never had to cover any of these synthesized fields.
+
+    def test_subflow_contract_with_nested_if_compiles(self):
+        """Outer if + inner if inside a SubFlow stack two skip controls on
+        the innermost op. Both skip fields are underscore-prefixed and the
+        SubFlow contract check tolerates them."""
+        sf = SubFlow(name="sf", common_input=["a", "b"], item_input=["x"], item_output=["x"])
+        sf.if_("{{a}} ~= nil") \
+          .if_("{{b}} ~= nil") \
+          ._add_op(
+              "transform_by_lua",
+              item_input=["x"], item_output=["x"], name="deep_op",
+              lua_script="function f() return x end",
+              function_for_item="f", function_for_common="",
+          ) \
+          .end_if_() \
+          .end_if_()
+        flow = Flow(
+            name="parent",
+            common_input=["a", "b"],
+            item_input=["x"],
+            item_output=["x"],
+            sub_flows=[sf],
+        )
+        cfg = compile_flow(flow)
+        deep_op = cfg["pipeline_config"]["operators"]["deep_op"]
+        # Two stacked skips, both underscore-prefixed and SubFlow-renamed.
+        skips = deep_op.get("skip") or []
+        assert len(skips) == 2
+        for s in skips:
+            assert s.startswith("_")
+        assert sorted(deep_op["$metadata"]["common_input_skip"]) == sorted(skips)
+
+    def test_subflow_contract_real_field_inside_branch_still_checked(self):
+        """The underscore filter ONLY exempts skip fields. A real
+        common_input field consumed inside an if branch still must be in
+        the SubFlow contract — the contract enforcement does not get
+        weaker just because the op happens to live under a control block."""
+        from apple.validator import ValidationError
+
+        sf = SubFlow(name="sf", common_input=["enabled"], item_input=["x"], item_output=["x"])
+        sf.if_("{{enabled}} ~= nil") \
+          ._add_op(
+              "transform_by_lua",
+              common_input=["secret"],
+              item_input=["x"], item_output=["x"],
+              lua_script="function f() return secret end",
+              function_for_item="f", function_for_common="",
+          ) \
+          .end_if_()
+        flow = Flow(
+            name="parent",
+            common_input=["enabled", "secret"],
+            item_input=["x"],
+            item_output=["x"],
+            sub_flows=[sf],
+        )
+        msg = r"common_input field 'secret' not provided by SubFlow 'sf'"
+        with pytest.raises(ValidationError, match=msg):
+            compile_flow(flow)
+
+
+

--- a/apple/tests/test_fixture_drift.py
+++ b/apple/tests/test_fixture_drift.py
@@ -238,10 +238,58 @@ def _build_e2e_apple_dsl_flow() -> Flow:
     return flow
 
 
+def _build_e2e_apple_dsl_control_flow() -> Flow:
+    """Round-trip pair for ``e2e_apple_dsl_control.json``.
+
+    Covers DSL surface that ``e2e_apple_dsl.json`` does not:
+
+    * ``if_/else_/end_if_`` control-flow primitives → ``for_branch_control``
+      operators with the deterministic ``if_<id>`` / ``else_<id>`` names and
+      Lua-emitted ``evaluate`` bodies.
+    * ``common_input_skip`` propagation onto downstream business ops (issue
+      #74's three-bucket skip metadata).
+    * Caller-widened row-set markers on ``reorder_sort``
+      (``consumes_row_set`` + ``mutates_row_set``).
+
+    Any compiler change that re-spells those fields, drops a marker, or
+    shifts the ctrl-field naming scheme will diverge the round-trip.
+    """
+    flow = Flow(
+        name="apple_e2e_ifelse",
+        common_input=["enabled"],
+        item_output=["item_id", "item_score", "mark"],
+    )
+    flow.recall_static(
+        item_output=["item_id", "item_score"],
+        items=[
+            {"item_id": "a", "item_score": 1.0},
+            {"item_id": "b", "item_score": 2.0},
+        ],
+    )
+    flow.if_("{{enabled}}")._add_op(
+        "transform_by_lua",
+        item_input=["item_score"],
+        item_output=["item_score", "mark"],
+        lua_script="function f() return item_score, true end",
+        function_for_item="f",
+        function_for_common="",
+    ).else_()._add_op(
+        "transform_by_lua",
+        item_input=["item_score"],
+        item_output=["item_score", "mark"],
+        lua_script="function f() return item_score, false end",
+        function_for_item="f",
+        function_for_common="",
+    ).end_if_()
+    flow.reorder_sort(item_input=["item_score"], order="desc")
+    return flow
+
+
 # Map fixture file -> builder function. Only fixtures with a known DSL
 # source belong here; others are covered by the shape-drift tests above.
 DSL_SOURCED_FIXTURES = {
     "e2e_apple_dsl.json": _build_e2e_apple_dsl_flow,
+    "e2e_apple_dsl_control.json": _build_e2e_apple_dsl_control_flow,
 }
 
 

--- a/apple/tests/test_redis_legacy_symbols_removed.py
+++ b/apple/tests/test_redis_legacy_symbols_removed.py
@@ -1,0 +1,93 @@
+"""Guard against reintroducing pine-cpp's pre-ResourceManager redis API.
+
+Before commit ``2a88df3`` (feat(pine-cpp): migrate Redis operators to
+ResourceManager connection pools), pine-cpp's redis path was driven by
+``RedisParams`` + a ``shared_pool()`` singleton. The migration removed
+both — connection pooling now flows through ``ResourceManager`` and the
+``redis_connection`` resource type.
+
+There is no compile-time barrier preventing the legacy names from
+sneaking back in (e.g. via a copy-paste from an old branch, an external
+contribution, or a partial revert). This test scans the runtime source
+trees for the two legacy identifiers and fails loudly if either
+reappears anywhere outside known-historical locations.
+
+Audit reference: ``L2`` in v0.9.0..HEAD test coverage audit.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# Runtime source roots to scan. Build artefacts, third-party deps, and
+# the `.code-review/` historical audit notes are deliberately excluded.
+SCAN_ROOTS = [
+    os.path.join(REPO_ROOT, "pine-cpp", "include"),
+    os.path.join(REPO_ROOT, "pine-cpp", "src"),
+    os.path.join(REPO_ROOT, "pine-cpp", "tests"),
+    os.path.join(REPO_ROOT, "pine-go"),
+    os.path.join(REPO_ROOT, "pine-java", "src"),
+    os.path.join(REPO_ROOT, "apple"),
+    os.path.join(REPO_ROOT, "apple_generated"),
+]
+
+SCAN_EXTENSIONS = (".cpp", ".hpp", ".h", ".cc", ".go", ".java", ".py")
+
+# Files explicitly allowed to mention the legacy symbols. This guard file is
+# the only intentional reference site — it has to spell the names out to scan
+# for them.
+SELF_PATH = os.path.normpath(os.path.abspath(__file__))
+
+LEGACY_PATTERNS = (
+    re.compile(r"\bRedisParams\b"),
+    re.compile(r"\bshared_pool\b"),
+)
+
+# Excluded directory components anywhere in the path.
+EXCLUDED_PARTS = {
+    "build", "third_party", "_deps", "target", "node_modules",
+    "__pycache__", ".pytest_cache",
+}
+
+
+def _iter_source_files():
+    for root in SCAN_ROOTS:
+        if not os.path.isdir(root):
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in EXCLUDED_PARTS]
+            for name in filenames:
+                if not name.endswith(SCAN_EXTENSIONS):
+                    continue
+                full = os.path.normpath(os.path.abspath(os.path.join(dirpath, name)))
+                if full == SELF_PATH:
+                    continue
+                yield full
+
+
+def test_legacy_redis_symbols_not_reintroduced():
+    """No production source under SCAN_ROOTS may mention RedisParams or
+    shared_pool. The migration to ResourceManager removed both; reintroduction
+    would break the resource_config hot-reload path and the cross-runtime
+    metrics-name parity (cache → cache_v2 swap in `10-hot-reload.sh`)."""
+    hits: list[str] = []
+    for path in _iter_source_files():
+        try:
+            with open(path, encoding="utf-8") as f:
+                text = f.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            for pat in LEGACY_PATTERNS:
+                m = pat.search(line)
+                if m:
+                    rel = os.path.relpath(path, REPO_ROOT)
+                    hits.append(f"{rel}:{line_no}: {m.group(0)} -> {line.strip()}")
+    assert not hits, (
+        "Legacy redis API names re-appeared in runtime source. The pine-cpp "
+        "migration to ResourceManager removed RedisParams + shared_pool; "
+        "all redis pooling now flows through redis_connection resources.\n  "
+        + "\n  ".join(hits)
+    )

--- a/apple/validator.py
+++ b/apple/validator.py
@@ -442,6 +442,50 @@ def _find_nested_template_marker(value, _path=""):
     return None
 
 
+def validate_explicit_null_params(ops: list[tuple[str, OpCall]]) -> None:
+    """Reject ``param=None`` for scalar params at compile time.
+
+    The Java/C++ runtime ``Init`` paths (commits 1fa18b3 / 452aee4) gate
+    parameter lookups with ``containsKey`` so that an explicit JSON ``null``
+    is classified as "wrong type" rather than silently falling back to the
+    default. Apple compiled to JSON sends ``null`` as ``null`` — meaning a
+    DSL author who hand-passes ``ttl=None`` to ``transform_redis_set`` could
+    only have the divergence surface at runtime, not at compile time, and
+    only if all three runtimes agreed on the wording.
+
+    Pulling the rejection forward to the validator gives the DSL author
+    the same line-number-anchored ``ValidationError`` as every other
+    schema violation. Scalar params (string / int / int64 / float /
+    float64 / bool) reject explicit ``None`` here; container params
+    (any / dict / list) and any operator without a codegen schema are
+    skipped — those have no clean "no value vs explicit null" contract.
+
+    Silently skips when ``apple_generated`` is not importable so that pre-
+    codegen development workflows still succeed.
+    """
+    for name, op in ops:
+        schema = _lookup_params_schema(op.type_name)
+        if schema is None:
+            continue
+        for param_name, value in op.params.items():
+            if value is not None:
+                continue
+            spec = schema.get(param_name)
+            if spec is None:
+                continue
+            declared_type = spec.get("type", "")
+            if declared_type not in _TEMPLATABLE_SCALAR_TYPES:
+                continue
+            raise ValidationError(
+                f"{_op_location(name, op)}param {param_name!r} on operator "
+                f"{op.type_name!r} is explicitly None; declared type "
+                f"{declared_type!r} does not accept null — pass the "
+                f"declared default or omit the keyword. The runtimes "
+                f"reject this as a type mismatch (see commits 1fa18b3 / "
+                f"452aee4 for the parity rationale)."
+            )
+
+
 def validate_templated_params(ops: list[tuple[str, OpCall]]) -> None:
     """Ensure ``{{field}}`` markers target params that opted into templating.
 

--- a/fixtures/pipelines/bench_cpu_work_parity.json
+++ b/fixtures/pipelines/bench_cpu_work_parity.json
@@ -1,0 +1,79 @@
+{
+  "name": "transform_bench_cpu byte-identical work output across runtimes (M12)",
+  "config": {
+    "_PINEAPPLE_VERSION": "0.9.13",
+    "pipeline_config": {
+      "operators": {
+        "bench": {
+          "type_name": "transform_bench_cpu",
+          "iterations": 2,
+          "$metadata": {
+            "common_input": [],
+            "common_output": [],
+            "item_input": [],
+            "item_output": ["_bench_result"]
+          }
+        }
+      },
+      "pipeline_map": {
+        "main_stage": {"pipeline": ["bench"]}
+      }
+    },
+    "pipeline_group": {
+      "main": {"pipeline": ["main_stage"]}
+    },
+    "flow_contract": {
+      "common_input": [],
+      "item_input": ["id"],
+      "common_output": [],
+      "item_output": ["id", "_bench_result"]
+    }
+  },
+  "cases": [
+    {
+      "name": "iterations=2, single item, all three runtimes must agree bit-for-bit",
+      "request": {
+        "common": {},
+        "items": [
+          {"id": "a"}
+        ]
+      },
+      "expected": {
+        "common": {},
+        "items": [
+          {"id": "a", "_bench_result": 4356611.465081713}
+        ]
+      }
+    },
+    {
+      "name": "iterations=2, three items, per-item compute repeated identically",
+      "request": {
+        "common": {},
+        "items": [
+          {"id": "x"},
+          {"id": "y"},
+          {"id": "z"}
+        ]
+      },
+      "expected": {
+        "common": {},
+        "items": [
+          {"id": "x", "_bench_result": 4356611.465081713},
+          {"id": "y", "_bench_result": 4356611.465081713},
+          {"id": "z", "_bench_result": 4356611.465081713}
+        ]
+      }
+    },
+    {
+      "name": "iterations=2, zero items, body never executed (parity)",
+      "request": {
+        "common": {},
+        "items": []
+      },
+      "expected": {
+        "common": {},
+        "items": []
+      }
+    }
+  ]
+}

--- a/fixtures/pipelines/reorder_topn_boost_parity.json
+++ b/fixtures/pipelines/reorder_topn_boost_parity.json
@@ -1,0 +1,66 @@
+{
+  "name": "reorder_topn_boost byte-identical reorder output across runtimes (H8)",
+  "requires": ["bench"],
+  "config": {
+    "_PINEAPPLE_VERSION": "0.9.13",
+    "pipeline_config": {
+      "operators": {
+        "boost": {
+          "type_name": "reorder_topn_boost",
+          "size": 3,
+          "$metadata": {
+            "common_input": ["shuffle_salt"],
+            "common_output": [],
+            "item_input": ["id"],
+            "item_output": [],
+            "consumes_row_set": true,
+            "mutates_row_set": true
+          }
+        }
+      },
+      "pipeline_map": {
+        "main_stage": {"pipeline": ["boost"]}
+      }
+    },
+    "pipeline_group": {
+      "main": {"pipeline": ["main_stage"]}
+    },
+    "flow_contract": {
+      "common_input": ["shuffle_salt"],
+      "item_input": ["id"],
+      "common_output": [],
+      "item_output": ["id"]
+    }
+  },
+  "cases": [
+    {
+      "name": "size=3, n=8, FNV-1a salted hash chooses 3 boosted items by ascending hash, rest preserve original order",
+      "request": {
+        "common": {"shuffle_salt": "beef"},
+        "items": [
+          {"id": "10001"},
+          {"id": "10002"},
+          {"id": "10003"},
+          {"id": "10004"},
+          {"id": "10005"},
+          {"id": "10006"},
+          {"id": "10007"},
+          {"id": "10008"}
+        ]
+      },
+      "expected": {
+        "common": {},
+        "items": [
+          {"id": "10004"},
+          {"id": "10005"},
+          {"id": "10006"},
+          {"id": "10001"},
+          {"id": "10002"},
+          {"id": "10003"},
+          {"id": "10007"},
+          {"id": "10008"}
+        ]
+      }
+    }
+  ]
+}

--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -29,6 +29,7 @@
 - `llmdoc/reference/apple-control-template-syntax.md` — Apple DSL 控制流条件参考：`if_` / `elseif_` 需要使用 `{{field_name}}` 模板语法显式标记字段引用，编译器据此提取依赖并在发射 Lua 前去掉模板标记。
 - `llmdoc/reference/metrics-observability.md` — 可插拔观测参考：跨运行时 `Provider` 契约（pine-go 规范 + pine-cpp/pine-java 对等）、引擎/调度器/Lua pool 指标注入、`/stats` 组合响应（含 `/stats.http` 与 `/stats.resources` 子树 schema）、内置 HTTP metrics middleware（各运行时 default-on）、资源级指标 fan-out（Tee）路由与 Collector 契约、Prometheus 适配边界。
 - `llmdoc/reference/dag-visualization.md` — DAG 可视化参考：`RenderDAG` / `WithCollapse` API、SubFlow 折叠规则、`GET /dag` 参数与 DOT/Mermaid 输出约定。
+- `llmdoc/reference/admin-pprof-disclosure.md` — pine-go 可选 admin server 的 pprof 暴露面、默认关闭契约、五条 `/debug/pprof/*` 路径的信息泄漏内容、运维约束(网络层隔离/认证反代/诊断窗口)与跨 runtime 对等(pine-cpp/pine-java 不实现 admin pprof)。
 
 ## memory/
 

--- a/llmdoc/reference/admin-pprof-disclosure.md
+++ b/llmdoc/reference/admin-pprof-disclosure.md
@@ -1,0 +1,85 @@
+# Admin pprof 端口与信息泄漏面参考
+
+本文档归档 pine-go 可选 admin server 的暴露面、默认状态、运维约束,以及为什么"信息泄漏面默认关闭"是一个有意为之的安全契约。pine-cpp 与 pine-java 不实现 admin pprof,本文为 pine-go 独有特性的边界说明。
+
+## 权威文件
+
+- `pine-go/pkg/server/server.go` — `Config.AdminAddr`、`newAdminMux()`、admin `http.Server` 启停
+- `pine-go/pkg/server/server_test.go` — `TestAdminPprofMuxServesPprof` / `TestMainMuxDoesNotExposePprof`(H7) 与三方主端口 pprof 404 断言(M11)
+- `pine-go/cmd/pineapple-server/main.go` — `-admin-addr` flag(默认空字符串)
+- `scripts/cross-validate/12-extensibility-parity.sh` — Test 7:三 runtime 主端口 `/debug/pprof/` 必须 404
+- `scripts/cross-validate/06-error-shapes.sh` — 主端口未知路径返回 404 的对等断言
+
+## 暴露面清单
+
+`newAdminMux()` 仅注册标准 `net/http/pprof` 五条路径,挂在与业务端口完全隔离的独立 `http.Server` 上:
+
+| 路径 | 用途 | 信息泄漏内容 |
+|------|------|------|
+| `/debug/pprof/` | pprof 首页 + heap/goroutine/allocs/block/mutex/threadcreate 索引 | 进程内存/goroutine 计数、运行时元数据 |
+| `/debug/pprof/cmdline` | 进程命令行 | 完整 argv,**含 `-admin-addr`、`-config`、`-listen` 等 flag 取值** |
+| `/debug/pprof/profile` | CPU profile 采样(默认 30s,可 `?seconds=N` 拉长) | 函数级 CPU 热点 + 调用图 |
+| `/debug/pprof/symbol` | 符号表查询 | 二进制 PC → 函数名映射 |
+| `/debug/pprof/trace` | 执行 trace | goroutine 调度事件 + system call 时序 |
+
+主业务 mux(`/health`、`/execute`、`/stats`、`/dag`、catch-all 404)**不**挂载任何 `/debug/pprof/*` handler,这条边界由 `TestMainMuxDoesNotExposePprof` 单元测试与 cross-validate Section 12 Test 7 共同钉住。
+
+## 默认状态:关闭
+
+`Config.AdminAddr` 默认为空字符串(`pine-go/pkg/server/server.go:35`),CLI flag `-admin-addr` 默认为空字符串(`pine-go/cmd/pineapple-server/main.go:23`)。空值时 admin server 不构造、不监听:
+
+```go
+if cfg.AdminAddr != "" {
+    adminSrv = &http.Server{ ... Handler: newAdminMux(), ... }
+    go adminSrv.ListenAndServe()
+}
+```
+
+也就是说:**默认部署不暴露 pprof**。要启用必须显式 `-admin-addr :6060`(或 `Config{AdminAddr: ":6060"}`),即明确知会运维人员"我要在 6060 上挂一个进程级诊断面"。
+
+## 信息泄漏风险评估
+
+启用 admin 端口后,以下几类信息会经 6060 端口直接暴露:
+
+1. **进程命令行(`/debug/pprof/cmdline`)** — argv 含所有 CLI flag 取值。如果运维通过 flag 传入 `-config /etc/pineapple/secret.yaml` 这类路径,路径片段会在 cmdline 上原文出现;如果业务通过 flag 传入鉴权 token(不推荐),会直接泄漏。
+2. **运行时元数据(`/debug/pprof/`)** — heap profile 含分配栈、function name、文件路径,可推断业务逻辑、依赖版本、构建路径。
+3. **执行 trace(`/debug/pprof/trace`)** — goroutine 调度细节可推断并发模型与压力曲线。
+4. **代码地址布局(`/debug/pprof/symbol`)** — 二进制符号表可辅助 ROP/JOP 利用链构造。
+
+## 运维约束
+
+启用 admin 端口必须满足以下三条之一,否则视为配置事故:
+
+1. **网络层隔离** — admin 端口仅绑回环(`-admin-addr 127.0.0.1:6060`)或内网 ACL/Service Mesh 限制访问源。
+2. **认证反代** — 经 nginx/envoy 等反代加 mTLS / Basic Auth 后再放行公网。
+3. **诊断窗口** — 仅在故障诊断窗口期临时开启,排障完成立即关闭(SIGTERM 后 admin server 与主 server 一并 graceful shutdown,见 `server.go:297`)。
+
+公网直连 admin 端口的部署被视为 **严重配置漏洞**,等同把 `pprof.Cmdline` 暴露在 internet。
+
+## 独立 server 的设计动机
+
+admin 与主业务跑在两个独立 `http.Server`:
+
+- **超时隔离** — 主端口有 `WriteTimeout: 60s`(默认),`/debug/pprof/profile?seconds=120` 这种长 CPU 采样会被截断。admin server 不设 `WriteTimeout`,放任长 profile 走完(`server.go:273-280`)。
+- **绑定隔离** — admin 可单独绑回环,主端口绑公网,不需要复杂的 path-based ACL。
+- **mux 隔离** — 主 mux 与 admin mux 是两份 `*http.ServeMux`,生产代码不会因为路径前缀写错而把 pprof 误挂主端口(`TestMainMuxDoesNotExposePprof` 钉住此回归点)。
+
+## 跨运行时对等
+
+pine-cpp 与 pine-java 的 server 都不实现 admin pprof:
+
+- **pine-cpp** — `pine-cpp/src/server/server.cpp` 无 `/debug/pprof` 路由,profiling 走外部工具(perf/gperftools)。
+- **pine-java** — `pine-java/.../PineServer.java` 用 `com.sun.net.httpserver.HttpServer`,无 pprof 等价物,profiling 走 JFR/async-profiler。
+
+cross-validate Section 12 Test 7 断言三 runtime 主端口对 `/debug/pprof/` 一律返回 404。任何运行时把 pprof 挂主端口会立即触发 parity 失败。
+
+## 测试断言矩阵
+
+| 断言 | 位置 | 含义 |
+|------|------|------|
+| admin mux 三条 pprof 路径 200 | `server_test.go::TestAdminPprofMuxServesPprof` | 启用后 admin 必须可达 |
+| 主 mux 三条 pprof 路径 404 | `server_test.go::TestMainMuxDoesNotExposePprof` | 主端口必须无 pprof |
+| 三 runtime 主端口 `/debug/pprof/` 404 | `12-extensibility-parity.sh` Test 7 | 跨 runtime 主端口零 pprof |
+| `Config.AdminAddr` 默认空 | `server.go:35` 字面量 + `main.go:23` flag default | 默认零暴露 |
+
+任何修改其中一条都会触发 CI 失败。

--- a/pine-cpp/CMakeLists.txt
+++ b/pine-cpp/CMakeLists.txt
@@ -245,6 +245,7 @@ if(PINE_CPP_BUILD_TESTS)
         tests/test_closer.cpp
         tests/test_metrics_collector.cpp
         tests/test_template.cpp
+        tests/test_arena.cpp
     )
     target_sources(pine_cpp_tests PRIVATE src/server/http_metrics.cpp src/server/http_stats.cpp)
     target_link_libraries(pine_cpp_tests PRIVATE pine_cpp_core doctest::doctest)

--- a/pine-cpp/operators/bench_stubs.cpp
+++ b/pine-cpp/operators/bench_stubs.cpp
@@ -1,3 +1,15 @@
+// Benchmark-only stub operators (recall_feed_data, transform_redis_*,
+// reorder_topn_boost, ...). Compiled in only when PINE_BUILD_BENCH_STUBS=ON;
+// otherwise the registrations below are absent from the Engine's operator
+// table.
+//
+// Diff-fuzz exclusion (audit L3): these stubs are deliberately absent from
+// scripts/differential-fuzz.py op_types. They are throughput-only and have
+// no cases/expected fixture surface; including them would force the
+// cross-runtime oracle to reason about timing-derived outputs that are not
+// part of the engine's pure-function contract. byte-equal work parity for
+// transform_bench_cpu is locked separately by
+// fixtures/pipelines/bench_cpu_work_parity.json (audit M12).
 #include "pine/operator.hpp"
 #include "pine/resource.hpp"
 

--- a/pine-cpp/tests/test_arena.cpp
+++ b/pine-cpp/tests/test_arena.cpp
@@ -1,0 +1,210 @@
+#include "pine/arena.hpp"
+
+#include <doctest/doctest.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+using namespace pine;
+
+namespace {
+
+// All bytes inside [p, p+n) of a freshly-bumped region must be writable
+// without aliasing any other live allocation. We use this to verify
+// non-overlap by stamping unique tags into each block and reading them
+// back.
+bool all_unique(const std::vector<std::pair<unsigned char*, std::size_t>>& blocks) {
+  // O(n^2) overlap check; n is small in tests.
+  for (std::size_t i = 0; i < blocks.size(); ++i) {
+    auto [pi, ni] = blocks[i];
+    for (std::size_t j = i + 1; j < blocks.size(); ++j) {
+      auto [pj, nj] = blocks[j];
+      // Disjoint iff one ends before the other begins.
+      if (!(pi + ni <= pj || pj + nj <= pi)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+TEST_CASE("RequestArena routes ArenaAllocator through the per-thread bump") {
+  // Outside a RequestArena, allocator falls back to new_delete_resource.
+  auto* before = current_resource();
+  CHECK(current_central_arena() == nullptr);
+  {
+    RequestArena arena;
+    CHECK(current_central_arena() != nullptr);
+    CHECK(current_resource() != before);
+
+    // ArenaAllocator is stateless; two instances compare equal.
+    ArenaAllocator<int> a1;
+    ArenaAllocator<int> a2;
+    CHECK(a1 == a2);
+
+    // Allocate from the bump and ensure the pointer is non-null and aligned.
+    int* p = a1.allocate(16);
+    REQUIRE(p != nullptr);
+    CHECK(reinterpret_cast<std::uintptr_t>(p) % alignof(int) == 0);
+    a1.deallocate(p, 16);  // no-op for arena
+  }
+  // Restored after RequestArena destructs.
+  CHECK(current_resource() == before);
+  CHECK(current_central_arena() == nullptr);
+}
+
+TEST_CASE("ThreadLocalBump hands out non-overlapping regions across many sizes") {
+  RequestArena arena;
+  ArenaAllocator<unsigned char> alloc;
+
+  std::vector<std::pair<unsigned char*, std::size_t>> blocks;
+  // Mix small, medium, and chunk-spanning allocations to force at least
+  // one central-arena refill of the local buffer.
+  const std::size_t sizes[] = {1, 7, 64, 4096, 50 * 1024, 8, 32 * 1024};
+  for (std::size_t s : sizes) {
+    auto* p = alloc.allocate(s);
+    REQUIRE(p != nullptr);
+    // Stamp the block with a tag tied to its index so any later overlap
+    // would corrupt one of the witnesses.
+    for (std::size_t i = 0; i < s; ++i) {
+      p[i] = static_cast<unsigned char>(blocks.size() & 0xff);
+    }
+    blocks.emplace_back(p, s);
+  }
+  CHECK(all_unique(blocks));
+  // Witnesses survive: stamps are still readable as their original index.
+  for (std::size_t b = 0; b < blocks.size(); ++b) {
+    auto [p, n] = blocks[b];
+    for (std::size_t i = 0; i < n; ++i) {
+      REQUIRE(p[i] == static_cast<unsigned char>(b & 0xff));
+    }
+  }
+}
+
+TEST_CASE("ScopedInstall isolates worker-thread allocations from caller bump") {
+  RequestArena arena;
+  auto* caller_resource = current_resource();
+  auto* central = current_central_arena();
+  REQUIRE(central != nullptr);
+
+  std::atomic<bool> worker_ok{false};
+  std::thread t([&]() {
+    // Worker has no inherited tl_resource; install a local bump backed by
+    // the same central arena.
+    ScopedInstall guard(central);
+    CHECK(current_resource() != caller_resource);
+    ArenaAllocator<int> a;
+    int* p = a.allocate(128);
+    REQUIRE(p != nullptr);
+    for (int i = 0; i < 128; ++i) {
+      p[i] = i;
+    }
+    for (int i = 0; i < 128; ++i) {
+      REQUIRE(p[i] == i);
+    }
+    worker_ok.store(true, std::memory_order_release);
+    // ScopedInstall destructor restores the prior thread-local resource.
+  });
+  t.join();
+  CHECK(worker_ok.load(std::memory_order_acquire));
+  // Caller's tl_resource is unaffected by what the worker did.
+  CHECK(current_resource() == caller_resource);
+}
+
+TEST_CASE("Many concurrent workers allocate from the same CentralArena without corruption") {
+  RequestArena arena;
+  auto* central = current_central_arena();
+  REQUIRE(central != nullptr);
+
+  constexpr int kThreads = 8;
+  constexpr int kPerThread = 256;
+  std::atomic<int> failures{0};
+
+  std::vector<std::thread> ts;
+  ts.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&, t]() {
+      ScopedInstall guard(central);
+      ArenaAllocator<std::uint64_t> a;
+      // Each worker stamps its own tag into its block; if two workers
+      // ever returned overlapping memory, the tag-readback would mismatch.
+      const std::uint64_t tag = (static_cast<std::uint64_t>(t) << 56) | 0xdeadbeefULL;
+      for (int i = 0; i < kPerThread; ++i) {
+        const std::size_t n = 1 + (i % 64);
+        auto* p = a.allocate(n);
+        for (std::size_t k = 0; k < n; ++k) {
+          p[k] = tag ^ static_cast<std::uint64_t>(i * 31 + k);
+        }
+        for (std::size_t k = 0; k < n; ++k) {
+          if (p[k] != (tag ^ static_cast<std::uint64_t>(i * 31 + k))) {
+            failures.fetch_add(1, std::memory_order_relaxed);
+            break;
+          }
+        }
+      }
+    });
+  }
+  for (auto& th : ts) {
+    th.join();
+  }
+  CHECK(failures.load() == 0);
+}
+
+TEST_CASE("Nested RequestArena restores the outer bump on inner destruction") {
+  // The outer arena's pointer must come back unchanged after the inner
+  // scope exits, even though the inner arena swapped tl_resource and
+  // tl_central in its constructor.
+  CHECK(current_central_arena() == nullptr);
+  {
+    RequestArena outer;
+    auto* outer_resource = current_resource();
+    auto* outer_central = current_central_arena();
+    REQUIRE(outer_central != nullptr);
+
+    {
+      RequestArena inner;
+      CHECK(current_resource() != outer_resource);
+      CHECK(current_central_arena() != outer_central);
+    }
+
+    CHECK(current_resource() == outer_resource);
+    CHECK(current_central_arena() == outer_central);
+  }
+  CHECK(current_central_arena() == nullptr);
+}
+
+TEST_CASE("Allocations after a chunk boundary remain readable until arena destruction") {
+  // The bump's local chunk is 32 KB. Allocate just enough small blocks
+  // to span at least two chunks, write a witness into each, and then
+  // confirm every witness still reads correctly. This catches a bug
+  // where a refill stomps on the previous chunk's live region.
+  RequestArena arena;
+  ArenaAllocator<std::uint32_t> a;
+
+  std::vector<std::pair<std::uint32_t*, std::size_t>> blocks;
+  std::size_t total_bytes = 0;
+  std::uint32_t k = 0;
+  while (total_bytes < 80 * 1024) {  // > 2 chunks
+    const std::size_t n = 64 + (k % 64);
+    auto* p = a.allocate(n);
+    REQUIRE(p != nullptr);
+    for (std::size_t i = 0; i < n; ++i) {
+      p[i] = k * 1000003u + static_cast<std::uint32_t>(i);
+    }
+    blocks.emplace_back(p, n);
+    total_bytes += n * sizeof(std::uint32_t);
+    ++k;
+  }
+  // All witnesses still match — no chunk refill clobbered prior data.
+  for (std::uint32_t b = 0; b < blocks.size(); ++b) {
+    auto [p, n] = blocks[b];
+    for (std::size_t i = 0; i < n; ++i) {
+      REQUIRE(p[i] == b * 1000003u + static_cast<std::uint32_t>(i));
+    }
+  }
+}

--- a/pine-cpp/tests/test_column.cpp
+++ b/pine-cpp/tests/test_column.cpp
@@ -235,6 +235,47 @@ TEST_CASE("TypedColumnStore::reorder_rows shares visited bitmap across K>2 colum
   CHECK(store.column("j")->get(5).as_string() == "six");
 }
 
+TEST_CASE("Derived-class static type can call 1-arg reorder(order) (name-hiding fix)") {
+  // Regression for 0dec52a: TypedColumn/JsonColumn override the 2-arg
+  // reorder(order, visited_scratch); by C++ name-hiding rules, that
+  // suppresses the base-class 1-arg convenience overload reorder(order)
+  // unless the derived class re-imports it via `using Column::reorder`.
+  // All callers in the runtime go through Column* / unique_ptr<Column>,
+  // so the typed-static-type call path is exercised only here.
+  // Without `using Column::reorder` in each derived class, this test
+  // would fail to compile.
+  {
+    Int64Column c(3);
+    REQUIRE(c.set(0, Variant(10.0)));
+    REQUIRE(c.set(1, Variant(20.0)));
+    REQUIRE(c.set(2, Variant(30.0)));
+    c.reorder({2, 0, 1});
+    CHECK(c.get(0).as_number() == 30.0);
+    CHECK(c.get(1).as_number() == 10.0);
+    CHECK(c.get(2).as_number() == 20.0);
+  }
+  {
+    StringColumn c(3);
+    REQUIRE(c.set(0, Variant(std::string("a"))));
+    REQUIRE(c.set(1, Variant(std::string("b"))));
+    REQUIRE(c.set(2, Variant(std::string("c"))));
+    c.reorder({2, 0, 1});
+    CHECK(c.get(0).as_string() == "c");
+    CHECK(c.get(1).as_string() == "a");
+    CHECK(c.get(2).as_string() == "b");
+  }
+  {
+    JsonColumn c;
+    REQUIRE(c.append(Variant(1.0)));
+    REQUIRE(c.append(Variant(std::string("two"))));
+    REQUIRE(c.append(Variant(true)));
+    c.reorder({2, 0, 1});
+    CHECK(c.get(0).as_bool() == true);
+    CHECK(c.get(1).as_number() == 1.0);
+    CHECK(c.get(2).as_string() == "two");
+  }
+}
+
 TEST_CASE("Int64Column precision boundary detection") {
   using pine::int64_lossy_as_double;
   // Within IEEE 754 binary64 precise range: 0..2^53

--- a/pine-cpp/tests/test_column.cpp
+++ b/pine-cpp/tests/test_column.cpp
@@ -157,6 +157,84 @@ TEST_CASE("TypedColumnStore::remove_rows rejects OOB indices") {
   CHECK(store.column("x")->size() == 2);
 }
 
+TEST_CASE("TypedColumnStore::reorder_rows shares visited bitmap across K>2 columns") {
+  // The store hoists the cycle-following visited bitmap out of the per-column
+  // call so K columns share one buffer (column_store.cpp:91-94). The frame
+  // tests in test_column_frame.cpp exercise ≤2 columns; with that few, a
+  // bug in reset-between-columns hides easily because the cycle structure
+  // tends to be trivial. This case uses 5 typed columns of mixed dtypes
+  // and a permutation with multiple non-trivial cycles, so any failure to
+  // reset visited_scratch between columns would leave the second-onwards
+  // column in a partially-permuted state.
+  const std::size_t n = 6;
+  pine::TypedColumnStore store(n);
+
+  // 5 columns of three dtypes — exercises Int64/Double/String/Bool reorder
+  // paths plus a JsonColumn (heterogeneous values).
+  std::vector<pine::Variant> ints{
+      pine::Variant(10.0), pine::Variant(11.0), pine::Variant(12.0),
+      pine::Variant(13.0), pine::Variant(14.0), pine::Variant(15.0),
+  };
+  std::vector<pine::Variant> doubles{
+      pine::Variant(0.5), pine::Variant(1.5), pine::Variant(2.5),
+      pine::Variant(3.5), pine::Variant(4.5), pine::Variant(5.5),
+  };
+  std::vector<pine::Variant> strings{
+      pine::Variant(std::string("a")), pine::Variant(std::string("b")), pine::Variant(std::string("c")),
+      pine::Variant(std::string("d")), pine::Variant(std::string("e")), pine::Variant(std::string("f")),
+  };
+  std::vector<pine::Variant> bools{
+      pine::Variant(true),  pine::Variant(false), pine::Variant(true),
+      pine::Variant(false), pine::Variant(true),  pine::Variant(false),
+  };
+  // Heterogeneous → JsonColumn.
+  std::vector<pine::Variant> jsons{
+      pine::Variant(1.0), pine::Variant(std::string("two")), pine::Variant(true), pine::Variant(),
+      pine::Variant(4.0), pine::Variant(std::string("six")),
+  };
+
+  store.set_column("i", pine::make_column(ints));
+  store.set_column("d", pine::make_column(doubles));
+  store.set_column("s", pine::make_column(strings));
+  store.set_column("b", pine::make_column(bools));
+  store.set_column("j", pine::make_column(jsons));
+
+  // Permutation with two non-trivial cycles plus one fixed point:
+  //   cycle A: 0 → 2 → 4 → 0
+  //   cycle B: 1 → 3 → 1
+  //   fixed:   5 → 5
+  // After the reorder, new[i] == old[order[i]].
+  std::vector<int> order = {2, 3, 4, 1, 0, 5};
+  store.reorder_rows(order);
+
+  // Expected per-column values after permutation.
+  const std::vector<double> exp_i = {12, 13, 14, 11, 10, 15};
+  const std::vector<double> exp_d = {2.5, 3.5, 4.5, 1.5, 0.5, 5.5};
+  const std::vector<std::string> exp_s = {"c", "d", "e", "b", "a", "f"};
+  const std::vector<bool> exp_b = {true, false, true, false, true, false};
+
+  for (std::size_t i = 0; i < n; ++i) {
+    CHECK(store.column("i")->get(i).as_number() == exp_i[i]);
+    CHECK(store.column("d")->get(i).as_number() == exp_d[i]);
+    CHECK(store.column("s")->get(i).as_string() == exp_s[i]);
+    CHECK(store.column("b")->get(i).as_bool() == exp_b[i]);
+  }
+  // JsonColumn carries the heterogeneous mix; spot-check that each
+  // permuted position holds jsons[order[i]] under the same permutation.
+  // exp_j[0] = jsons[2] = true
+  CHECK(store.column("j")->get(0).as_bool() == true);
+  // exp_j[1] = jsons[3] = null
+  CHECK(store.column("j")->is_null(1));
+  // exp_j[2] = jsons[4] = 4.0
+  CHECK(store.column("j")->get(2).as_number() == 4.0);
+  // exp_j[3] = jsons[1] = "two"
+  CHECK(store.column("j")->get(3).as_string() == "two");
+  // exp_j[4] = jsons[0] = 1.0
+  CHECK(store.column("j")->get(4).as_number() == 1.0);
+  // exp_j[5] = jsons[5] = "six"
+  CHECK(store.column("j")->get(5).as_string() == "six");
+}
+
 TEST_CASE("Int64Column precision boundary detection") {
   using pine::int64_lossy_as_double;
   // Within IEEE 754 binary64 precise range: 0..2^53

--- a/pine-cpp/tests/test_column_frame.cpp
+++ b/pine-cpp/tests/test_column_frame.cpp
@@ -79,6 +79,64 @@ TEST_CASE("ColumnFrame: apply_output type-mismatch promotes column to Json") {
   CHECK(frame.item(2, "score").as_number() == 30.0);
 }
 
+TEST_CASE("ColumnFrame: present-null write promotes typed column to Json") {
+  // The null-write branch of write_item_field_locked (column_frame.cpp:278-282)
+  // must turn a typed column into a JsonColumn so the slot can carry
+  // present-null (validity=true, value=null). Existing coverage only
+  // exercises the *type-mismatch* retry branch (line 283-287); this case
+  // pins the null-write branch separately.
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_item(1, "score", Variant());  // explicit null, not absent
+  frame.apply_output(out, "op", false);
+  CHECK(frame.item(0, "score").as_number() == 10.0);
+  CHECK(frame.item(1, "score").is_null());
+  CHECK(frame.item(2, "score").as_number() == 30.0);
+
+  // A subsequent typed write must still land — the column is now JsonColumn
+  // and JsonColumn accepts any Variant.
+  OperatorOutput out2;
+  out2.set_item(1, "score", Variant(std::string("recovered")));
+  frame.apply_output(out2, "op", false);
+  CHECK(frame.item(1, "score").as_string() == "recovered");
+}
+
+TEST_CASE("ColumnFrame: object/array write promotes StringColumn to Json") {
+  // First write picks a typed column based on the value's runtime type
+  // (column_frame.cpp:260-272). A subsequent object/array write into a
+  // StringColumn cannot succeed via TypedColumn::set (it rejects the type)
+  // and must fall through to the type-mismatch retry branch
+  // (column_frame.cpp:283-287). Existing tests only cover string→typed
+  // numeric mismatches — this case exercises object/array → StringColumn.
+  auto frame = make_frame();
+  OperatorOutput out;
+  out.set_item(0, "tag", Variant(std::string("hello")));  // creates StringColumn
+  frame.apply_output(out, "op", false);
+
+  OperatorOutput out2;
+  Variant::object_t obj{{"k", Variant(std::string("v"))}};
+  out2.set_item(1, "tag", Variant(std::move(obj)));  // StringColumn → Json
+  frame.apply_output(out2, "op", false);
+
+  CHECK(frame.item(0, "tag").as_string() == "hello");
+  REQUIRE(frame.item(1, "tag").is_object());
+  CHECK(frame.item(1, "tag").as_object().at("k").as_string() == "v");
+  CHECK(frame.item(2, "tag").is_null());
+
+  // Array write into the now-promoted JsonColumn must also land cleanly.
+  OperatorOutput out3;
+  Variant::array_t arr{Variant(1.0), Variant(std::string("two"))};
+  out3.set_item(2, "tag", Variant(std::move(arr)));
+  frame.apply_output(out3, "op", false);
+  REQUIRE(frame.item(2, "tag").is_array());
+  CHECK(frame.item(2, "tag").as_array().size() == 2);
+  CHECK(frame.item(2, "tag").as_array()[0].as_number() == 1.0);
+  CHECK(frame.item(2, "tag").as_array()[1].as_string() == "two");
+  // Earlier rows still hold their pre-promotion values.
+  CHECK(frame.item(0, "tag").as_string() == "hello");
+  REQUIRE(frame.item(1, "tag").is_object());
+}
+
 TEST_CASE("ColumnFrame: apply_output removes rows preserves remaining fields") {
   auto frame = make_frame();
   OperatorOutput out;

--- a/pine-cpp/tests/test_engine.cpp
+++ b/pine-cpp/tests/test_engine.cpp
@@ -4,6 +4,10 @@
 
 #include <doctest/doctest.h>
 
+#include <atomic>
+#include <thread>
+#include <vector>
+
 using namespace pine;
 
 namespace {
@@ -290,4 +294,57 @@ TEST_CASE("Engine::execute external cancel mid-flight on multi-node DAG (R10-4)"
   auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
   INFO("elapsed=" << ms << "ms");
   CHECK(ms < 1200);
+}
+
+TEST_CASE("Engine::execute is safe to call concurrently from many threads on the same Plan") {
+  // Direct doctest (TSan-runnable) coverage for shared `const Engine` use.
+  // Server-layer integration tests already pound execute() concurrently via
+  // the HTTP path, but those are coarse: a TSan failure surfaces only by
+  // way of a serialized stack trace inside the request handler, which
+  // hides the engine-internal race. This case calls Engine::execute
+  // directly from N threads with the same Plan and per-thread Request
+  // payloads, asserting both: (1) every thread observes its own input
+  // round-tripped through transform_copy → its own output (no cross-talk
+  // through any shared mutable state inside Engine), and (2) the total
+  // call survives the run with no crash, no hang.
+  Engine engine(load_config_from_json(kCopyConfig));
+
+  constexpr int kThreads = 16;
+  constexpr int kPerThread = 32;
+  std::atomic<int> mismatches{0};
+  std::atomic<int> exceptions{0};
+
+  std::vector<std::thread> ts;
+  ts.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&, t]() {
+      for (int i = 0; i < kPerThread; ++i) {
+        // Each (thread, iteration) pair gets a unique input string so
+        // any cross-pollination between concurrent execute() calls is
+        // detectable on output.
+        std::string payload = "t" + std::to_string(t) + "-i" + std::to_string(i);
+        Request req;
+        req.common["src"] = Variant(payload);
+        try {
+          auto result = engine.execute(req);
+          auto it = result.common.find("dst");
+          if (it == result.common.end() || it->second.as_string() != payload) {
+            mismatches.fetch_add(1, std::memory_order_relaxed);
+          }
+        } catch (...) {
+          exceptions.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+  for (auto& th : ts) {
+    th.join();
+  }
+  CHECK(mismatches.load() == 0);
+  CHECK(exceptions.load() == 0);
+  // peak_concurrency() is a cumulative atomic across all execute() calls.
+  // With kThreads concurrent runs we expect it to be > 0 (the scheduler
+  // observed at least one in-flight node), independent of the precise
+  // peak — a stronger bound would be flaky on under-provisioned CI.
+  CHECK(engine.peak_concurrency() > 0);
 }

--- a/pine-cpp/tests/test_engine.cpp
+++ b/pine-cpp/tests/test_engine.cpp
@@ -348,3 +348,83 @@ TEST_CASE("Engine::execute is safe to call concurrently from many threads on the
   // peak — a stronger bound would be flaky on under-provisioned CI.
   CHECK(engine.peak_concurrency() > 0);
 }
+
+TEST_CASE("Engine: cancel mid-flight then immediately destroy is safe (M13)") {
+  // Audit M13 — the dual isolated pools (dag_pool_ + shard_pool_) live as
+  // unique_ptr members on Engine. When the user fires a stop_token and
+  // destroys the Engine right after execute() returns, the pool dtors
+  // must drain workers cleanly without racing on tasks that observed
+  // cancel and bailed via the fast `propagate_and_signal` path
+  // (engine.cpp:828-832). Existing R10-4 case proves cancel works for
+  // ONE execute, but never destroys Engine — the dtor path is exercised
+  // only by static-storage cleanup at process exit, when no in-flight
+  // task ever existed. This test loops cancel→destroy so a sanitizer
+  // build (TSan/ASan) can flag any UAF or torn pool teardown.
+  struct SlowOp : public pine::Operator {
+    void init(const pine::OperatorConfig&) override {
+    }
+    void execute(const pine::OperatorInput&, pine::OperatorOutput&) override {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+  };
+  static const pine::OperatorSchema s_m13{
+      "m13_slow_op", pine::OpType::Transform, "test operator: 50 ms sleep for cancel→destroy loop", {}};
+  static bool registered = false;
+  if (!registered) {
+    pine::register_operator_typed<SlowOp>(s_m13);
+    registered = true;
+  }
+
+  // 4-node linear DAG so cancel-mid-flight has work still queued in
+  // dag_pool when execute() returns. Total without cancel ~200 ms.
+  static const char* kCfg = R"({
+      "_PINEAPPLE_VERSION": "0.9.0",
+      "pipeline_config": {
+        "operators": {
+          "n1": {"type_name": "m13_slow_op", "$metadata": {"item_input": [], "item_output": [], "common_input": [], "common_output": []}},
+          "n2": {"type_name": "m13_slow_op", "$metadata": {"item_input": [], "item_output": [], "common_input": [], "common_output": []}},
+          "n3": {"type_name": "m13_slow_op", "$metadata": {"item_input": [], "item_output": [], "common_input": [], "common_output": []}},
+          "n4": {"type_name": "m13_slow_op", "$metadata": {"item_input": [], "item_output": [], "common_input": [], "common_output": []}}
+        },
+        "pipeline_map": {"stage": {"pipeline": ["n1", "n2", "n3", "n4"]}}
+      },
+      "pipeline_group": {"main": {"pipeline": ["stage"]}}
+    })";
+
+  static const std::map<std::string, Variant> empty_res;
+  constexpr int kIterations = 12;
+
+  std::atomic<int> survived{0};
+  for (int it = 0; it < kIterations; ++it) {
+    // Engine in unique_ptr so we can `reset()` to trigger destructor at
+    // a precise moment, immediately after execute() returns. RAII alone
+    // would also work but `reset()` makes the cancel→destroy ordering
+    // explicit at the call site.
+    auto engine = std::make_unique<Engine>(load_config_from_json(kCfg));
+    Request req;
+
+    std::stop_source src;
+    auto tok = src.get_token();
+
+    std::thread canceller([&src]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      src.request_stop();
+    });
+
+    try {
+      engine->execute(req, empty_res, tok);
+    } catch (const Error&) {
+      // Cancel may surface as a thrown Error — accepted.
+    }
+
+    // Critical sequence: destroy Engine *while* worker loops in both
+    // dag_pool_ and shard_pool_ are still draining their queues. The
+    // ThreadPool dtor (thread_pool.cpp:16) flips stopping_=true, notifies,
+    // and joins each worker. Any read-after-free of the captured `&` lambda
+    // state (cancel_source / fatal_err / done_cv) would land here.
+    engine.reset();
+    canceller.join();
+    survived.fetch_add(1, std::memory_order_relaxed);
+  }
+  CHECK(survived.load() == kIterations);
+}

--- a/pine-cpp/tests/test_json.cpp
+++ b/pine-cpp/tests/test_json.cpp
@@ -96,3 +96,55 @@ TEST_CASE("dump_json: nested objects all sort keys (L5)") {
   std::string out = dump_json(v, 0);
   CHECK(out == R"({"x":"hi","y":{"a":false,"z":true}})");
 }
+
+TEST_CASE("FlatMap::reserve is a capacity hint that does not perturb semantics (L6)") {
+  // FlatMap::reserve (flat_map.hpp:68) and the keys.reserve in
+  // write_json_value (json_writer.hpp:166) / json_writer.cpp (29, 50, 166)
+  // are pure capacity hints. They MUST NOT introduce phantom entries,
+  // change size(), reorder, or alter serialization. Without this guarantee
+  // dump_json's keys.reserve would silently bias output and 09-raw-byte.sh
+  // / 14-byte-exact-execute.sh would lose byte-equality across runtimes.
+
+  // Scenario A: reserve on empty map — stays empty and serializes to "{}".
+  Variant::object_t a;
+  a.reserve(64);
+  CHECK(a.size() == 0);
+  CHECK(a.empty());
+  CHECK(dump_json(Variant(std::move(a)), 0) == "{}");
+
+  // Scenario B: reserve before bulk emplace — identical to no-reserve path.
+  Variant::object_t with_reserve;
+  with_reserve.reserve(8);
+  with_reserve.emplace("c", Variant(3.0));
+  with_reserve.emplace("a", Variant(1.0));
+  with_reserve.emplace("b", Variant(2.0));
+
+  Variant::object_t no_reserve;
+  no_reserve.emplace("c", Variant(3.0));
+  no_reserve.emplace("a", Variant(1.0));
+  no_reserve.emplace("b", Variant(2.0));
+
+  CHECK(with_reserve.size() == 3);
+  CHECK(no_reserve.size() == 3);
+  CHECK(dump_json(Variant(std::move(with_reserve)), 0) == dump_json(Variant(std::move(no_reserve)), 0));
+}
+
+TEST_CASE("FlatMap::reserve after partial insertion preserves entries (L6)") {
+  // reserve called *after* some inserts must keep all existing key/value
+  // pairs intact and in sorted order across the capacity grow. A bug that
+  // re-routed entries through a non-sort-preserving path would corrupt the
+  // sorted-vector invariant silently.
+  Variant::object_t obj;
+  obj.emplace("delta", Variant(4.0));
+  obj.emplace("alpha", Variant(1.0));
+
+  obj.reserve(32);  // forces vector capacity grow on a populated FlatMap
+
+  obj.emplace("charlie", Variant(3.0));
+  obj.emplace("bravo", Variant(2.0));
+
+  CHECK(obj.size() == 4);
+
+  Variant v(std::move(obj));
+  CHECK(dump_json(v, 0) == R"({"alpha":1,"bravo":2,"charlie":3,"delta":4})");
+}

--- a/pine-cpp/tests/test_json.cpp
+++ b/pine-cpp/tests/test_json.cpp
@@ -58,3 +58,41 @@ TEST_CASE("Variant truthy semantics") {
   CHECK(Variant(std::string("")).truthy() == true);
   CHECK(Variant(std::string("x")).truthy() == true);
 }
+
+TEST_CASE("dump_json: object keys serialize in sorted order regardless of insertion order (L5)") {
+  // Locks the invariant that pine-cpp's JSON output sorts object keys
+  // lexicographically before emit, matching Go encoding/json + Java Jackson
+  // with sortKeysOnSerialize. The FieldMap backend (sorted FlatMap by default,
+  // unordered_map under PINE_USE_HASH_MAP=ON) is a benchmark A/B knob that
+  // must not be observable on output. A regression here would silently
+  // break cross-runtime byte-equal parity in 09-raw-byte.sh and
+  // 14-byte-exact-execute.sh.
+  Variant::object_t obj;
+  // Insert keys in deliberately reverse-lexicographic order so the test is
+  // sensitive to "writer iterates underlying map in insertion order" bugs.
+  obj.emplace("zeta", Variant(1.0));
+  obj.emplace("mu", Variant(2.0));
+  obj.emplace("beta", Variant(3.0));
+  obj.emplace("alpha", Variant(4.0));
+
+  Variant v(std::move(obj));
+  std::string out = dump_json(v, 0);
+  CHECK(out == R"({"alpha":4,"beta":3,"mu":2,"zeta":1})");
+}
+
+TEST_CASE("dump_json: nested objects all sort keys (L5)") {
+  // The sort applies recursively — every object_t at every depth must emit
+  // sorted. A bug that only sorts the top level would slip past the flat
+  // sibling check above.
+  Variant::object_t inner;
+  inner.emplace("z", Variant(true));
+  inner.emplace("a", Variant(false));
+
+  Variant::object_t outer;
+  outer.emplace("y", Variant(std::move(inner)));
+  outer.emplace("x", Variant(std::string("hi")));
+
+  Variant v(std::move(outer));
+  std::string out = dump_json(v, 0);
+  CHECK(out == R"({"x":"hi","y":{"a":false,"z":true}})");
+}

--- a/pine-go/internal/dataframe/dataframe_test.go
+++ b/pine-go/internal/dataframe/dataframe_test.go
@@ -512,6 +512,48 @@ func TestApplyOutputCombinedRemoveThenAdd(t *testing.T) {
 	}
 }
 
+// TestApplyOutputCombinedRemoveThenReorder pins the boundary between
+// stage 3 (remove) and stage 4 (reorder) in ApplyOutput. The reorder
+// permutation must be sized to the *post-compact* row count, and its
+// indices must address post-compact slots — feeding original indices
+// would silently re-ingest removed rows. Existing coverage:
+// TestApplyOutputRemoveItems and TestApplyOutputReorder each test one
+// stage in isolation; the combination chain only surfaces in the
+// 5-stage Java fiveStageOrdering test, with no Go counterpart.
+func TestApplyOutputCombinedRemoveThenReorder(t *testing.T) {
+	for _, tm := range testModes {
+		t.Run(tm.name, func(t *testing.T) {
+			f := newTestFrame(tm.mode, nil, []map[string]any{
+				{"id": int64(0)},
+				{"id": int64(1)},
+				{"id": int64(2)},
+				{"id": int64(3)},
+				{"id": int64(4)},
+			})
+			out := types.NewOperatorOutput()
+			out.RemoveItem(1) // post-compact rows: [0, 2, 3, 4]
+			out.RemoveItem(3) // drops original id=3 → post-compact: [0, 2, 4]
+			// Reorder must use the post-compact length (3) and the
+			// post-compact slot indices. order = [2, 0, 1] means
+			// new[i] = post[order[i]] → expected ids [4, 0, 2].
+			out.SetItemOrder([]int{2, 0, 1})
+
+			if err := ApplyOutput(f, out, "op", false); err != nil {
+				t.Fatal(err)
+			}
+			if f.ItemCount() != 3 {
+				t.Fatalf("ItemCount = %d, want 3", f.ItemCount())
+			}
+			expected := []int64{4, 0, 2}
+			for i, want := range expected {
+				if got := f.Item(i, "id"); got != want {
+					t.Errorf("item[%d] id = %v, want %v", i, got, want)
+				}
+			}
+		})
+	}
+}
+
 func TestToResultIsolation(t *testing.T) {
 	for _, tm := range testModes {
 		t.Run(tm.name, func(t *testing.T) {

--- a/pine-go/internal/dataframe/dataframe_test.go
+++ b/pine-go/internal/dataframe/dataframe_test.go
@@ -817,6 +817,117 @@ func TestColumnFrameLazyColumnCreation(t *testing.T) {
 	}
 }
 
+// TestColumnFrameKColumnsConcurrentWriteThenRemoveReorder exercises the
+// extension of TestColumnFrameLazyColumnCreation to K=10 newly-created
+// columns followed by a single ApplyOutput that combines remove + reorder.
+// The contract being pinned: after the structural pass every one of the K
+// columns must observe the same per-row permutation, and the per-column
+// `visited` scratch buffer is reset between columns inside ApplyOutput
+// (column_frame.go:237-241).
+//
+// Run under `-race` to catch any per-column write that escapes ApplyOutput's
+// frame-level Lock; without this case, K column reorder consistency was
+// only indirectly covered by single-engine integration tests.
+func TestColumnFrameKColumnsConcurrentWriteThenRemoveReorder(t *testing.T) {
+	const N = 8 // initial row count
+	const K = 10
+
+	items := make([]map[string]any, N)
+	for i := range items {
+		items[i] = map[string]any{"id": i}
+	}
+	f := NewFrame(StorageModeColumn, map[string]any{}, items)
+
+	// Phase 1: K goroutines each create a unique column with a deterministic
+	// per-row value so we can compute the post-permutation expectation
+	// without depending on goroutine ordering.
+	var wg sync.WaitGroup
+	for k := 0; k < K; k++ {
+		wg.Add(1)
+		go func(k int) {
+			defer wg.Done()
+			out := types.NewOperatorOutput()
+			for i := 0; i < N; i++ {
+				// Encode (column, row) so any cross-column bleed is detectable.
+				out.SetItem(i, "col_"+itoa(k), k*1000+i)
+			}
+			if err := f.ApplyOutput(out, "writer_"+itoa(k), false); err != nil {
+				t.Errorf("col_%d write: %v", k, err)
+			}
+		}(k)
+	}
+	wg.Wait()
+
+	// Sanity: every (k, i) pair landed correctly before structural ops.
+	for k := 0; k < K; k++ {
+		for i := 0; i < N; i++ {
+			if got := f.Item(i, "col_"+itoa(k)); got != k*1000+i {
+				t.Fatalf("pre-structural col_%d[%d]: got %v, want %d", k, i, got, k*1000+i)
+			}
+		}
+	}
+
+	// Phase 2: single ApplyOutput that removes one row then reorders the
+	// remainder. Both stages walk every column and share the visited
+	// bitmap (column_frame.go:237-241); a missing reset between columns
+	// would leave later columns in a partially-permuted state while
+	// earlier columns reordered correctly.
+	out := types.NewOperatorOutput()
+	out.RemoveItem(2) // drop row originally carrying id=2
+	// After removal we have rows whose original ids are 0,1,3,4,5,6,7
+	// (length 7). Apply a non-identity permutation with two cycles plus
+	// a fixed point to make a per-column reset bug visible.
+	// new[i] = old[order[i]]: order = [3, 0, 5, 6, 1, 4, 2]
+	out.SetItemOrder([]int{3, 0, 5, 6, 1, 4, 2})
+	if err := f.ApplyOutput(out, "structural", false); err != nil {
+		t.Fatalf("structural ApplyOutput: %v", err)
+	}
+
+	// Compute expected post-structural id sequence the same way ApplyOutput
+	// does: remove first, then reorder.
+	postRemove := []int{0, 1, 3, 4, 5, 6, 7}
+	order := []int{3, 0, 5, 6, 1, 4, 2}
+	expectedIDs := make([]int, len(order))
+	for i, oi := range order {
+		expectedIDs[i] = postRemove[oi]
+	}
+
+	if f.ItemCount() != len(expectedIDs) {
+		t.Fatalf("item count: got %d, want %d", f.ItemCount(), len(expectedIDs))
+	}
+	for i, expectedID := range expectedIDs {
+		// `id` field validates the remove+reorder are consistent on the
+		// pre-existing column.
+		if got := f.Item(i, "id"); got != expectedID {
+			t.Errorf("post-structural id[%d]: got %v, want %d", i, got, expectedID)
+		}
+		// Every K newly-created column must follow the same permutation;
+		// the original row carrying col_k = k*1000+expectedID must now
+		// sit at row i.
+		for k := 0; k < K; k++ {
+			want := k*1000 + expectedID
+			if got := f.Item(i, "col_"+itoa(k)); got != want {
+				t.Errorf("post-structural col_%d[%d]: got %v, want %d", k, i, got, want)
+			}
+		}
+	}
+}
+
+// Local int-to-string helper to avoid pulling strconv into the test file
+// solely for diagnostic field names.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	x := n
+	for x > 0 {
+		digits = append([]byte{byte('0' + x%10)}, digits...)
+		x /= 10
+	}
+	return string(digits)
+}
+
 func TestColumnFrameStructuralBlocksReaders(t *testing.T) {
 	items := make([]map[string]any, 20)
 	for i := range items {

--- a/pine-go/internal/runtime/parallel_test.go
+++ b/pine-go/internal/runtime/parallel_test.go
@@ -625,3 +625,57 @@ func TestParallelExecuteRaceSafe(t *testing.T) {
 		}
 	}
 }
+
+// TestParallelExecuteRaceSafeLazy mirrors TestParallelExecuteRaceSafe but
+// drives the lazy OperatorInput path: the input is built from a
+// ColumnFrame via BuildInput so each shard is a NewLazyOperatorInput
+// reading through the shared FrameReader. data_parallel>1 then runs N
+// goroutines that all dereference the same frame concurrently. Without
+// this case, the materialized-input race test alone would miss any
+// race introduced inside ColumnFrame.Item / lazy-proxy field lookup
+// (e.g. a future cache layer added behind the read path that forgot
+// to take the RLock).
+func TestParallelExecuteRaceSafeLazy(t *testing.T) {
+	const itemCount = 200
+	items := make([]map[string]any, itemCount)
+	for i := range items {
+		items[i] = map[string]any{"val": float64(i)}
+	}
+
+	cop := &CompiledOperator{
+		Name:     "safe_op_lazy",
+		Instance: &safeStatelessOp{readField: "val", writeField: "result"},
+		Config: config.OperatorConfig{
+			TypeName:     "transform_test",
+			OperatorType: "Transform",
+			DataParallel: 8,
+			Meta:         config.Metadata{ItemInput: []string{"val"}, ItemOutput: []string{"result"}},
+		},
+	}
+	spec := &config.InputFieldSpec{StrictItem: []string{"val"}}
+
+	for iter := 0; iter < 10; iter++ {
+		// ColumnFrame's BuildInput returns a *lazy* OperatorInput backed
+		// by FrameReader; splitInput preserves that and hands every shard
+		// the same frame.
+		f := dataframe.NewFrame(dataframe.StorageModeColumn, map[string]any{}, cloneRuntimeItems(items))
+		input, err := f.BuildInput("safe_op_lazy", spec)
+		if err != nil {
+			t.Fatalf("iter %d build: %v", iter, err)
+		}
+		if !input.IsLazy() {
+			t.Fatalf("iter %d: expected lazy input, got materialized", iter)
+		}
+		output, err := parallelExecute(context.Background(), cop, input)
+		if err != nil {
+			t.Fatalf("iter %d execute: %v", iter, err)
+		}
+		iw := output.ItemWriteMap()
+		for i := 0; i < itemCount; i++ {
+			want := float64(i) + 1
+			if iw[i]["result"] != want {
+				t.Errorf("iter %d item %d: got %v, want %v", iter, i, iw[i]["result"], want)
+			}
+		}
+	}
+}

--- a/pine-go/operators/bench/bench_stubs.go
+++ b/pine-go/operators/bench/bench_stubs.go
@@ -2,6 +2,15 @@
 
 // Package bench provides benchmark-only stub operators and resource fetchers
 // for running realistic production pipeline fixtures without external dependencies.
+//
+// Diff-fuzz exclusion (audit L3): every operator registered here is gated
+// behind the pine_bench build tag and is intentionally absent from
+// scripts/differential-fuzz.py op_types. The stubs are throughput-only and
+// have no cases/expected fixture surface; including them would force the
+// cross-runtime oracle to reason about timing-derived outputs that are not
+// part of the engine's pure-function contract. byte-equal work parity for
+// transform_bench_cpu is locked separately by
+// fixtures/pipelines/bench_cpu_work_parity.json (audit M12).
 package bench
 
 import (

--- a/pine-go/pkg/server/server.go
+++ b/pine-go/pkg/server/server.go
@@ -273,15 +273,9 @@ func (s *Server) run(cfg Config) error {
 	// No WriteTimeout so long-running profiles (e.g. ?seconds=120) are not truncated.
 	var adminSrv *http.Server
 	if cfg.AdminAddr != "" {
-		adminMux := http.NewServeMux()
-		adminMux.HandleFunc("/debug/pprof/", pprof.Index)
-		adminMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-		adminMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-		adminMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		adminMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 		adminSrv = &http.Server{
 			Addr:              cfg.AdminAddr,
-			Handler:           adminMux,
+			Handler:           newAdminMux(),
 			ReadHeaderTimeout: 10 * time.Second,
 		}
 		go func() {
@@ -592,4 +586,18 @@ func (s *Server) effectiveMaxRequestBodySize() int64 {
 		return 10 << 20
 	}
 	return s.maxRequestBodySize
+}
+
+// newAdminMux builds the mux mounted on AdminAddr. It exposes the standard
+// net/http/pprof handlers under /debug/pprof/. Kept as a package-private
+// helper so tests can assert that pprof is reachable on the admin port and
+// — crucially — *not* reachable on the main mux.
+func newAdminMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	return mux
 }

--- a/pine-go/pkg/server/server_test.go
+++ b/pine-go/pkg/server/server_test.go
@@ -1431,3 +1431,57 @@ func TestSnapshotDrainDefersTeardown(t *testing.T) {
 	// object — so there is no double-free.
 	snap.release()
 }
+
+// TestAdminPprofMuxServesPprof asserts that the admin mux (which gets
+// mounted only when AdminAddr is set) exposes /debug/pprof/. Profiling
+// endpoints are deliberately served on a side port so the main listener
+// — which is reachable from any Pineapple deployment — does not leak
+// goroutine state, command-line args, or symbol tables. If a refactor
+// accidentally drops a HandleFunc, this test fails before the binary
+// ships.
+func TestAdminPprofMuxServesPprof(t *testing.T) {
+	mux := newAdminMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	for _, path := range []string{
+		"/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/symbol",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("admin %s = %d, want 200", path, w.Code)
+		}
+	}
+}
+
+// TestMainMuxDoesNotExposePprof guards the information-leak boundary:
+// the main mux assembled in run() registers /health, /execute, /stats,
+// /dag and a catch-all /. If a future change accidentally adds pprof
+// handlers to that mux (e.g. by reusing newAdminMux), this test fires.
+func TestMainMuxDoesNotExposePprof(t *testing.T) {
+	srv := setupTestHTTPServer(t)
+
+	for _, path := range []string{
+		"/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/profile",
+	} {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+path, nil)
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		_ = resp.Body.Close()
+		// handleNotFound returns 404 for any unmatched path. If pprof leaks
+		// onto the main mux, the response would be 200 (Index) or a long
+		// running 200 (Profile).
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("main mux %s = %d, want 404 (pprof must be admin-only)",
+				path, resp.StatusCode)
+		}
+	}
+}

--- a/pine-go/testdata/e2e_apple_dsl_control.json
+++ b/pine-go/testdata/e2e_apple_dsl_control.json
@@ -1,0 +1,151 @@
+{
+  "_PINEAPPLE_VERSION": "0.9.13",
+  "_PINEAPPLE_CREATE_TIME": "2026-06-05T00:00:00Z",
+  "pipeline_config": {
+    "operators": {
+      "recall_static_2F9573": {
+        "type_name": "recall_static",
+        "$metadata": {
+          "common_input": [],
+          "common_output": [],
+          "item_input": [],
+          "item_output": [
+            "item_id",
+            "item_score"
+          ]
+        },
+        "recall": true,
+        "additive_writes_row_set": true,
+        "items": [
+          {
+            "item_id": "a",
+            "item_score": 1.0
+          },
+          {
+            "item_id": "b",
+            "item_score": 2.0
+          }
+        ]
+      },
+      "if_1": {
+        "type_name": "transform_by_lua",
+        "$metadata": {
+          "common_input": [
+            "enabled"
+          ],
+          "common_output": [
+            "_if_1"
+          ],
+          "item_input": [],
+          "item_output": []
+        },
+        "for_branch_control": true,
+        "lua_script": "function evaluate() if (enabled) then return false else return true end end",
+        "function_for_item": "",
+        "function_for_common": "evaluate"
+      },
+      "transform_by_lua_C36269": {
+        "type_name": "transform_by_lua",
+        "$metadata": {
+          "common_input": [],
+          "common_output": [],
+          "item_input": [
+            "item_score"
+          ],
+          "item_output": [
+            "item_score",
+            "mark"
+          ],
+          "common_input_skip": [
+            "_if_1"
+          ]
+        },
+        "skip": [
+          "_if_1"
+        ],
+        "lua_script": "function f() return item_score, true end",
+        "function_for_item": "f",
+        "function_for_common": ""
+      },
+      "else_2": {
+        "type_name": "transform_by_lua",
+        "$metadata": {
+          "common_input": [
+            "_if_1"
+          ],
+          "common_output": [
+            "_else_2"
+          ],
+          "item_input": [],
+          "item_output": []
+        },
+        "for_branch_control": true,
+        "lua_script": "function evaluate() if ((_if_1)) then return false else return true end end",
+        "function_for_item": "",
+        "function_for_common": "evaluate"
+      },
+      "transform_by_lua_91BB49": {
+        "type_name": "transform_by_lua",
+        "$metadata": {
+          "common_input": [],
+          "common_output": [],
+          "item_input": [
+            "item_score"
+          ],
+          "item_output": [
+            "item_score",
+            "mark"
+          ],
+          "common_input_skip": [
+            "_else_2"
+          ]
+        },
+        "skip": [
+          "_else_2"
+        ],
+        "lua_script": "function f() return item_score, false end",
+        "function_for_item": "f",
+        "function_for_common": ""
+      },
+      "reorder_sort_798553": {
+        "type_name": "reorder_sort",
+        "$metadata": {
+          "common_input": [],
+          "common_output": [],
+          "item_input": [
+            "item_score"
+          ],
+          "item_output": []
+        },
+        "consumes_row_set": true,
+        "mutates_row_set": true,
+        "order": "desc"
+      }
+    },
+    "pipeline_map": {}
+  },
+  "pipeline_group": {
+    "main": {
+      "pipeline": [
+        "recall_static_2F9573",
+        "if_1",
+        "transform_by_lua_C36269",
+        "else_2",
+        "transform_by_lua_91BB49",
+        "reorder_sort_798553"
+      ]
+    }
+  },
+  "flow_contract": {
+    "common_input": [
+      "enabled"
+    ],
+    "item_input": [],
+    "common_output": [],
+    "item_output": [
+      "item_id",
+      "item_score",
+      "mark"
+    ]
+  }
+}

--- a/pine-java/src/main/java/page/liam/pine/operators/bench/BenchStubs.java
+++ b/pine-java/src/main/java/page/liam/pine/operators/bench/BenchStubs.java
@@ -4,6 +4,21 @@ import page.liam.pine.*;
 
 import java.util.*;
 
+/**
+ * Benchmark-only stub operators (recall_feed_data, transform_redis_*,
+ * reorder_topn_boost, ...). Registration is gated on the system property
+ * {@code -Dpine.bench=true}; otherwise the registrations below are absent
+ * from the Engine's operator table.
+ *
+ * <p>Diff-fuzz exclusion (audit L3): every operator registered here is
+ * deliberately absent from {@code scripts/differential-fuzz.py op_types}.
+ * The stubs are throughput-only and have no cases/expected fixture surface;
+ * including them would force the cross-runtime oracle to reason about
+ * timing-derived outputs that are not part of the engine's pure-function
+ * contract. Byte-equal work parity for {@code transform_bench_cpu} is
+ * locked separately by {@code fixtures/pipelines/bench_cpu_work_parity.json}
+ * (audit M12).
+ */
 public class BenchStubs {
     private static volatile boolean registered = false;
 

--- a/pine-java/src/test/java/page/liam/pine/BenchmarkTest.java
+++ b/pine-java/src/test/java/page/liam/pine/BenchmarkTest.java
@@ -25,6 +25,12 @@ public class BenchmarkTest {
             for (Path path : (Iterable<Path>) files::iterator) {
                 if (!path.toString().endsWith(".json")) continue;
                 JsonNode root = mapper.readTree(path.toFile());
+
+                if (root.has("requires") && root.get("requires").isArray()
+                        && root.get("requires").size() > 0) {
+                    continue;
+                }
+
                 String name = path.getFileName().toString().replace(".json", "");
                 byte[] configBytes = mapper.writeValueAsBytes(root.get("config"));
 

--- a/pine-java/src/test/java/page/liam/pine/FrameEquivalenceTest.java
+++ b/pine-java/src/test/java/page/liam/pine/FrameEquivalenceTest.java
@@ -120,6 +120,42 @@ public class FrameEquivalenceTest {
     }
 
     @Test
+    @DisplayName("Remove + immediate reorder uses post-compact index")
+    void removeThenReorderPostCompactIndex() {
+        // Targeted check that the reorder index after a remove walks the
+        // *post-compact* row space, not the original. Without this, a
+        // bug that fed reorder original indices would silently re-ingest
+        // the removed row at a new position. fiveStageOrdering exercises
+        // the same path indirectly while mixing four other stages; this
+        // case isolates the remove → reorder boundary so a regression
+        // points at the right stage transition.
+        List<Map<String, Object>> items = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            items.add(new LinkedHashMap<>(Map.of("id", i)));
+        }
+        Frame row = new DataFrame(new LinkedHashMap<>(), copyItems(items));
+        Frame col = new ColumnFrame(new LinkedHashMap<>(), copyItems(items));
+
+        OperatorOutput out = new OperatorOutput();
+        out.removeItem(1);  // drop id=1 → post-compact rows: [0, 2, 3, 4]
+        out.removeItem(3);  // drop id=3 (original) → post-compact: [0, 2, 4]
+        // reorder uses the post-compact length (3) and the post-compact
+        // row identities. order = [2, 0, 1] means new[i] = post[order[i]].
+        out.setItemOrder(List.of(2, 0, 1));
+        applyBoth(row, col, out, "op", false);
+
+        assertEquals(3, row.itemCount());
+        assertEquals(3, col.itemCount());
+        // Expected ids: post[2]=4, post[0]=0, post[1]=2
+        List<Map<String, Object>> rowItems = row.toResultItems(List.of("id"));
+        List<Map<String, Object>> colItems = col.toResultItems(List.of("id"));
+        assertEquals(4, rowItems.get(0).get("id"));
+        assertEquals(0, rowItems.get(1).get("id"));
+        assertEquals(2, rowItems.get(2).get("id"));
+        assertEquals(rowItems, colItems, "remove_then_reorder — items mismatch");
+    }
+
+    @Test
     @DisplayName("Additions + recall _source stamp equivalence")
     void additionsWithRecall() {
         List<Map<String, Object>> items = new ArrayList<>();

--- a/pine-java/src/test/java/page/liam/pine/ParallelExecutorRaceSafeTest.java
+++ b/pine-java/src/test/java/page/liam/pine/ParallelExecutorRaceSafeTest.java
@@ -1,0 +1,87 @@
+package page.liam.pine;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Lazy OperatorInput proxy must be safe to dereference concurrently from
+ * data_parallel shards. ParallelExecutor.execute splits a lazy input into
+ * N shards that all share the same FrameReader; the operator's Execute
+ * runs in N parallel ExecutorService tasks and reads through that shared
+ * frame.
+ *
+ * <p>Without a targeted test, any future change that introduces
+ * non-thread-safe state into ColumnFrame.item() (e.g. a memoization
+ * cache that forgets to take rwLock) would slip past the existing
+ * IntegrationTest because that test exercises full Engine pipelines
+ * without the -race / -fno-omit-frame-pointer style introspection.
+ * This test runs a bare-metal lazy split with N=8 shards repeatedly
+ * and asserts every (i, val+1) pair lands correctly. Run with `mvn test`
+ * — failures here also tend to surface as flaky values.
+ */
+public class ParallelExecutorRaceSafeTest {
+
+    static class StatelessIncrementOp implements Operator, ConcurrentSafe {
+        @Override
+        public void init(OperatorParams params) {}
+
+        @Override
+        public void execute(CancellationToken token, OperatorInput input, OperatorOutput out) {
+            for (int i = 0; i < input.itemCount(); i++) {
+                Object v = input.item(i, "val");
+                double d = (v instanceof Number) ? ((Number) v).doubleValue() : 0.0;
+                out.setItem(i, "result", d + 1.0);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("ParallelExecutor lazy input race-safe across shards")
+    void lazyInputAcrossShardsIsRaceSafe() throws Exception {
+        final int itemCount = 200;
+        final int parallelism = 8;
+        final int iterations = 10;
+
+        ExecutorService pool = Executors.newFixedThreadPool(parallelism);
+        try {
+            for (int iter = 0; iter < iterations; iter++) {
+                List<Map<String, Object>> items = new ArrayList<>(itemCount);
+                for (int i = 0; i < itemCount; i++) {
+                    items.add(new LinkedHashMap<>(Map.of("val", (double) i)));
+                }
+                ColumnFrame frame = new ColumnFrame(new LinkedHashMap<>(), items);
+                InputFieldSpec spec = new InputFieldSpec(
+                        List.of(), List.of(), List.of(),
+                        List.of("val"), List.of(), List.of());
+                OperatorInput input = frame.buildInput("incr", spec);
+                assertTrue(input.isLazy(),
+                        "iter " + iter + ": expected lazy input from ColumnFrame.buildInput");
+
+                OperatorOutput out = ParallelExecutor.execute(
+                        CancellationToken.create(),
+                        new StatelessIncrementOp(),
+                        input,
+                        parallelism,
+                        "incr",
+                        pool);
+
+                Map<Integer, Map<String, Object>> writes = out.getItemWrites();
+                assertEquals(itemCount, writes.size(), "iter " + iter + ": item write count");
+                for (int i = 0; i < itemCount; i++) {
+                    Map<String, Object> row = writes.get(i);
+                    assertNotNull(row, "iter " + iter + " missing row " + i);
+                    assertEquals((double) i + 1.0, ((Number) row.get("result")).doubleValue(),
+                            "iter " + iter + " row " + i);
+                }
+            }
+        } finally {
+            pool.shutdownNow();
+            pool.awaitTermination(2, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/scripts/cpp-sanitizer-smoke.sh
+++ b/scripts/cpp-sanitizer-smoke.sh
@@ -39,7 +39,23 @@ echo "==> Iterating pipeline fixtures"
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR"' EXIT
 fixture_count=0
+skipped=0
 for fixture in "$REPO_ROOT"/fixtures/pipelines/*.json; do
+    # Skip fixtures that need external prepopulated state (redis) or
+    # specially-built binaries (bench-tag stubs). The sanitizer build
+    # is the production binary set — bench stubs aren't registered, so
+    # `reorder_topn_boost` etc. cannot be loaded here. These fixtures
+    # have dedicated cross-validate sections (Section 11 for redis,
+    # Section 19 for bench).
+    if python3 -c "
+import json, sys
+data = json.load(open('$fixture'))
+req = set(data.get('requires', []) or [])
+sys.exit(0 if req & {'redis', 'redis-unavailable', 'bench'} else 1)
+"; then
+        skipped=$((skipped + 1))
+        continue
+    fi
     fixture_count=$((fixture_count + 1))
     cfg="$WORK_DIR/cfg.json"
     req="$WORK_DIR/req.json"
@@ -59,7 +75,7 @@ else:
     # run executor
     "$RUN" -config "$cfg" -request "$req" >/dev/null || true
 done
-echo "    Ran $fixture_count fixtures through dag + run."
+echo "    Ran $fixture_count fixtures through dag + run (skipped $skipped requires-tagged)."
 
 echo "==> HTTP server smoke under sanitizers"
 SRV_CFG="$WORK_DIR/srv_cfg.json"

--- a/scripts/cpp-tsan-smoke.sh
+++ b/scripts/cpp-tsan-smoke.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Build pine-cpp with ThreadSanitizer and stress-run high-fanout DAG
+# fixtures concurrently. Targets the ready-queue seed loop (engine.cpp:959-975)
+# and the per-worker propagate path that race-shares in_degree[] and the
+# done condvar — all of which sit outside the single-request serial path
+# that ASan/UBSan smoke happens to exercise.
+#
+# Failure modes this catches:
+#   * Reading graph.nodes[i].preds.size() racing with worker writes elsewhere.
+#   * propagate_and_signal touching in_degree[] without proper memory ordering
+#     when many roots seed simultaneously.
+#   * done_cv / remaining notify-wait ordering bug that surfaces only when
+#     workers finish before the main thread reaches done_cv.wait().
+#
+# Any TSan report aborts the process and causes the script to fail.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CPP_DIR="$REPO_ROOT/pine-cpp"
+BUILD_DIR="$CPP_DIR/build-tsan"
+
+# halt_on_error keeps the first race report the canonical failure;
+# second_deadlock_stack is cheap to enable and surfaces lock-order bugs
+# that can mask as nondeterministic hangs in stress runs.
+export TSAN_OPTIONS="halt_on_error=1:second_deadlock_stack=1:history_size=7"
+
+PARALLEL="${TSAN_PARALLEL:-8}"
+ITERATIONS="${TSAN_ITERATIONS:-50}"
+
+echo "==> Configuring pine-cpp with ThreadSanitizer"
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+cmake -S "$CPP_DIR" -B "$BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -O1 -g" \
+    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \
+    -DPINE_USE_JEMALLOC=OFF
+
+echo "==> Building"
+cmake --build "$BUILD_DIR" -j2
+
+RUN="$BUILD_DIR/pineapple-run"
+SERVER="$BUILD_DIR/pineapple-server"
+
+# TSan's shadow memory layout collides with high-entropy ASLR on recent
+# kernels (observed on 6.8 + glibc 2.39: "unexpected memory mapping").
+# setarch -R disables ASLR for the child process tree only — no need to
+# touch /proc/sys/kernel/randomize_va_space globally. Fall back to a
+# bare invocation when setarch is missing.
+if command -v setarch >/dev/null 2>&1; then
+    NOASLR=(setarch -R)
+else
+    NOASLR=()
+fi
+
+# High-fanout fixtures: each picked because the DAG has 3+ root nodes that
+# get seeded simultaneously by the engine's seed loop, maximising the race
+# window between seed enqueue and worker propagate.
+HIGH_FANOUT=(
+    multi_recall_row_set_ordering.json   # 6 roots
+    recall_merge_filter_sort.json        # 4 roots
+    parallel_recall_set_comparison.json  # 3 roots
+    data_parallel.json                   # 3 roots
+    data_parallel_lua.json               # 3 roots
+    barrier_transform_reorder.json       # 4 roots
+)
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "==> Stress: $ITERATIONS iterations × $PARALLEL parallel workers per fixture"
+for fname in "${HIGH_FANOUT[@]}"; do
+    fixture="$REPO_ROOT/fixtures/pipelines/$fname"
+    [[ -f "$fixture" ]] || { echo "    skip $fname (missing)"; continue; }
+    cfg="$WORK_DIR/cfg_$fname"
+    req="$WORK_DIR/req_$fname"
+    python3 -c "
+import json
+data = json.load(open('$fixture'))
+json.dump(data.get('config', {}), open('$cfg', 'w'))
+cases = data.get('cases', [])
+if cases:
+    json.dump(cases[0].get('request', {}), open('$req', 'w'))
+else:
+    json.dump({'common': {}, 'items': []}, open('$req', 'w'))
+"
+    echo "    Stressing $fname"
+    for ((iter=0; iter<ITERATIONS; iter++)); do
+        pids=()
+        for ((p=0; p<PARALLEL; p++)); do
+            "${NOASLR[@]}" "$RUN" -config "$cfg" -request "$req" >/dev/null 2>>"$WORK_DIR/run.err" &
+            pids+=("$!")
+        done
+        for pid in "${pids[@]}"; do
+            if ! wait "$pid"; then
+                echo "    pineapple-run failed under TSan (iter=$iter, fixture=$fname)" >&2
+                tail -n 60 "$WORK_DIR/run.err" >&2 || true
+                exit 1
+            fi
+        done
+    done
+done
+
+echo "==> Server stress: 200 concurrent /execute against high-fanout config"
+SRV_CFG="$WORK_DIR/srv_cfg.json"
+SRV_REQ="$WORK_DIR/srv_req.json"
+python3 -c "
+import json
+data = json.load(open('$REPO_ROOT/fixtures/pipelines/multi_recall_row_set_ordering.json'))
+json.dump(data.get('config', {}), open('$SRV_CFG', 'w'))
+json.dump(data['cases'][0].get('request', {'common': {}, 'items': []}), open('$SRV_REQ', 'w'))
+"
+
+"${NOASLR[@]}" "$SERVER" -config "$SRV_CFG" -addr ":19897" >/dev/null 2>>"$WORK_DIR/srv.err" &
+SRV_PID=$!
+trap 'kill -KILL $SRV_PID 2>/dev/null || true; rm -rf "$WORK_DIR"' EXIT
+
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    if curl -fsS http://localhost:19897/health >/dev/null 2>&1; then break; fi
+    sleep 0.5
+done
+
+# Burst 200 /execute, 16 in flight. Server uses its dag_pool to schedule
+# each request's seed loop; concurrent requests amplify the seed-vs-propagate
+# race window beyond what the single-shot CLI run reaches.
+PAYLOAD=$(cat "$SRV_REQ")
+for batch in $(seq 1 13); do
+    pids=()
+    for _ in $(seq 1 16); do
+        curl -fsS -X POST -H "Content-Type: application/json" \
+            -d "$PAYLOAD" http://localhost:19897/execute >/dev/null 2>&1 &
+        pids+=("$!")
+    done
+    for pid in "${pids[@]}"; do
+        wait "$pid" || true
+    done
+done
+
+kill -INT $SRV_PID 2>/dev/null || true
+wait $SRV_PID 2>/dev/null || true
+SRV_PID=""
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "==> TSan smoke complete (no ThreadSanitizer reports)"

--- a/scripts/cross-validate/01-codegen-schema.sh
+++ b/scripts/cross-validate/01-codegen-schema.sh
@@ -28,6 +28,7 @@ def extract_structure(schemas):
                 'type': pspec.get('Type', ''),
                 'required': pspec.get('Required', False),
                 'default': normalize_value(pspec.get('Default')),
+                'templatable': pspec.get('Templatable', False),
             }
         result[name] = params
     return result
@@ -84,6 +85,7 @@ def extract_structure(schemas):
                 'type': pspec.get('Type', ''),
                 'required': pspec.get('Required', False),
                 'default': normalize_value(pspec.get('Default')),
+                'templatable': pspec.get('Templatable', False),
             }
         result[name] = params
     return result

--- a/scripts/cross-validate/02-render-dag.sh
+++ b/scripts/cross-validate/02-render-dag.sh
@@ -15,6 +15,18 @@ for fixture in "$REPO_ROOT"/fixtures/pipelines/*.json; do
   [[ -f "$fixture" ]] || continue
   fname=$(basename "$fixture")
 
+  # Skip fixtures that need external prepopulated state (redis) or
+  # specially-built bench-tag binaries. Production binaries (used here)
+  # don't register bench stubs, so render-dag would error out.
+  if python3 -c "
+import json, sys
+data = json.load(open('$fixture'))
+req = set(data.get('requires', []) or [])
+sys.exit(0 if req & {'redis', 'redis-unavailable', 'bench'} else 1)
+"; then
+    continue
+  fi
+
   config_file="$WORK_DIR/dag_config_${fname}"
   python3 -c "
 import json

--- a/scripts/cross-validate/03-execution-parity.sh
+++ b/scripts/cross-validate/03-execution-parity.sh
@@ -20,11 +20,12 @@ for fixture_file in "$FIXTURES_DIR"/*.json; do
 import json, sys
 with open('$fixture_file') as f:
     data = json.load(f)
-# Skip fixtures that need external prepopulated state (redis, etc).
-# Those have dedicated sections (11-redis-integration, 17-templated-params)
-# that wire up addr replacement + prepopulate.
+# Skip fixtures that need external prepopulated state (redis, etc) or
+# specially-built binaries. Those have dedicated sections that wire up
+# the precondition (11-redis-integration, 17-templated-params for redis;
+# 19-bench-stub-parity for bench-tag/system-property gated stubs).
 requires = set(data.get('requires', []) or [])
-if requires & {'redis', 'redis-unavailable'}:
+if requires & {'redis', 'redis-unavailable', 'bench'}:
     sys.exit(0)
 cases = data.get('cases', [])
 if not cases:

--- a/scripts/cross-validate/04-column-store.sh
+++ b/scripts/cross-validate/04-column-store.sh
@@ -20,11 +20,12 @@ for fixture_file in "$FIXTURES_DIR"/*.json; do
 import json, sys
 with open('$fixture_file') as f:
     data = json.load(f)
-# Skip fixtures that need external prepopulated state (redis, etc).
-# Those have dedicated sections (11-redis-integration, 17-templated-params)
-# that wire up addr replacement + prepopulate.
+# Skip fixtures that need external prepopulated state (redis) or
+# specially-built bench-tag binaries. Dedicated sections cover these:
+# 11-redis-integration / 17-templated-params for redis,
+# 19-bench-stub-parity for bench-only stubs.
 requires = set(data.get('requires', []) or [])
-if requires & {'redis', 'redis-unavailable'}:
+if requires & {'redis', 'redis-unavailable', 'bench'}:
     sys.exit(0)
 cases = data.get('cases', [])
 if not cases:

--- a/scripts/cross-validate/07-cancellation.sh
+++ b/scripts/cross-validate/07-cancellation.sh
@@ -154,5 +154,160 @@ elif [[ $cancel_total -eq 0 ]]; then
   pass "cancellation parity (skipped)"
 fi
 
+# ============================================================
+# Audit M14: server-side TCP-disconnect cancellation parity.
+#
+# Tests 1+1b above only cover OS-level SIGKILL via `timeout` against the
+# CLI (pineapple-run / RunCli). They prove the engine doesn't deadlock
+# when its host process is killed, but say nothing about the server-mode
+# path: client opens POST /execute on a slow pipeline, then closes the
+# connection mid-flight. The server must observe the disconnect and
+# request_stop() the engine via stop_token (R10-2), so the worker pool
+# stops doing useless work and frees up slots for the next request.
+#
+# Go: r.Context() is cancelled when the client RSTs — propagated to
+#   engine.Execute(ctx, req) at server.go:447-448. Observable via
+#   /stats: scheduler.run_count for the truncated request still
+#   increments, but op_exec_count for downstream ops should NOT
+#   increment beyond the cancel boundary.
+# C++: explicit poll(POLLRDHUP|POLLHUP|POLLERR) watcher thread fires
+#   request_stop() on a stop_source whose token is passed to
+#   execute_traced_into() at server.cpp:902.
+# Java: PineServer.handleExecute calls engine.execute(common, items)
+#   without a CancellationToken (Engine.java:228 vs the externalToken
+#   overload at line 232 which the server never uses). com.sun.net
+#   .HttpServer also has no observable disconnect signal on the
+#   exchange. So Java cannot propagate TCP RST to the engine — known
+#   gap. We DON'T fail the section on it; we document and skip.
+# ============================================================
+echo
+echo "    [3] server-side TCP-disconnect cancellation (audit M14)"
+
+CD_CFG="$WORK_DIR/cancel_disconnect_cfg.json"
+cat > "$CD_CFG" << 'CFG'
+{
+  "_PINEAPPLE_VERSION": "0.9.13",
+  "pipeline_config": {
+    "operators": {
+      "slow1": {"type_name": "transform_bench_sleep", "delay_ms": 800,
+        "$metadata": {"common_input": [], "item_input": [], "common_output": [], "item_output": ["_bench_slept"]}},
+      "slow2": {"type_name": "transform_bench_sleep", "delay_ms": 800,
+        "$metadata": {"common_input": [], "item_input": [], "common_output": [], "item_output": ["_bench_slept"]}},
+      "slow3": {"type_name": "transform_bench_sleep", "delay_ms": 800,
+        "$metadata": {"common_input": [], "item_input": [], "common_output": [], "item_output": ["_bench_slept"]}}
+    },
+    "pipeline_map": {"stage": {"pipeline": ["slow1", "slow2", "slow3"]}}
+  },
+  "pipeline_group": {"main": {"pipeline": ["stage"]}},
+  "flow_contract": {
+    "common_input": [], "item_input": ["id"],
+    "common_output": [], "item_output": ["id", "_bench_slept"]
+  }
+}
+CFG
+
+CD_REQ='{"common":{},"items":[{"id":"a"}]}'
+CD_GO_PORT=18301
+CD_CPP_PORT=18304
+
+"$WORK_DIR/pineapple-server" -config "$CD_CFG" -addr ":$CD_GO_PORT" &
+CD_GO_PID=$!
+CD_CPP_PID=""
+if [[ -n "${CPP_SERVER:-}" ]]; then
+  "$CPP_SERVER" -config "$CD_CFG" -addr ":$CD_CPP_PORT" &
+  CD_CPP_PID=$!
+fi
+
+# probe_disconnect_cancel <port>: opens /execute, kills the client at
+# 300ms while pipeline would otherwise take ~2400ms. Total elapsed
+# (client kill → server-side completion of the in-flight op) must come
+# in well under 2400ms — we use 1500ms (current op finishes ~800ms +
+# slack) as the noise-tolerant ceiling. If the server kept running to
+# completion despite the disconnect, scheduler.run_count would tick up
+# but op_exec_count for slow3 would equal scheduler.run_count, proving
+# all three ops ran. With cancel honored, slow3 exec_count should stay
+# strictly less than the run_count of completed runs.
+probe_disconnect_cancel() {
+  local port=$1
+  # Snapshot scheduler state before the doomed request
+  local sched_before
+  sched_before=$(curl -s "http://localhost:$port/stats" \
+    | python3 -c "import json,sys; print(json.load(sys.stdin).get('scheduler',{}).get('run_count',0))")
+  local slow3_before
+  slow3_before=$(curl -s "http://localhost:$port/stats" \
+    | python3 -c "import json,sys; ops=json.load(sys.stdin).get('operators',{}); print(ops.get('slow3',{}).get('exec_count',0))")
+
+  # Send POST /execute with --max-time 0.3 → curl tears down the TCP
+  # connection at 300ms while slow1 is still inside its sleep(800ms).
+  local t0 t1 elapsed_ms
+  t0=$(date +%s%3N)
+  curl -s --max-time 0.3 -X POST -H "Content-Type: application/json" \
+    -d "$CD_REQ" "http://localhost:$port/execute" >/dev/null 2>&1 || true
+  # Now wait for the server's view of this request to settle. We poll
+  # scheduler.run_count up to 1.5s; once it ticks (even if the request
+  # was aborted, the engine still records the completed-or-cancelled
+  # run via dag_exec_total), we measure elapsed.
+  for _ in $(seq 1 30); do
+    local now
+    now=$(curl -s "http://localhost:$port/stats" \
+      | python3 -c "import json,sys; print(json.load(sys.stdin).get('scheduler',{}).get('run_count',0))" 2>/dev/null || echo 0)
+    if [[ "$now" -gt "$sched_before" ]]; then
+      break
+    fi
+    sleep 0.05
+  done
+  t1=$(date +%s%3N)
+  elapsed_ms=$((t1 - t0))
+
+  local slow3_after
+  slow3_after=$(curl -s "http://localhost:$port/stats" \
+    | python3 -c "import json,sys; ops=json.load(sys.stdin).get('operators',{}); print(ops.get('slow3',{}).get('exec_count',0))")
+
+  # Two-part assertion:
+  # (a) elapsed wallclock from connect → server settles must be under
+  #     1500 ms — proves we did NOT run all three 800 ms ops.
+  # (b) slow3 exec_count must NOT have advanced — proves the cancel
+  #     fired before reaching the third stage (the cancel beat slow2's
+  #     end at 1600 ms, never enqueueing slow3).
+  echo "$elapsed_ms $slow3_before $slow3_after"
+}
+
+if srv_ready $CD_GO_PORT; then
+  cancel_total=$((cancel_total + 1))
+  read -r el sb sa <<< "$(probe_disconnect_cancel $CD_GO_PORT)"
+  if [[ "$el" -lt 1500 && "$sa" == "$sb" ]]; then
+    cancel_pass=$((cancel_pass + 1))
+    echo "    [3] Go: TCP RST → cancel honored (elapsed=${el}ms, slow3 exec stayed at $sa)"
+  else
+    fail "M14 Go disconnect-cancel: elapsed=${el}ms (want <1500), slow3 ${sb}->${sa} (want unchanged)"
+  fi
+else
+  fail "M14 Go: server not ready on :$CD_GO_PORT"
+fi
+
+if [[ -n "${CPP_SERVER:-}" ]] && srv_ready $CD_CPP_PORT; then
+  cancel_total=$((cancel_total + 1))
+  read -r el sb sa <<< "$(probe_disconnect_cancel $CD_CPP_PORT)"
+  if [[ "$el" -lt 1500 && "$sa" == "$sb" ]]; then
+    cancel_pass=$((cancel_pass + 1))
+    echo "    [3] C++: TCP RST → cancel honored (elapsed=${el}ms, slow3 exec stayed at $sa)"
+  else
+    fail "M14 C++ disconnect-cancel: elapsed=${el}ms (want <1500), slow3 ${sb}->${sa} (want unchanged)"
+  fi
+fi
+
+echo "    [3] Java: skipped — PineServer.handleExecute does not pass a CancellationToken"
+echo "         (Engine.java:228 single-arg execute, server.go uses r.Context() and"
+echo "          server.cpp uses POLLRDHUP watcher; Java parity gap is documented in M14)"
+
+kill $CD_GO_PID 2>/dev/null || true
+[[ -n "$CD_CPP_PID" ]] && kill $CD_CPP_PID 2>/dev/null || true
+wait $CD_GO_PID 2>/dev/null || true
+[[ -n "$CD_CPP_PID" ]] && wait $CD_CPP_PID 2>/dev/null || true
+
+if [[ $cancel_total -gt 0 && $cancel_pass -eq $cancel_total ]]; then
+  pass "cancellation parity (audit M14): $cancel_pass/$cancel_total"
+fi
+
 # Return to caller if sourced, exit if run directly
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] && exit $_CV_FAIL || true

--- a/scripts/cross-validate/09-raw-byte.sh
+++ b/scripts/cross-validate/09-raw-byte.sh
@@ -31,6 +31,12 @@ with open('$config_file', 'w') as cf:
 import json, sys
 with open('$fixture_file') as f:
     data = json.load(f)
+# Skip fixtures that need external prepopulated state (redis) or
+# specially-built bench-tag binaries. Section 11/17 cover redis;
+# Section 19 covers bench-only stubs.
+requires = set(data.get('requires', []) or [])
+if requires & {'redis', 'redis-unavailable', 'bench'}:
+    sys.exit(0)
 cases = data.get('cases', [])
 if not cases:
     sys.exit(0)

--- a/scripts/cross-validate/10-hot-reload.sh
+++ b/scripts/cross-validate/10-hot-reload.sh
@@ -176,6 +176,208 @@ else
   CPP_SRV_PID=""
 fi
 
+# ============================================================
+# Audit M8: resource_config hot-reload parity. The hot-reload path
+# rebuilds both the engine AND the ResourceManager from scratch on
+# every reload, but the existing tests (1-3) only swap pipeline ops.
+# This block swaps a config whose resource_config has metrics_name="cache"
+# for one with metrics_name="cache_v2", proving the new manager starts,
+# the old metrics label disappears from /stats.resources, the new label
+# appears, and the swap happens without serving a request against a
+# closed resource. Requires redis-server; cleanly skipped otherwise.
+# ============================================================
+if which redis-server >/dev/null 2>&1; then
+  echo
+  echo "    [4-6] resource_config hot-reload (audit M8)"
+
+  RC_REDIS_PORT=21102
+  redis-server --port $RC_REDIS_PORT --daemonize yes --logfile /dev/null --save "" --appendonly no
+  redis_ready=false
+  for i in $(seq 1 20); do
+    if redis-cli -p $RC_REDIS_PORT PING 2>/dev/null | grep -q PONG; then
+      redis_ready=true
+      break
+    fi
+    sleep 0.1
+  done
+
+  if [[ "$redis_ready" == "true" ]]; then
+    RC_CONFIG="$WORK_DIR/rc_reload_config.json"
+    RC_CONFIG_V2="$WORK_DIR/rc_reload_config_v2.json"
+
+    rc_write_config() {
+      # $1 = output path, $2 = metrics_name
+      local out="$1" mname="$2"
+      cat > "$out" << CFG
+{
+  "resource_config": {
+    "redis_conn": {
+      "type": "redis_connection",
+      "interval": -1,
+      "params": {"addr": "127.0.0.1:$RC_REDIS_PORT", "metrics_name": "$mname"}
+    }
+  },
+  "pipeline_config": {
+    "operators": {
+      "get_cache": {
+        "type_name": "transform_redis_get",
+        "resource_name": "redis_conn",
+        "key_prefix": "test:",
+        "\$metadata": {
+          "common_input": ["uid"],
+          "common_output": ["result", "cache_hit"],
+          "item_input": [],
+          "item_output": []
+        }
+      }
+    }
+  },
+  "pipeline_group": {
+    "main": {"pipeline": ["get_cache"]}
+  },
+  "flow_contract": {
+    "common_input": ["uid"],
+    "item_input": [],
+    "common_output": ["uid", "result", "cache_hit"],
+    "item_output": []
+  }
+}
+CFG
+    }
+    rc_write_config "$RC_CONFIG" "cache"
+    rc_write_config "$RC_CONFIG_V2" "cache_v2"
+
+    RC_GO_PORT=20011
+    RC_JAVA_PORT=20012
+    RC_CPP_PORT=20014
+
+    "$WORK_DIR/pineapple-server" -config "$RC_CONFIG" -addr ":$RC_GO_PORT" &
+    RC_GO_PID=$!
+    java -cp "$JAVA_CP" -Dpine.config="$RC_CONFIG" -Dpine.port=$RC_JAVA_PORT page.liam.pine.PineServer &
+    RC_JAVA_PID=$!
+    RC_CPP_PID=""
+    rc_cpp_ready=false
+    if [[ -n "${CPP_SERVER:-}" ]]; then
+      "$CPP_SERVER" -config "$RC_CONFIG" -addr ":$RC_CPP_PORT" &
+      RC_CPP_PID=$!
+    fi
+
+    rc_label() {
+      curl -s "http://localhost:$1/stats" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print('__ERR__'); sys.exit()
+res = d.get('resources') or {}
+print(','.join(sorted(res.get('pine_redis_up', {}).keys())))
+"
+    }
+
+    rc_wait_label() {
+      local port=$1 want=$2
+      for _ in $(seq 1 60); do
+        if [[ "$(rc_label $port)" == "$want" ]]; then
+          return 0
+        fi
+        sleep 0.2
+      done
+      return 1
+    }
+
+    if srv_ready $RC_GO_PORT && srv_ready $RC_JAVA_PORT; then
+      [[ -n "${CPP_SERVER:-}" ]] && srv_ready $RC_CPP_PORT && rc_cpp_ready=true
+
+      # [4] before reload: only "cache" label exposed on all three engines
+      reload_total=$((reload_total + 1))
+      rc_wait_label $RC_GO_PORT "cache" || true
+      rc_wait_label $RC_JAVA_PORT "cache" || true
+      $rc_cpp_ready && (rc_wait_label $RC_CPP_PORT "cache" || true)
+      rc_lbl_go=$(rc_label $RC_GO_PORT)
+      rc_lbl_ja=$(rc_label $RC_JAVA_PORT)
+      if [[ "$rc_lbl_go" == "cache" && "$rc_lbl_ja" == "cache" ]]; then
+        reload_pass=$((reload_pass + 1))
+        echo "    [4] before reload: pine_redis_up label = 'cache' (Go + Java)"
+      else
+        fail "hot-reload resource_config: pre-reload label drift Go='$rc_lbl_go' Java='$rc_lbl_ja'"
+      fi
+      if $rc_cpp_ready; then
+        cpp_reload_total=$((cpp_reload_total + 1))
+        rc_lbl_cpp=$(rc_label $RC_CPP_PORT)
+        if [[ "$rc_lbl_cpp" == "cache" ]]; then
+          cpp_reload_pass=$((cpp_reload_pass + 1))
+          echo "    [4] before reload: pine_redis_up label = 'cache' (C++)"
+        else
+          fail "hot-reload resource_config: pre-reload label drift C++='$rc_lbl_cpp'"
+        fi
+      fi
+
+      # Trigger reload: swap config contents in place
+      cp "$RC_CONFIG_V2" "$RC_CONFIG"
+
+      # [5] after reload: label must transition cache → cache_v2 across all
+      reload_total=$((reload_total + 1))
+      go_ok=$(rc_wait_label $RC_GO_PORT "cache_v2" && echo y || echo n)
+      ja_ok=$(rc_wait_label $RC_JAVA_PORT "cache_v2" && echo y || echo n)
+      if [[ "$go_ok" == "y" && "$ja_ok" == "y" ]]; then
+        reload_pass=$((reload_pass + 1))
+        echo "    [5] after reload: pine_redis_up label = 'cache_v2' (Go + Java)"
+      else
+        rc_lbl_go=$(rc_label $RC_GO_PORT)
+        rc_lbl_ja=$(rc_label $RC_JAVA_PORT)
+        fail "hot-reload resource_config: post-reload label not cache_v2 (Go='$rc_lbl_go' Java='$rc_lbl_ja')"
+      fi
+      if $rc_cpp_ready; then
+        cpp_reload_total=$((cpp_reload_total + 1))
+        cpp_ok=$(rc_wait_label $RC_CPP_PORT "cache_v2" && echo y || echo n)
+        if [[ "$cpp_ok" == "y" ]]; then
+          cpp_reload_pass=$((cpp_reload_pass + 1))
+          echo "    [5] after reload: pine_redis_up label = 'cache_v2' (C++)"
+        else
+          rc_lbl_cpp=$(rc_label $RC_CPP_PORT)
+          fail "hot-reload resource_config: post-reload C++ label='$rc_lbl_cpp'"
+        fi
+      fi
+
+      # [6] /execute against the new resource still resolves: the borrow
+      #     path must reach the *new* manager, not retain a stale reference
+      #     to the old one (which would have been Stop()ed).
+      reload_total=$((reload_total + 1))
+      RC_REQ='{"common":{"uid":"u1"},"items":[]}'
+      go_status=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" -d "$RC_REQ" "http://localhost:$RC_GO_PORT/execute")
+      ja_status=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" -d "$RC_REQ" "http://localhost:$RC_JAVA_PORT/execute")
+      if [[ "$go_status" == "200" && "$ja_status" == "200" ]]; then
+        reload_pass=$((reload_pass + 1))
+        echo "    [6] post-reload /execute against new manager: 200 (Go + Java)"
+      else
+        fail "hot-reload resource_config: post-reload execute Go=$go_status Java=$ja_status"
+      fi
+      if $rc_cpp_ready; then
+        cpp_reload_total=$((cpp_reload_total + 1))
+        cpp_status=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" -d "$RC_REQ" "http://localhost:$RC_CPP_PORT/execute")
+        if [[ "$cpp_status" == "200" ]]; then
+          cpp_reload_pass=$((cpp_reload_pass + 1))
+          echo "    [6] post-reload /execute against new manager: 200 (C++)"
+        else
+          fail "hot-reload resource_config: post-reload execute C++=$cpp_status"
+        fi
+      fi
+    else
+      fail "hot-reload resource_config: servers failed to start"
+    fi
+
+    kill $RC_GO_PID $RC_JAVA_PID 2>/dev/null || true
+    [[ -n "$RC_CPP_PID" ]] && kill $RC_CPP_PID 2>/dev/null || true
+    wait $RC_GO_PID $RC_JAVA_PID 2>/dev/null || true
+    [[ -n "$RC_CPP_PID" ]] && wait $RC_CPP_PID 2>/dev/null || true
+    redis-cli -p $RC_REDIS_PORT SHUTDOWN NOSAVE >/dev/null 2>&1 || true
+  else
+    echo "    [4-6] skipped: redis on $RC_REDIS_PORT failed to start"
+  fi
+else
+  echo "    [4-6] skipped: redis-server not found"
+fi
+
 if [[ $reload_total -gt 0 && $reload_pass -eq $reload_total ]]; then
   pass "hot-reload parity ($reload_pass/$reload_total checks)"
 elif [[ $reload_total -eq 0 ]]; then

--- a/scripts/cross-validate/12-extensibility-parity.sh
+++ b/scripts/cross-validate/12-extensibility-parity.sh
@@ -222,6 +222,32 @@ else
     fi
   fi
 
+  # Test 7: /debug/pprof/* must NOT be on the main port for any runtime.
+  # pine-go ships net/http/pprof on a separate AdminAddr (default off);
+  # pine-java and pine-cpp have no equivalent feature. Asserting 404 here
+  # documents pprof as a pine-go-only side-port concern and catches a
+  # future regression that wires it onto the public listener (audit M11).
+  ext_total=$((ext_total + 1))
+  go_pprof=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$GO_EXT_PORT/debug/pprof/")
+  java_pprof=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$JAVA_EXT_PORT/debug/pprof/")
+  if [[ "$go_pprof" == "404" && "$java_pprof" == "404" ]]; then
+    ext_pass=$((ext_pass + 1))
+    echo "    [7] GET /debug/pprof/ → 404 (Go without AdminAddr, Java has no pprof)"
+  else
+    fail "extensibility: /debug/pprof/ must be 404 on main port (Go=$go_pprof, Java=$java_pprof)"
+  fi
+
+  if $cpp_srv_ready; then
+    cpp_ext_total=$((cpp_ext_total + 1))
+    cpp_pprof=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$CPP_EXT_PORT/debug/pprof/")
+    if [[ "$cpp_pprof" == "404" ]]; then
+      cpp_ext_pass=$((cpp_ext_pass + 1))
+      echo "    [7] C++ GET /debug/pprof/ → 404 (no pprof feature)"
+    else
+      fail "extensibility: C++ /debug/pprof/ must be 404 ($cpp_pprof)"
+    fi
+  fi
+
   ext_cleanup
 fi
 

--- a/scripts/cross-validate/13-metrics-parity.sh
+++ b/scripts/cross-validate/13-metrics-parity.sh
@@ -690,6 +690,192 @@ else
   lua_cleanup
 fi
 
+# ---------------------------------------------------------------------------
+# Audit M10: data_parallel + transform_by_lua concurrent reuse invariant.
+# The sequential check [10] only proves single-threaded bookkeeping. With
+# data_parallel=4 each /execute fans out across 4 worker shards, and N
+# concurrent /execute requests multiply that fan-out. The invariant
+#   borrow_count == reuse_count + create_count
+# must hold under contention — a CAS bug in any one runtime would surface
+# as borrow != reuse + create even when totals match.
+# ---------------------------------------------------------------------------
+DPL_FIXTURE="$REPO_ROOT/fixtures/pipelines/data_parallel_lua.json"
+DPL_CONFIG="$WORK_DIR/dpl_metrics_config.json"
+python3 -c "
+import json
+with open('$DPL_FIXTURE') as f:
+    data = json.load(f)
+with open('$DPL_CONFIG', 'w') as cf:
+    json.dump(data.get('config', {}), cf)
+"
+DPL_REQ=$(python3 -c "
+import json
+with open('$DPL_FIXTURE') as f:
+    data = json.load(f)
+print(json.dumps(data['cases'][0]['request']))
+")
+
+GO_DPL_PORT=23021
+JAVA_DPL_PORT=23022
+CPP_DPL_PORT=23024
+
+"$WORK_DIR/pineapple-server" -config "$DPL_CONFIG" -addr ":$GO_DPL_PORT" &
+GO_DPL_PID=$!
+java -cp "$JAVA_CP" -Dpine.config="$DPL_CONFIG" -Dpine.port=$JAVA_DPL_PORT page.liam.pine.PineServer &
+JAVA_DPL_PID=$!
+CPP_DPL_PID=""
+if [[ -n "${CPP_SERVER:-}" ]]; then
+  "$CPP_SERVER" -config "$DPL_CONFIG" -addr ":$CPP_DPL_PORT" &
+  CPP_DPL_PID=$!
+fi
+
+dpl_cleanup() {
+  kill $GO_DPL_PID $JAVA_DPL_PID 2>/dev/null || true
+  [[ -n "$CPP_DPL_PID" ]] && kill $CPP_DPL_PID 2>/dev/null || true
+  wait $GO_DPL_PID $JAVA_DPL_PID 2>/dev/null || true
+  [[ -n "$CPP_DPL_PID" ]] && wait $CPP_DPL_PID 2>/dev/null || true
+  GO_DPL_PID=""
+  JAVA_DPL_PID=""
+  CPP_DPL_PID=""
+}
+trap 'dpl_cleanup' EXIT
+
+cpp_dpl_ready=false
+if srv_ready $GO_DPL_PORT && srv_ready $JAVA_DPL_PORT; then
+  if [[ -n "${CPP_SERVER:-}" ]] && srv_ready $CPP_DPL_PORT; then
+    cpp_dpl_ready=true
+  fi
+
+  GO_DPL_BASELINE=$(curl -s "http://localhost:$GO_DPL_PORT/stats")
+  JAVA_DPL_BASELINE=$(curl -s "http://localhost:$JAVA_DPL_PORT/stats")
+  CPP_DPL_BASELINE=""
+  $cpp_dpl_ready && CPP_DPL_BASELINE=$(curl -s "http://localhost:$CPP_DPL_PORT/stats")
+
+  # Burst N=24 concurrent requests with up to 8 in flight at a time. Picked
+  # so each engine's pool sees real contention (data_parallel=4 → 4 workers
+  # per request × 8 in-flight = 32 concurrent borrows) without overwhelming
+  # the test machine.
+  DPL_N=24
+  DPL_INFLIGHT=8
+  fire_burst() {
+    local port=$1 total=$2 inflight=$3
+    local sent=0
+    while (( sent < total )); do
+      local pids=()
+      local batch=$inflight
+      (( total - sent < batch )) && batch=$((total - sent))
+      for ((p = 0; p < batch; p++)); do
+        curl -s -X POST -H "Content-Type: application/json" \
+          -d "$DPL_REQ" "http://localhost:$port/execute" >/dev/null 2>&1 &
+        pids+=("$!")
+      done
+      for pid in "${pids[@]}"; do
+        wait "$pid" || true
+      done
+      sent=$((sent + batch))
+    done
+  }
+  fire_burst $GO_DPL_PORT $DPL_N $DPL_INFLIGHT
+  fire_burst $JAVA_DPL_PORT $DPL_N $DPL_INFLIGHT
+  $cpp_dpl_ready && fire_burst $CPP_DPL_PORT $DPL_N $DPL_INFLIGHT
+
+  GO_DPL_STATS=$(curl -s "http://localhost:$GO_DPL_PORT/stats")
+  JAVA_DPL_STATS=$(curl -s "http://localhost:$JAVA_DPL_PORT/stats")
+  CPP_DPL_STATS=""
+  $cpp_dpl_ready && CPP_DPL_STATS=$(curl -s "http://localhost:$CPP_DPL_PORT/stats")
+
+  # [11] Concurrent invariant: borrow_count == reuse_count + create_count
+  #      per-op, under contention. Totals may differ across runtimes (warm-set
+  #      vs lazy creation, shard worker-pool sizing) but the equation must
+  #      hold in each engine independently.
+  metrics_total=$((metrics_total + 1))
+  dpl_invariant_ok=$(python3 -c "
+import json
+N = $DPL_N
+FIELDS = ('borrow_count', 'reuse_count', 'create_count')
+def view(stats):
+    detail = stats.get('operator_detail') or {}
+    out = {}
+    for op, fields in detail.items():
+        if all(k in fields for k in FIELDS):
+            out[op] = {k: fields[k] for k in FIELDS}
+    return out
+def delta(before, after):
+    out = {}
+    for op in after:
+        b = before.get(op, {k: 0 for k in FIELDS})
+        out[op] = {k: after[op][k] - b[k] for k in FIELDS}
+    return out
+def check_invariant(label, d):
+    for op, f in d.items():
+        if f['borrow_count'] != f['reuse_count'] + f['create_count']:
+            return f'{label}/{op}: borrow={f[\"borrow_count\"]} != reuse={f[\"reuse_count\"]} + create={f[\"create_count\"]}'
+        # data_parallel=4, N requests → at minimum N × 1 = N borrows on each
+        # lua op's pool (each shard worker borrows ≥1 state per request).
+        # A bookkeeping bug that drops borrows below N indicates a lost
+        # accounting path on the concurrent shard fan-out.
+        if f['borrow_count'] < N:
+            return f'{label}/{op}: borrow={f[\"borrow_count\"]} < N={N}'
+    return None
+go_d = delta(view(json.loads('''$GO_DPL_BASELINE''')), view(json.loads('''$GO_DPL_STATS''')))
+ja_d = delta(view(json.loads('''$JAVA_DPL_BASELINE''')), view(json.loads('''$JAVA_DPL_STATS''')))
+if not go_d:
+    print('go: no operator_detail with lua pool fields')
+else:
+    err = check_invariant('go', go_d) or check_invariant('java', ja_d)
+    print(err or 'match')
+")
+  if [[ "$dpl_invariant_ok" == "match" ]]; then
+    metrics_pass=$((metrics_pass + 1))
+    echo "    [11] data_parallel+lua concurrent invariant (borrow=reuse+create) Go + Java"
+  else
+    fail "metrics: data_parallel+lua concurrent invariant: $dpl_invariant_ok"
+  fi
+
+  if $cpp_dpl_ready; then
+    cpp_metrics_total=$((cpp_metrics_total + 1))
+    cpp_dpl_invariant_ok=$(python3 -c "
+import json
+N = $DPL_N
+FIELDS = ('borrow_count', 'reuse_count', 'create_count')
+def view(stats):
+    detail = stats.get('operator_detail') or {}
+    out = {}
+    for op, fields in detail.items():
+        if all(k in fields for k in FIELDS):
+            out[op] = {k: fields[k] for k in FIELDS}
+    return out
+def delta(before, after):
+    out = {}
+    for op in after:
+        b = before.get(op, {k: 0 for k in FIELDS})
+        out[op] = {k: after[op][k] - b[k] for k in FIELDS}
+    return out
+cpp_d = delta(view(json.loads('''$CPP_DPL_BASELINE''')), view(json.loads('''$CPP_DPL_STATS''')))
+err = None
+for op, f in cpp_d.items():
+    if f['borrow_count'] != f['reuse_count'] + f['create_count']:
+        err = f'cpp/{op}: borrow={f[\"borrow_count\"]} != reuse={f[\"reuse_count\"]} + create={f[\"create_count\"]}'
+        break
+    if f['borrow_count'] < N:
+        err = f'cpp/{op}: borrow={f[\"borrow_count\"]} < N={N}'
+        break
+print(err or 'match')
+")
+    if [[ "$cpp_dpl_invariant_ok" == "match" ]]; then
+      cpp_metrics_pass=$((cpp_metrics_pass + 1))
+      echo "    [11] data_parallel+lua concurrent invariant C++"
+    else
+      fail "metrics: data_parallel+lua concurrent invariant C++: $cpp_dpl_invariant_ok"
+    fi
+  fi
+
+  dpl_cleanup
+else
+  fail "metrics: data_parallel+lua servers failed to start"
+  dpl_cleanup
+fi
+
 if [[ $metrics_total -gt 0 && $metrics_pass -eq $metrics_total ]]; then
   pass "metrics parity ($metrics_pass/$metrics_total checks)"
 elif [[ $metrics_total -eq 0 ]]; then

--- a/scripts/cross-validate/13-metrics-parity.sh
+++ b/scripts/cross-validate/13-metrics-parity.sh
@@ -493,6 +493,203 @@ else
   CPP_PID=""
 fi
 
+# ---------------------------------------------------------------------------
+# Lua pool reuse_count parity (audit gap H6)
+# Reuses the same machinery but with a transform_by_lua fixture so we can
+# assert operator_detail.<op>.{borrow_count,reuse_count,create_count} are
+# byte-identical across runtimes after a fixed-N execution. Without this
+# section, /stats only verifies exec/skip/error counters; lua pool drift
+# (e.g. Java incrementing reuse on misses, or C++ counting borrow twice)
+# would survive every parity gate.
+# ---------------------------------------------------------------------------
+LUA_FIXTURE="$REPO_ROOT/fixtures/pipelines/barrier_transform_reorder.json"
+LUA_CONFIG="$WORK_DIR/lua_metrics_config.json"
+python3 -c "
+import json
+with open('$LUA_FIXTURE') as f:
+    data = json.load(f)
+with open('$LUA_CONFIG', 'w') as cf:
+    json.dump(data.get('config', {}), cf)
+"
+LUA_REQ=$(python3 -c "
+import json
+with open('$LUA_FIXTURE') as f:
+    data = json.load(f)
+print(json.dumps(data['cases'][0]['request']))
+")
+
+GO_LUA_PORT=23011
+JAVA_LUA_PORT=23012
+CPP_LUA_PORT=23014
+
+"$WORK_DIR/pineapple-server" -config "$LUA_CONFIG" -addr ":$GO_LUA_PORT" &
+GO_LUA_PID=$!
+java -cp "$JAVA_CP" -Dpine.config="$LUA_CONFIG" -Dpine.port=$JAVA_LUA_PORT page.liam.pine.PineServer &
+JAVA_LUA_PID=$!
+CPP_LUA_PID=""
+if [[ -n "${CPP_SERVER:-}" ]]; then
+  "$CPP_SERVER" -config "$LUA_CONFIG" -addr ":$CPP_LUA_PORT" &
+  CPP_LUA_PID=$!
+fi
+
+lua_cleanup() {
+  kill $GO_LUA_PID $JAVA_LUA_PID 2>/dev/null || true
+  [[ -n "$CPP_LUA_PID" ]] && kill $CPP_LUA_PID 2>/dev/null || true
+  wait $GO_LUA_PID $JAVA_LUA_PID 2>/dev/null || true
+  [[ -n "$CPP_LUA_PID" ]] && wait $CPP_LUA_PID 2>/dev/null || true
+  GO_LUA_PID=""
+  JAVA_LUA_PID=""
+  CPP_LUA_PID=""
+}
+trap 'lua_cleanup' EXIT
+
+cpp_lua_ready=false
+if srv_ready $GO_LUA_PORT && srv_ready $JAVA_LUA_PORT; then
+  if [[ -n "${CPP_SERVER:-}" ]] && srv_ready $CPP_LUA_PORT; then
+    cpp_lua_ready=true
+  fi
+
+  # Snapshot baseline counters BEFORE any /execute traffic. This isolates
+  # exec-time parity from runtime-specific init behavior — pine-go does a
+  # one-shot validation borrow during NewEngine (operators/lua/lua.go:85)
+  # to confirm the declared funcName resolves, which Java/C++ check on the
+  # seed state without going through the pool. That intentional asymmetry
+  # would make absolute counters diverge by 1, but the *delta* across N
+  # executes must be byte-identical across all runtimes.
+  GO_LUA_BASELINE=$(curl -s "http://localhost:$GO_LUA_PORT/stats")
+  JAVA_LUA_BASELINE=$(curl -s "http://localhost:$JAVA_LUA_PORT/stats")
+  CPP_LUA_BASELINE=""
+  if $cpp_lua_ready; then
+    CPP_LUA_BASELINE=$(curl -s "http://localhost:$CPP_LUA_PORT/stats")
+  fi
+
+  # Drive N requests; each call borrows ≥1 lua state per transform_by_lua op.
+  # With a warm-set sized ≥1, all N exec-time borrows hit the pool and
+  # increment reuse_count; create_count must not move at all.
+  LUA_N=8
+  for i in $(seq 1 $LUA_N); do
+    curl -s -X POST -H "Content-Type: application/json" -d "$LUA_REQ" "http://localhost:$GO_LUA_PORT/execute" > /dev/null
+    curl -s -X POST -H "Content-Type: application/json" -d "$LUA_REQ" "http://localhost:$JAVA_LUA_PORT/execute" > /dev/null
+    if $cpp_lua_ready; then
+      curl -s -X POST -H "Content-Type: application/json" -d "$LUA_REQ" "http://localhost:$CPP_LUA_PORT/execute" > /dev/null
+    fi
+  done
+
+  GO_LUA_STATS=$(curl -s "http://localhost:$GO_LUA_PORT/stats")
+  JAVA_LUA_STATS=$(curl -s "http://localhost:$JAVA_LUA_PORT/stats")
+  CPP_LUA_STATS=""
+  if $cpp_lua_ready; then
+    CPP_LUA_STATS=$(curl -s "http://localhost:$CPP_LUA_PORT/stats")
+  fi
+
+  # [10] Lua pool exec-time delta parity: per-op
+  #   {borrow_count, reuse_count, create_count}_after - _before
+  # must be byte-identical across go/java/(cpp). Expected delta per op:
+  #   borrow = N, reuse = N, create = 0  (warm-set seed pre-allocates;
+  # exec-time hits the pool only). This catches any future bookkeeping
+  # bug where one runtime miscounts a hit, double-counts a borrow, or
+  # silently grows the pool on the hot path.
+  metrics_total=$((metrics_total + 1))
+  lua_pool_ok=$(python3 -c "
+import json
+N = $LUA_N
+FIELDS = ('borrow_count', 'reuse_count', 'create_count')
+def view(stats):
+    detail = stats.get('operator_detail') or {}
+    out = {}
+    for op, fields in detail.items():
+        if all(k in fields for k in FIELDS):
+            out[op] = {k: fields[k] for k in FIELDS}
+    return out
+def delta(before, after):
+    out = {}
+    for op in after:
+        b = before.get(op, {k: 0 for k in FIELDS})
+        out[op] = {k: after[op][k] - b[k] for k in FIELDS}
+    return out
+def expected_delta(view_after, n):
+    for op, f in view_after.items():
+        # borrow == reuse + create  (every borrow is either hit or miss)
+        if f['borrow_count'] != f['reuse_count'] + f['create_count']:
+            return f'{op}: borrow={f[\"borrow_count\"]} != reuse={f[\"reuse_count\"]} + create={f[\"create_count\"]}'
+        # warm-set sized ≥1, so exec-time borrows must all be hits.
+        if f['create_count'] != 0:
+            return f'{op}: exec-time create_count={f[\"create_count\"]} != 0 (pool churn on hot path)'
+        if f['reuse_count'] != n:
+            return f'{op}: reuse_count={f[\"reuse_count\"]} != N={n}'
+    return None
+go_after = view(json.loads('''$GO_LUA_STATS'''))
+java_after = view(json.loads('''$JAVA_LUA_STATS'''))
+go_before = view(json.loads('''$GO_LUA_BASELINE'''))
+java_before = view(json.loads('''$JAVA_LUA_BASELINE'''))
+if not go_after:
+    print('go: no operator_detail with lua pool fields')
+elif sorted(go_after.keys()) != sorted(java_after.keys()):
+    print(f'op set differs: go={sorted(go_after.keys())} java={sorted(java_after.keys())}')
+else:
+    go_d = delta(go_before, go_after)
+    java_d = delta(java_before, java_after)
+    err = expected_delta(go_d, N) or expected_delta(java_d, N)
+    if not err and go_d != java_d:
+        err = f'delta drift: go={go_d} java={java_d}'
+    print(err or 'match')
+")
+  if [[ "$lua_pool_ok" == "match" ]]; then
+    metrics_pass=$((metrics_pass + 1))
+    echo "    [10] lua pool exec-time delta byte-identical Go vs Java (borrow=reuse=N, create=0)"
+  else
+    fail "metrics: lua pool reuse_count parity Go vs Java: $lua_pool_ok"
+  fi
+
+  if $cpp_lua_ready; then
+    cpp_metrics_total=$((cpp_metrics_total + 1))
+    cpp_lua_pool_ok=$(python3 -c "
+import json
+N = $LUA_N
+FIELDS = ('borrow_count', 'reuse_count', 'create_count')
+def view(stats):
+    detail = stats.get('operator_detail') or {}
+    out = {}
+    for op, fields in detail.items():
+        if all(k in fields for k in FIELDS):
+            out[op] = {k: fields[k] for k in FIELDS}
+    return out
+def delta(before, after):
+    out = {}
+    for op in after:
+        b = before.get(op, {k: 0 for k in FIELDS})
+        out[op] = {k: after[op][k] - b[k] for k in FIELDS}
+    return out
+go_d = delta(view(json.loads('''$GO_LUA_BASELINE''')),
+             view(json.loads('''$GO_LUA_STATS''')))
+cpp_d = delta(view(json.loads('''$CPP_LUA_BASELINE''')),
+              view(json.loads('''$CPP_LUA_STATS''')))
+if sorted(go_d.keys()) != sorted(cpp_d.keys()):
+    print(f'op set differs: go={sorted(go_d.keys())} cpp={sorted(cpp_d.keys())}')
+elif go_d != cpp_d:
+    print(f'delta drift: go={go_d} cpp={cpp_d}')
+else:
+    bad = None
+    for op, f in cpp_d.items():
+        if f['create_count'] != 0 or f['reuse_count'] != N or f['borrow_count'] != N:
+            bad = f'{op}: cpp delta {f} != expected (borrow={N},reuse={N},create=0)'
+            break
+    print(bad or 'match')
+")
+    if [[ "$cpp_lua_pool_ok" == "match" ]]; then
+      cpp_metrics_pass=$((cpp_metrics_pass + 1))
+      echo "    [10] C++ lua pool exec-time delta byte-identical to Go"
+    else
+      fail "metrics: lua pool reuse_count parity Go vs C++: $cpp_lua_pool_ok"
+    fi
+  fi
+
+  lua_cleanup
+else
+  fail "metrics: lua-fixture servers failed to start"
+  lua_cleanup
+fi
+
 if [[ $metrics_total -gt 0 && $metrics_pass -eq $metrics_total ]]; then
   pass "metrics parity ($metrics_pass/$metrics_total checks)"
 elif [[ $metrics_total -eq 0 ]]; then

--- a/scripts/cross-validate/16-resource-metrics.sh
+++ b/scripts/cross-validate/16-resource-metrics.sh
@@ -216,6 +216,79 @@ else:
           fail "resource metrics: Go vs C++ parity: $gc_parity"
         fi
       fi
+
+      # [3a] Audit M6: 有量后再 scrape — fire 3 /execute rounds and verify
+      #      the resources subtree still resolves to the same key shape with
+      #      up=1. This catches "borrowing the client races with the probe
+      #      goroutine and corrupts the metrics view" (the kind of regression
+      #      that wouldn't show up in either the cold-start scrape or the
+      #      probeless negative case).
+      rm_total=$((rm_total + 1))
+      send_traffic() {
+        local port=$1 n=$2
+        for ((i = 0; i < n; i++)); do
+          curl -fsS -X POST -H "Content-Type: application/json" \
+            -d '{"common":{"uid":"u-'"$i"'"},"items":[]}' \
+            "http://localhost:$port/execute" >/dev/null 2>&1 || true
+        done
+      }
+      send_traffic $GO_PORT 3
+      send_traffic $JAVA_PORT 3
+      $cpp_srv_ready && send_traffic $CPP_PORT 3
+      GO_RES2=$(scrape_resources $GO_PORT)
+      JAVA_RES2=$(scrape_resources $JAVA_PORT)
+      CPP_RES2=""
+      $cpp_srv_ready && CPP_RES2=$(scrape_resources $CPP_PORT)
+      under_load=$(python3 -c "
+import json
+def shape(s):
+    r = json.loads(s)
+    return {m: sorted(v.keys()) for m, v in r.items()}
+def up(s):
+    return json.loads(s).get('pine_redis_up', {}).get('cache')
+go1 = shape('''$GO_RES'''); go2 = shape('''$GO_RES2''')
+ja1 = shape('''$JAVA_RES'''); ja2 = shape('''$JAVA_RES2''')
+if go1 != go2:
+    print(f'go shape drifted under load: {go1} -> {go2}')
+elif ja1 != ja2:
+    print(f'java shape drifted under load: {ja1} -> {ja2}')
+elif up('''$GO_RES2''') != 1:
+    print(f'go up degraded under load: {up(\"\"\"$GO_RES2\"\"\")}')
+elif up('''$JAVA_RES2''') != 1:
+    print(f'java up degraded under load: {up(\"\"\"$JAVA_RES2\"\"\")}')
+else:
+    print('stable')
+")
+      if [[ "$under_load" == "stable" ]]; then
+        rm_pass=$((rm_pass + 1))
+        echo "    [3a] under load: resources shape + up=1 stable across Go + Java"
+      else
+        fail "resource metrics: under-load state: $under_load"
+      fi
+      if $cpp_srv_ready; then
+        cpp_rm_total=$((cpp_rm_total + 1))
+        cpp_under_load=$(python3 -c "
+import json
+def shape(s):
+    r = json.loads(s)
+    return {m: sorted(v.keys()) for m, v in r.items()}
+def up(s):
+    return json.loads(s).get('pine_redis_up', {}).get('cache')
+c1 = shape('''$CPP_RES'''); c2 = shape('''$CPP_RES2''')
+if c1 != c2:
+    print(f'cpp shape drifted under load: {c1} -> {c2}')
+elif up('''$CPP_RES2''') != 1:
+    print(f'cpp up degraded under load: {up(\"\"\"$CPP_RES2\"\"\")}')
+else:
+    print('stable')
+")
+        if [[ "$cpp_under_load" == "stable" ]]; then
+          cpp_rm_pass=$((cpp_rm_pass + 1))
+          echo "    [3a] under load: resources shape + up=1 stable in C++"
+        else
+          fail "resource metrics: under-load state C++: $cpp_under_load"
+        fi
+      fi
     else
       fail "resource metrics: servers failed to start (positive case)"
     fi
@@ -276,6 +349,232 @@ print(json.dumps(res, sort_keys=True) if res is not None else '__MISSING__')
       fi
     else
       fail "resource metrics: servers failed to start (negative case)"
+    fi
+
+    kill $GO_PID $JAVA_PID 2>/dev/null || true
+    [[ -n "$CPP_PID" ]] && kill $CPP_PID 2>/dev/null || true
+    wait $GO_PID $JAVA_PID 2>/dev/null || true
+    [[ -n "$CPP_PID" ]] && wait $CPP_PID 2>/dev/null || true
+
+    # ============================================================
+    # UNREACHABLE CASE (audit M6): metrics_name set, addr → dead port.
+    # Probe runs once at resource Start; PING fails so up=0 must surface,
+    # the metrics keys must still be present (resources != {}), and
+    # fail_on_error=true must propagate as a 5xx-flavoured response.
+    # ============================================================
+    UNREACH_CONFIG="$WORK_DIR/rm_unreach_config.json"
+    DEAD_PORT=21099
+    cat > "$UNREACH_CONFIG" << CFG
+{
+  "resource_config": {
+    "redis_conn": {
+      "type": "redis_connection",
+      "interval": -1,
+      "params": {"addr": "127.0.0.1:$DEAD_PORT", "metrics_name": "cache"}
+    }
+  },
+  "pipeline_config": {
+    "operators": {
+      "get_cache": {
+        "type_name": "transform_redis_get",
+        "resource_name": "redis_conn",
+        "key_prefix": "test:",
+        "fail_on_error": true,
+        "\$metadata": {
+          "common_input": ["uid"],
+          "common_output": ["result", "cache_hit"],
+          "item_input": [],
+          "item_output": []
+        }
+      }
+    }
+  },
+  "pipeline_group": {
+    "main": {"pipeline": ["get_cache"]}
+  },
+  "flow_contract": {
+    "common_input": ["uid"],
+    "item_input": [],
+    "common_output": ["uid", "result", "cache_hit"],
+    "item_output": []
+  }
+}
+CFG
+
+    # Pick fresh ports — old ones may still be in TIME_WAIT
+    GO_PORT=23031; JAVA_PORT=23032; CPP_PORT=23034
+    "$WORK_DIR/pineapple-server" -config "$UNREACH_CONFIG" -addr ":$GO_PORT" &
+    GO_PID=$!
+    java -cp "$JAVA_CP" -Dpine.config="$UNREACH_CONFIG" -Dpine.port=$JAVA_PORT page.liam.pine.PineServer &
+    JAVA_PID=$!
+    CPP_PID=""
+    cpp_srv_ready=false
+    if [[ -n "${CPP_SERVER:-}" ]]; then
+      "$CPP_SERVER" -config "$UNREACH_CONFIG" -addr ":$CPP_PORT" &
+      CPP_PID=$!
+    fi
+
+    # scrape_unreach <port>: wait for the probe goroutine to complete its
+    # first round and surface up=0 + populated cells. Go's go-redis client
+    # retries 5× with backoff, so the first probe can take 10-20s before
+    # the failure is reflected — bump the wait window beyond what the
+    # positive-case scrape needs.
+    scrape_unreach() {
+      local port=$1
+      for _ in $(seq 1 80); do
+        local r
+        r=$(curl -s "http://localhost:$port/stats" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print('__ERR__'); sys.exit()
+res = d.get('resources', None)
+print(json.dumps(res, sort_keys=True) if res is not None else '__MISSING__')
+")
+        # Wait for pine_redis_up to have a populated 'cache' cell
+        # (probe finished its first iteration with the dial failure).
+        local cell
+        cell=$(printf '%s' "$r" | python3 -c "
+import json, sys
+try:
+    r = json.loads(sys.stdin.read())
+    print(r.get('pine_redis_up', {}).get('cache', '__MISSING__'))
+except Exception:
+    print('__MISSING__')
+")
+        if [[ "$cell" != "__MISSING__" && "$cell" != "None" ]]; then
+          echo "$r"
+          return 0
+        fi
+        sleep 0.5
+      done
+      curl -s "http://localhost:$port/stats" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+res = d.get('resources', None)
+print(json.dumps(res, sort_keys=True) if res is not None else '__MISSING__')
+"
+    }
+
+    if srv_ready $GO_PORT && srv_ready $JAVA_PORT; then
+      if [[ -n "${CPP_SERVER:-}" ]] && srv_ready $CPP_PORT; then
+        cpp_srv_ready=true
+      fi
+
+      GO_DEAD=$(scrape_unreach $GO_PORT)
+      JAVA_DEAD=$(scrape_unreach $JAVA_PORT)
+      CPP_DEAD=""
+      $cpp_srv_ready && CPP_DEAD=$(scrape_unreach $CPP_PORT)
+
+      # [5] Go: redis dead → up=0, but metrics keys still present
+      rm_total=$((rm_total + 1))
+      go_dead_ok=$(python3 -c "
+import json
+r = json.loads('''$GO_DEAD''')
+if r == {}:
+    print('resources empty (probe never ran or metrics_name lost)')
+elif 'pine_redis_up' not in r:
+    print(f'pine_redis_up missing: keys={sorted(r.keys())}')
+elif r['pine_redis_up'].get('cache') != 0:
+    print(f'pine_redis_up.cache = {r[\"pine_redis_up\"].get(\"cache\")} != 0')
+else:
+    print('ok')
+")
+      if [[ "$go_dead_ok" == "ok" ]]; then
+        rm_pass=$((rm_pass + 1))
+        echo "    [5] Go: redis dead → up=0, metrics keys retained"
+      else
+        fail "resource metrics: unreachable case Go: $go_dead_ok"
+      fi
+
+      # [6] Go vs Java: same shape + same up=0
+      rm_total=$((rm_total + 1))
+      gj_dead=$(python3 -c "
+import json
+go = json.loads('''$GO_DEAD''')
+ja = json.loads('''$JAVA_DEAD''')
+def keyset(r):
+    return {m: sorted(v.keys()) for m, v in r.items()}
+if keyset(go) != keyset(ja):
+    print(f'shape go={keyset(go)} java={keyset(ja)}')
+elif go.get('pine_redis_up') != ja.get('pine_redis_up'):
+    print(f'up go={go.get(\"pine_redis_up\")} java={ja.get(\"pine_redis_up\")}')
+else:
+    print('match')
+")
+      if [[ "$gj_dead" == "match" ]]; then
+        rm_pass=$((rm_pass + 1))
+        echo "    [6] Go vs Java: redis dead → shape + up=0 parity"
+      else
+        fail "resource metrics: unreachable parity Go vs Java: $gj_dead"
+      fi
+
+      if $cpp_srv_ready; then
+        cpp_rm_total=$((cpp_rm_total + 1))
+        gc_dead=$(python3 -c "
+import json
+go = json.loads('''$GO_DEAD''')
+cpp = json.loads('''$CPP_DEAD''')
+def keyset(r):
+    return {m: sorted(v.keys()) for m, v in r.items()}
+if cpp == {}:
+    print('cpp resources empty (probe never ran or metrics_name lost)')
+elif keyset(go) != keyset(cpp):
+    print(f'shape go={keyset(go)} cpp={keyset(cpp)}')
+elif go.get('pine_redis_up') != cpp.get('pine_redis_up'):
+    print(f'up go={go.get(\"pine_redis_up\")} cpp={cpp.get(\"pine_redis_up\")}')
+else:
+    print('match')
+")
+        if [[ "$gc_dead" == "match" ]]; then
+          cpp_rm_pass=$((cpp_rm_pass + 1))
+          echo "    [6] Go vs C++: redis dead → shape + up=0 parity"
+        else
+          fail "resource metrics: unreachable parity Go vs C++: $gc_dead"
+        fi
+      fi
+
+      # [7] fail_on_error=true with dead redis → operator response should
+      #     surface as a non-2xx for both engines (proves the gauge is not
+      #     just decorative — pipeline reads it via the borrow path and the
+      #     error propagates). Tolerates either an HTTP error or a 200 with
+      #     an "error"-shaped body, whichever the engine's contract says.
+      rm_total=$((rm_total + 1))
+      probe_fail() {
+        local port=$1
+        # -o discards body; -w prints HTTP status + an explicit marker for
+        # connection-reset / curl-side errors.
+        local code
+        code=$(curl -s -o /tmp/rm_dead_body.$$ -w "%{http_code}" -X POST \
+          -H "Content-Type: application/json" \
+          -d '{"common":{"uid":"u1"},"items":[]}' \
+          "http://localhost:$port/execute" 2>/dev/null || echo "000")
+        if [[ "$code" != "200" ]]; then
+          rm -f "/tmp/rm_dead_body.$$"
+          echo "non-200"
+          return
+        fi
+        # 200 path: accept only if the body carries an error field;
+        # otherwise the failure was silently swallowed.
+        if grep -q '"error"' "/tmp/rm_dead_body.$$" 2>/dev/null; then
+          rm -f "/tmp/rm_dead_body.$$"
+          echo "error-body"
+        else
+          rm -f "/tmp/rm_dead_body.$$"
+          echo "swallowed"
+        fi
+      }
+      go_fail=$(probe_fail $GO_PORT)
+      java_fail=$(probe_fail $JAVA_PORT)
+      if [[ "$go_fail" != "swallowed" && "$java_fail" != "swallowed" ]]; then
+        rm_pass=$((rm_pass + 1))
+        echo "    [7] fail_on_error=true + dead redis → Go=$go_fail, Java=$java_fail"
+      else
+        fail "resource metrics: fail_on_error swallowed (Go=$go_fail, Java=$java_fail)"
+      fi
+    else
+      fail "resource metrics: servers failed to start (unreachable case)"
     fi
 
     kill $GO_PID $JAVA_PID 2>/dev/null || true

--- a/scripts/cross-validate/16-resource-metrics.sh
+++ b/scripts/cross-validate/16-resource-metrics.sh
@@ -289,6 +289,68 @@ else:
           fail "resource metrics: under-load state C++: $cpp_under_load"
         fi
       fi
+
+      # [3b] Audit M7: interval=-1 + probe cadence invariant.
+      #      Fetcher must run once at Start (no fetcher loop) and the probe
+      #      goroutine ticks every 15s — within a 2s window the ping count
+      #      must stay at 1 (just the immediate-after-Start probe) across
+      #      all three engines. This catches:
+      #        * a regression that interprets interval=-1 as "spin tightly"
+      #        * a regression that lowers / desyncs the probe period
+      #          (Go redisProbeInterval / Java PROBE_INTERVAL_SECONDS /
+      #           C++ kProbeInterval — all 15s)
+      #      The /execute requests above borrow the client but do not call
+      #      PING themselves, so they must not bump the gauge either.
+      sleep 2
+      GO_RES3=$(scrape_resources $GO_PORT)
+      JAVA_RES3=$(scrape_resources $JAVA_PORT)
+      CPP_RES3=""
+      $cpp_srv_ready && CPP_RES3=$(scrape_resources $CPP_PORT)
+      rm_total=$((rm_total + 1))
+      cadence=$(python3 -c "
+import json
+def cnt(s):
+    r = json.loads(s)
+    return r.get('pine_redis_ping_duration_seconds', {}).get('cache', {}).get('count')
+gc = cnt('''$GO_RES3''')
+jc = cnt('''$JAVA_RES3''')
+# Allow 1-2 in case the test machine raced the first PING tick at exactly
+# the wrong moment; cadence regressions show up as ≥3 within 2s.
+if gc is None or jc is None:
+    print(f'ping count missing: go={gc} java={jc}')
+elif gc not in (1, 2) or jc not in (1, 2):
+    print(f'ping count outside [1,2] within 2s: go={gc} java={jc}')
+else:
+    print(f'ok ({gc}/{jc})')
+")
+      if [[ "$cadence" == ok* ]]; then
+        rm_pass=$((rm_pass + 1))
+        echo "    [3b] probe cadence within 2s: ping count ∈ {1,2} ($cadence)"
+      else
+        fail "resource metrics: probe cadence (interval=-1) drifted: $cadence"
+      fi
+      if $cpp_srv_ready; then
+        cpp_rm_total=$((cpp_rm_total + 1))
+        cpp_cadence=$(python3 -c "
+import json
+def cnt(s):
+    r = json.loads(s)
+    return r.get('pine_redis_ping_duration_seconds', {}).get('cache', {}).get('count')
+cc = cnt('''$CPP_RES3''')
+if cc is None:
+    print('cpp ping count missing')
+elif cc not in (1, 2):
+    print(f'cpp ping count outside [1,2] within 2s: cpp={cc}')
+else:
+    print(f'ok (cpp={cc})')
+")
+        if [[ "$cpp_cadence" == ok* ]]; then
+          cpp_rm_pass=$((cpp_rm_pass + 1))
+          echo "    [3b] probe cadence within 2s C++: $cpp_cadence"
+        else
+          fail "resource metrics: probe cadence (interval=-1) C++: $cpp_cadence"
+        fi
+      fi
     else
       fail "resource metrics: servers failed to start (positive case)"
     fi

--- a/scripts/cross-validate/18-subflow-contract-stderr.sh
+++ b/scripts/cross-validate/18-subflow-contract-stderr.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Section 18: Apple SubFlow contract failure stderr shape (audit H3)
+#
+# SubFlow field-list contracts (issue #78) are enforced at Apple compile-time
+# only — the runtime engines never see the contract metadata. So this section
+# is structurally Apple-only: we run the same set of failing cases that
+# test_compiler.py::TestSubFlowContractEnforcement covers as unit tests and
+# pin the user-visible ValidationError surface (message prefix + stable
+# substring) at the integration layer. Without this section, a refactor that
+# changes the wording in apple/validator.py would only be caught by the
+# Apple unit suite — fixtures-driven smoke runs, downstream tooling that
+# parses these messages, and any "did the compiler error change?" gate
+# would silently drift.
+#
+# Each probe runs an independent python3 -c invocation that builds the
+# offending Flow, calls compile_flow, and asserts the raised ValidationError
+# stringifies to a message containing a known stable substring. Op names
+# carry a 6-hex-digit hash suffix that depends on call-site line numbers, so
+# we match against contract/SubFlow-name fragments which are deterministic.
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_env.sh"
+
+echo
+echo "==> [18/$TOTAL_SECTIONS] Apple SubFlow contract failure stderr (compile-time)"
+
+run_subflow_probe() {
+  local label="$1"
+  local expected_substr="$2"
+  local script="$3"
+  local out
+  out=$(python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT')
+from apple.flow import Flow, SubFlow
+from apple.compiler import compile_flow
+from apple.validator import ValidationError
+
+try:
+$script
+    print('NO_ERROR_RAISED')
+except ValidationError as e:
+    print('ERROR:' + str(e).replace(chr(10), ' | '))
+" 2>&1)
+  if [[ "$out" == NO_ERROR_RAISED ]]; then
+    fail "subflow-contract $label: compile_flow did not raise"
+    return
+  fi
+  if [[ "$out" != ERROR:* ]]; then
+    fail "subflow-contract $label: harness error"
+    printf '    output: %s\n' "$out" >&2
+    return
+  fi
+  if [[ "$out" == *"$expected_substr"* ]]; then
+    pass "subflow-contract $label: stderr contains expected fragment"
+  else
+    fail "subflow-contract $label: expected fragment missing"
+    printf '    expected substring: %s\n    got: %s\n' "$expected_substr" "$out" >&2
+  fi
+}
+
+# Probe 1: item_input field outside SubFlow contract.
+run_subflow_probe \
+  "item-input-missing" \
+  "item_input field 'y' not provided by SubFlow 'sf' contract" \
+  "
+    sf = SubFlow(name='sf', item_input=['x'])
+    sf._add_op('transform_by_lua', common_input=[], common_output=[],
+               item_input=['y'], item_output=['z'],
+               lua_script='function f() return 0 end',
+               function_for_item='f', function_for_common='')
+    flow = Flow(name='parent', item_input=['x','y'], item_output=['z'], sub_flows=[sf])
+    compile_flow(flow)
+"
+
+# Probe 2: nested SubFlow inherits outer contract (no own contract).
+run_subflow_probe \
+  "nested-inherits-outer" \
+  "item_input field 'bad' not provided by SubFlow 'outer' contract" \
+  "
+    inner = SubFlow(name='inner')
+    inner._add_op('transform_by_lua', common_input=[], common_output=[],
+                  item_input=['bad'], item_output=['z'],
+                  lua_script='function f() return 0 end',
+                  function_for_item='f', function_for_common='')
+    outer = SubFlow(name='outer', item_input=['x'], item_output=['z'])
+    outer.add_subflow(inner)
+    flow = Flow(name='parent', item_input=['x','bad'], item_output=['z'], sub_flows=[outer])
+    compile_flow(flow)
+"
+
+# Probe 3: dead op inside SubFlow (output not consumed within scope).
+run_subflow_probe \
+  "dead-op-inside-subflow" \
+  "SubFlow 'sf': dead operators" \
+  "
+    sf = SubFlow(name='sf', item_input=['x'], item_output=['z'])
+    sf._add_op('transform_by_lua', common_input=[], common_output=[],
+               item_input=['x'], item_output=['z'],
+               lua_script='function f() return 0 end',
+               function_for_item='f', function_for_common='')
+    sf._add_op('transform_by_lua', name='dead_op', common_input=[], common_output=[],
+               item_input=['x'], item_output=['extra'],
+               lua_script='function f() return 0 end',
+               function_for_item='f', function_for_common='')
+    flow = Flow(name='parent', item_input=['x'], item_output=['z','extra'], sub_flows=[sf])
+    compile_flow(flow)
+"
+
+# Probe 4: mixed contract — common satisfied, item missing.
+run_subflow_probe \
+  "mixed-item-missing" \
+  "item_input field 'missing_item' not provided by SubFlow 'sf' contract" \
+  "
+    sf = SubFlow(name='sf', common_input=['uid'], item_input=['x'],
+                 common_output=['greeting'], item_output=['z'])
+    sf._add_op('transform_by_lua', common_input=['uid'], common_output=['greeting'],
+               item_input=['missing_item'], item_output=['z'],
+               lua_script='function f() return 0 end',
+               function_for_item='f', function_for_common='')
+    flow = Flow(name='parent', common_input=['uid'], item_input=['x','missing_item'],
+                common_output=['greeting'], item_output=['z'], sub_flows=[sf])
+    compile_flow(flow)
+"
+
+# Probe 5: mixed contract — item satisfied, common missing.
+run_subflow_probe \
+  "mixed-common-missing" \
+  "common_input field 'missing_common' not provided by SubFlow 'sf' contract" \
+  "
+    sf = SubFlow(name='sf', common_input=['uid'], item_input=['x'],
+                 common_output=['greeting'], item_output=['z'])
+    sf._add_op('transform_by_lua', common_input=['missing_common'], common_output=['greeting'],
+               item_input=['x'], item_output=['z'],
+               lua_script='function f() return 0 end',
+               function_for_item='f', function_for_common='')
+    flow = Flow(name='parent', common_input=['uid','missing_common'], item_input=['x'],
+                common_output=['greeting'], item_output=['z'], sub_flows=[sf])
+    compile_flow(flow)
+"
+
+# Probe 6: template field referenced inside SubFlow whose contract doesn't
+# include it (#74 + #78 cross — the SubFlow validator unions the three
+# common_input buckets).
+run_subflow_probe \
+  "template-outside-subflow-contract" \
+  "common_input field 'other_id' not provided by SubFlow 'sf' contract" \
+  "
+    sf = SubFlow(name='sf', common_input=['user_id'], item_input=['x'],
+                 common_output=['greeting'], item_output=['z'])
+    sf._add_op('synthetic_templated_op', common_input=[], common_output=['greeting'],
+               item_input=[], item_output=[], key_template='hi {{other_id}}')
+    sf._add_op('transform_by_lua', common_input=[], common_output=[],
+               item_input=['x'], item_output=['z'],
+               lua_script='function f() return 0 end',
+               function_for_item='f', function_for_common='')
+    flow = Flow(name='parent', common_input=['user_id','other_id'], item_input=['x'],
+                common_output=['greeting'], item_output=['z'], sub_flows=[sf])
+    compile_flow(flow)
+"
+
+# Probe 7: real common_input field inside an if branch still gated by the
+# SubFlow contract — underscore filter only exempts skip-control fields.
+run_subflow_probe \
+  "if-branch-real-field-still-checked" \
+  "common_input field 'secret' not provided by SubFlow 'sf' contract" \
+  "
+    sf = SubFlow(name='sf', common_input=['enabled'], item_input=['x'], item_output=['x'])
+    sf.if_('{{enabled}} ~= nil')._add_op(
+        'transform_by_lua', common_input=['secret'],
+        item_input=['x'], item_output=['x'],
+        lua_script='function f() return secret end',
+        function_for_item='f', function_for_common='').end_if_()
+    flow = Flow(name='parent', common_input=['enabled','secret'], item_input=['x'],
+                item_output=['x'], sub_flows=[sf])
+    compile_flow(flow)
+"
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && exit $_CV_FAIL || true

--- a/scripts/cross-validate/19-bench-stub-parity.sh
+++ b/scripts/cross-validate/19-bench-stub-parity.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Section 19: bench-stub byte-equal reorder parity (audit H8)
+#
+# The bench stub family (`reorder_topn_boost`, `recall_feed_data`,
+# `transform_redis_zrangebyscore`, ...) is gated behind per-runtime
+# build/launch flags so production binaries never see them:
+#   pine-go    → -tags pine_bench
+#   pine-java  → -Dpine.bench=true
+#   pine-cpp   → -DPINE_BUILD_BENCH_STUBS=ON
+# Their primary purpose is throughput-only synthetic load, so the
+# `realistic_for_you_*` fixtures are intentionally fixture-bare (no
+# `cases/expected`). H8 closes the audit gap by pinning the one stub
+# that does real work — `reorder_topn_boost` (FNV-1a salted hash sort
+# + top-N front boost) — with a byte-equal `cases/expected` fixture,
+# `fixtures/pipelines/reorder_topn_boost_parity.json` (`requires:
+# ["bench"]`, so Section 03 skips it). The shape of this section
+# mirrors 03 but uses the bench-enabled binaries built here.
+#
+# A new build_dir is used for cpp so we don't trample the
+# PINE_BUILD_BENCH_STUBS=OFF objects produced by _prebuild.sh.
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_env.sh"
+
+echo
+echo "==> [19/$TOTAL_SECTIONS] Bench-stub byte-equal reorder parity (Go/Java/C++ all bench-enabled)"
+
+FIXTURE="$REPO_ROOT/fixtures/pipelines/reorder_topn_boost_parity.json"
+if [[ ! -f "$FIXTURE" ]]; then
+  fail "fixture missing: $FIXTURE"
+  [[ "${BASH_SOURCE[0]}" == "${0}" ]] && exit $_CV_FAIL || true
+  return 0
+fi
+
+BENCH_WORK="$WORK_DIR/bench"
+mkdir -p "$BENCH_WORK"
+BENCH_LOG="$BENCH_WORK/build.log"
+
+echo "    Building bench-enabled Go binary (-tags pine_bench)..."
+if ! (cd "$REPO_ROOT/pine-go" && go build -tags pine_bench -o "$BENCH_WORK/pineapple-run-bench" ./cmd/pineapple-run/) >"$BENCH_LOG" 2>&1; then
+  fail "Go bench build failed (last 30 lines $BENCH_LOG):"
+  tail -n 30 "$BENCH_LOG" >&2 || true
+  [[ "${BASH_SOURCE[0]}" == "${0}" ]] && exit $_CV_FAIL || true
+  return 0
+fi
+
+echo "    Building bench-enabled C++ binary (-DPINE_BUILD_BENCH_STUBS=ON)..."
+CPP_BENCH_BUILD="$REPO_ROOT/pine-cpp/build-bench"
+mkdir -p "$CPP_BENCH_BUILD"
+if ! (cd "$CPP_BENCH_BUILD" \
+        && cmake .. -DCMAKE_BUILD_TYPE=Release -DPINE_BUILD_BENCH_STUBS=ON 2>&1 \
+        && make -j2 pineapple-run 2>&1) >>"$BENCH_LOG" 2>&1; then
+  fail "C++ bench build failed (last 50 lines $BENCH_LOG):"
+  tail -n 50 "$BENCH_LOG" >&2 || true
+  [[ "${BASH_SOURCE[0]}" == "${0}" ]] && exit $_CV_FAIL || true
+  return 0
+fi
+cp "$CPP_BENCH_BUILD/pineapple-run" "$BENCH_WORK/pineapple-run-bench-cpp"
+
+# Java: existing classes already include BenchStubs; we only need the
+# -Dpine.bench=true system property at launch (AllOperators.java:305).
+# No extra compile step required.
+
+# Extract config + per-case requests/expected.
+python3 -c "
+import json
+with open('$FIXTURE') as f:
+    data = json.load(f)
+cfg = data.get('config', {})
+with open('$BENCH_WORK/config.json', 'w') as cf:
+    json.dump(cfg, cf)
+cases = data.get('cases', [])
+for i, c in enumerate(cases):
+    with open('$BENCH_WORK/req_%d.json' % i, 'w') as rf:
+        json.dump(c.get('request', {}), rf)
+    with open('$BENCH_WORK/expected_%d.json' % i, 'w') as ef:
+        json.dump(c.get('expected', {}), ef)
+print(len(cases))
+" >"$BENCH_WORK/case_count.txt"
+
+cases=$(cat "$BENCH_WORK/case_count.txt")
+if [[ -z "$cases" || "$cases" == "0" ]]; then
+  fail "fixture has no cases"
+  [[ "${BASH_SOURCE[0]}" == "${0}" ]] && exit $_CV_FAIL || true
+  return 0
+fi
+
+case_results_g=""
+case_results_j=""
+case_results_c=""
+total_pass=0
+total_runs=0
+
+for ((i=0; i<cases; i++)); do
+  cfg_file="$BENCH_WORK/config.json"
+  req_file="$BENCH_WORK/req_${i}.json"
+  exp_file="$BENCH_WORK/expected_${i}.json"
+  out_g="$BENCH_WORK/out_${i}.go.json"
+  out_j="$BENCH_WORK/out_${i}.java.json"
+  out_c="$BENCH_WORK/out_${i}.cpp.json"
+  err_g="$BENCH_WORK/out_${i}.go.err"
+  err_j="$BENCH_WORK/out_${i}.java.err"
+  err_c="$BENCH_WORK/out_${i}.cpp.err"
+
+  # Go (bench-enabled)
+  if "$BENCH_WORK/pineapple-run-bench" -config "$cfg_file" -request "$req_file" >"$out_g" 2>"$err_g"; then
+    go_rc=0
+  else
+    go_rc=$?
+  fi
+
+  # Java (system-property gated)
+  if java_run -Dpine.bench=true page.liam.pine.RunCli -config "$cfg_file" -request "$req_file" >"$out_j" 2>"$err_j"; then
+    java_rc=0
+  else
+    java_rc=$?
+  fi
+
+  # C++ (bench-built)
+  if "$BENCH_WORK/pineapple-run-bench-cpp" -config "$cfg_file" -request "$req_file" >"$out_c" 2>"$err_c"; then
+    cpp_rc=0
+  else
+    cpp_rc=$?
+  fi
+
+  exp_norm=$(cat "$exp_file" | normalize_json)
+
+  for tag in g j c; do
+    case "$tag" in
+      g) rc="$go_rc";   out_file="$out_g";   err_file="$err_g";   label=Go ;;
+      j) rc="$java_rc"; out_file="$out_j";   err_file="$err_j";   label=Java ;;
+      c) rc="$cpp_rc";  out_file="$out_c";   err_file="$err_c";   label=C++ ;;
+    esac
+    total_runs=$((total_runs + 1))
+    if [[ "$rc" != "0" ]]; then
+      fail "$label execution failed (case $i, rc=$rc):"
+      tail -n 20 "$err_file" >&2 || true
+      eval "case_results_${tag}+=\"✗\""
+      continue
+    fi
+    got_norm=$(cat "$out_file" | normalize_json)
+    if [[ "$got_norm" == "$exp_norm" ]]; then
+      total_pass=$((total_pass + 1))
+      eval "case_results_${tag}+=\"✓\""
+    else
+      fail "$label diverged from expected (case $i)"
+      diff <(echo "$got_norm" | python3 -m json.tool) <(echo "$exp_norm" | python3 -m json.tool) >&2 || true
+      eval "case_results_${tag}+=\"✗\""
+    fi
+  done
+done
+
+echo "    reorder_topn_boost_parity.json ($cases cases) [G${case_results_g}J${case_results_j}C${case_results_c}]"
+
+if [[ $total_runs -gt 0 && $total_pass -eq $total_runs ]]; then
+  pass "bench-stub byte-equal reorder parity (Go/Java/C++ all match expected, $total_pass/$total_runs)"
+fi
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && exit $_CV_FAIL || true

--- a/scripts/differential-fuzz.py
+++ b/scripts/differential-fuzz.py
@@ -239,6 +239,21 @@ def gen_operator(rng: random.Random, name: str,
         "merge_dedup", "reorder_shuffle_by_salt", "filter_paginate",
         "transform_resource_lookup", "recall_resource",
     ]
+    # Deliberately excluded from random op generation (audit L3):
+    # * transform_bench_cpu / transform_bench_sleep / reorder_topn_boost and
+    #   the rest of the bench-stub family — these are throughput-only stubs
+    #   gated by build flags (Go pine_bench tag, Java -Dpine.bench=true,
+    #   C++ PINE_BUILD_BENCH_STUBS=ON) and intentionally have no
+    #   cases/expected fixture surface. Including them would force the
+    #   cross-runtime oracle to reason about timing-derived outputs that
+    #   are not part of the engine's pure-function contract. byte-equal
+    #   work parity is locked separately by fixtures/pipelines/
+    #   bench_cpu_work_parity.json (audit M12).
+    # * transform_redis_get / transform_redis_set — depend on a live
+    #   redis-server. Combinatorial coverage lives in
+    #   scripts/cross-validate/11-redis-integration.sh; H11 in the
+    #   coverage audit tracks the open question of whether to run a
+    #   dedicated redis diff-fuzz in nightly.
     op_type = rng.choice(op_types)
 
     item_in: list[str] = []

--- a/scripts/differential-fuzz.py
+++ b/scripts/differential-fuzz.py
@@ -19,6 +19,8 @@ Randomization dimensions:
   - Resource operators (transform_resource_lookup, recall_resource with static resource_config)
   - merge_dedup, reorder_shuffle_by_salt, filter_paginate operators
   - transform_copy all 4 directions (common_to_item, item_to_common, common_to_common, item_to_item)
+  - Templatable params (PR #74): filter_truncate.top_n optionally rendered as
+    `{{field}}` with the source value injected into request.common
 
 Usage:
     python3 scripts/differential-fuzz.py [--rounds N] [--seed S] [--engines go,java,cpp]
@@ -242,6 +244,7 @@ def gen_operator(rng: random.Random, name: str,
     item_in: list[str] = []
     item_out: list[str] = []
     common_in: list[str] = []
+    common_in_template: list[str] = []
     common_out: list[str] = []
 
     config: dict[str, Any] = {"type_name": op_type}
@@ -252,7 +255,16 @@ def gen_operator(rng: random.Random, name: str,
         config["data_parallel"] = dp
 
     if op_type == "filter_truncate":
-        config["top_n"] = rng.randint(1, 30)
+        # ~20% chance: use {{field}} template for top_n (PR #74 templatable param).
+        # Forces the runtime template-resolution path to be exercised under fuzz,
+        # not just static fixtures (audit gap H1).
+        if rng.random() < 0.20:
+            tmpl_name = f"_fuzz_tmpl_top_n_{name}"
+            config["top_n"] = "{{" + tmpl_name + "}}"
+            config["_fuzz_template_common_field"] = (tmpl_name, rng.randint(1, 30))
+            common_in_template = [tmpl_name]
+        else:
+            config["top_n"] = rng.randint(1, 30)
         item_in = prev_item_outputs[:2] if prev_item_outputs else []
 
     elif op_type == "filter_condition":
@@ -469,6 +481,8 @@ def gen_operator(rng: random.Random, name: str,
         "item_input": item_in,
         "item_output": item_out,
     }
+    if common_in_template:
+        config["$metadata"]["common_input_template"] = common_in_template
 
     # Randomly add defaults for declared input fields (20% chance each)
     if rng.random() < 0.2 and item_in:
@@ -609,6 +623,15 @@ def gen_pipeline(rng: random.Random) -> tuple[dict, dict, list[dict], bool]:
                 common_outputs.append("_fuzz_page")
             if "_fuzz_size" not in common_outputs:
                 common_outputs.append("_fuzz_size")
+
+        # Handle templatable params: inject template-source field into common
+        # so that {{field}} resolution at runtime can read the value (PR #74).
+        tmpl_field = op_config.pop("_fuzz_template_common_field", None)
+        if tmpl_field is not None:
+            tmpl_name, tmpl_val = tmpl_field
+            common[tmpl_name] = tmpl_val
+            if tmpl_name not in common_outputs:
+                common_outputs.append(tmpl_name)
 
         # Collect resource configs from resource operators
         fuzz_resource = op_config.pop("_fuzz_resource", None)
@@ -1282,7 +1305,8 @@ def main():
              "request_items": 0, "resources": 0, "debug": 0, "return_trace": 0,
              "sources": 0, "defaults": 0, "sparse_items": 0,
              "merge_dedup": 0, "shuffle_by_salt": 0, "paginate": 0,
-             "resource_lookup": 0, "recall_resource": 0}
+             "resource_lookup": 0, "recall_resource": 0,
+             "templated": 0}
     start_time = time.time()
 
     def _progress(i: int):
@@ -1370,6 +1394,11 @@ def main():
                         for op in ops.values()
                     ):
                         stats["defaults"] += 1
+                    if any(
+                        op.get("$metadata", {}).get("common_input_template")
+                        for op in ops.values()
+                    ):
+                        stats["templated"] += 1
 
                 with open(config_file, "w") as f:
                     json.dump(config, f, ensure_ascii=False)
@@ -1581,6 +1610,7 @@ def main():
     print(
         f"            resource_lookup={stats['resource_lookup']}"
         f" recall_resource={stats['recall_resource']}"
+        f" templated={stats['templated']}"
     )
     # Stratified summary:
     print(

--- a/scripts/differential-fuzz.py
+++ b/scripts/differential-fuzz.py
@@ -787,6 +787,44 @@ def gen_pipeline(rng: random.Random) -> tuple[dict, dict, list[dict], bool]:
     else:
         group_pipeline = pipeline
 
+    # ~30% chance: decorate each SubFlow entry with field-list contracts
+    # (common_input/item_input/common_output/item_output). These mirror the
+    # SubFlow contracts emitted by the Apple compiler (issue #78) — they
+    # are validated at compile time but ignored by all three runtimes,
+    # which only read `pipeline`. Injecting them here exercises the
+    # forward-compat boundary: every runtime parser must tolerate the
+    # extra keys without erroring or letting them leak into operator
+    # bookkeeping. Without this, nightly fuzz never observed pipeline_map
+    # entries with anything but `pipeline`. (Audit gap H4.)
+    if pipeline_map and rng.random() < 0.3:
+        # Map operator name -> its $metadata fields, for picking plausible
+        # contract subsets. Skip pipeline_map entries that recurse into
+        # other SubFlows; we only collect direct-leaf operator metadata.
+        op_meta = {n: o.get("$metadata", {}) for n, o in operators.items()}
+        for sf_name, sf_entry in pipeline_map.items():
+            members = sf_entry["pipeline"]
+            ci, ii, co, io = set(), set(), set(), set()
+            for m in members:
+                meta = op_meta.get(m)
+                if not meta:
+                    # Nested SubFlow reference; skip — its own iteration
+                    # will fill its contract.
+                    continue
+                ci.update(meta.get("common_input", []))
+                ii.update(meta.get("item_input", []))
+                co.update(meta.get("common_output", []))
+                io.update(meta.get("item_output", []))
+            # Only emit non-empty buckets — empty lists would still be
+            # parsed but provide zero fuzz signal beyond the key presence.
+            if ci:
+                sf_entry["common_input"] = sorted(ci)
+            if ii:
+                sf_entry["item_input"] = sorted(ii)
+            if co:
+                sf_entry["common_output"] = sorted(co)
+            if io:
+                sf_entry["item_output"] = sorted(io)
+
     # Randomly inject storage_mode
     # 50/50 storage_mode split. The prior 75% row / 25% column bias
     # was inherited from when pine-cpp lacked a RowFrame

--- a/scripts/differential-fuzz.py
+++ b/scripts/differential-fuzz.py
@@ -240,15 +240,23 @@ def gen_operator(rng: random.Random, name: str,
         "transform_resource_lookup", "recall_resource",
     ]
     # Deliberately excluded from random op generation (audit L3):
-    # * transform_bench_cpu / transform_bench_sleep / reorder_topn_boost and
-    #   the rest of the bench-stub family — these are throughput-only stubs
-    #   gated by build flags (Go pine_bench tag, Java -Dpine.bench=true,
-    #   C++ PINE_BUILD_BENCH_STUBS=ON) and intentionally have no
-    #   cases/expected fixture surface. Including them would force the
-    #   cross-runtime oracle to reason about timing-derived outputs that
-    #   are not part of the engine's pure-function contract. byte-equal
-    #   work parity is locked separately by fixtures/pipelines/
-    #   bench_cpu_work_parity.json (audit M12).
+    # * transform_bench_cpu / transform_bench_sleep — production operators
+    #   (no build-tag gating; package transform, registered unconditionally
+    #   in all three runtimes), but their outputs encode synthetic CPU/
+    #   sleep work whose absolute values are deterministic only under
+    #   matching iteration counts. byte-equal work parity is locked by
+    #   fixtures/pipelines/bench_cpu_work_parity.json (audit M12) running
+    #   through Section 03; random fuzz would have to reason about the
+    #   work-quantity arithmetic, which adds no signal beyond M12.
+    # * reorder_topn_boost and the rest of the bench-stub family
+    #   (recall_feed_data, transform_redis_zrangebyscore, observe_datahub,
+    #   transform_generate_request_id, ...) — gated by build flags
+    #   (Go pine_bench tag, Java -Dpine.bench=true, C++
+    #   PINE_BUILD_BENCH_STUBS=ON) and have no cases/expected on the
+    #   throughput-only realistic_for_you_*.json fixtures. byte-equal
+    #   reorder parity for the one stub that does real work
+    #   (reorder_topn_boost) is locked by reorder_topn_boost_parity.json
+    #   running through Section 19 with bench-enabled binaries.
     # * transform_redis_get / transform_redis_set — depend on a live
     #   redis-server. Combinatorial coverage lives in
     #   scripts/cross-validate/11-redis-integration.sh; H11 in the


### PR DESCRIPTION
## Summary

- 收口 v0.9.0..HEAD 共 38 项测试覆盖审计点 (H1-H12, M1-M18 + 2 extras, L1-L8)
- 39 commits,严格按域单一隔离 (pine-go / pine-java / pine-cpp / apple / scripts / fixtures / llmdoc)
- 不引入新功能,纯测试/CI/fixture/llmdoc 文档补齐

审计来源:`.code-review/from-v0.9.0-test-coverage-audit/progress.md`,基于自 `v0.9.0` 以来 51 feat + 31 perf 共 303 commits 的三路并行测试缺口调查。

## 主要锁线

**Apple 编译期** (H1-H4, H12, M1-M5, L1-L2, L8)
- `{{field}}` 模板 fuzz 注入 + schema parity `templatable` 字段 + nightly schema gate
- SubFlow 契约失败 stderr 形态 (Section 18) + 三桶 union 路径 + 嵌套 multi-skip 交叉
- explicit-null 标量参数拒绝 (Apple validator 层补齐 parity)
- 旧 `RedisParams/shared_pool` 反向负向编译测试

**运行时可观测性** (H5-H8, H10, M6-M8, M10-M12, L7)
- `lua_pool.reuse_count` 跨 runtime 字节级 diff (Section 13 [10])
- pprof 信息泄漏面 admin/main mux 边界单测 + 三 runtime 主端口 404 parity
- `/stats.resources` 三态 (无流量/有量/不可达) + `interval=-1` 三方对等
- `transform_bench_cpu` 字节级 work parity fixture
- `reorder_topn_boost` bench-stub byte-equal Section 19 (三 runtime 自构建 bench-enabled)
- per-request bump arena doctest

**pine-cpp DAG/perf** (H9, M13, M15, M17, M-extra-2, L4-L6)
- ready-queue seed loop 竞态 TSan smoke job
- mid-flight cancel + immediate destroy race-free
- 5+ 列 reorder visited bitmap reuse + 列退化 promotion 分支
- 16 线程并发 `Engine::execute` 同 Plan 安全
- `dump_json` 字典序排序不变量 + `FlatMap::reserve` 语义未漂移
- name-hiding 派生类静态类型 1-arg reorder 编译期钉

**跨 runtime 数据帧** (M14-M16, M18, M-extra-1)
- TCP-disconnect cancel parity (Section 07 [3])
- K=10 column 并发 + remove + reorder
- RemoveItem + SetItemOrder post-compact index chain (Go/Java)
- lazy OperatorInput shard race-safety (Go/Java)

## 三项用户裁决项

- **H8** 单算子 fixture (`reorder_topn_boost`) + Section 19 自构建 bench-enabled
- **H11** 放弃随机探索,fixture-only (基础路径由 Section 11 锁住)
- **M9** Lua pool 上限/GC-bound 跨 runtime 设计差异挂 issue [#91](https://github.com/Liam0205/pineapple/issues/91) follow-up

## Test plan

- [ ] `bash scripts/cross-validate.sh` 全 19 sections (Section 19 bench-stub byte-equal 新增)
- [ ] `cd pine-go && go test ./...`
- [ ] `cd pine-java && mvn test -B`
- [ ] `cd pine-cpp && cmake --build build && ctest --test-dir build`
- [ ] `cd apple && pytest`
- [ ] CI: cpp-tsan smoke job 通过 (新增)
- [ ] CI: nightly-diff-fuzz workflow 含新 schema gate