### PR TITLE
ci(cpp-tsan): print full TSan report on failure (refs #96)

### DIFF
--- a/scripts/cpp-tsan-smoke.sh
+++ b/scripts/cpp-tsan-smoke.sh
@@ -108,7 +108,13 @@ else:
         for pid in "${pids[@]}"; do
             if ! wait "$pid"; then
                 echo "    pineapple-run failed under TSan (iter=$iter, fixture=$subdir/$fname)" >&2
-                tail -n 60 "$WORK_DIR/run.err" >&2 || true
+                # Print the full run.err so the WARNING head + read/write
+                # stacks survive — TSan reports for high-fanout fixtures
+                # (6-root DAG / 4-way parallel) can exceed 200 lines, and a
+                # tail-truncated report drops the very lines a fix needs
+                # (Read of size N at 0xDEAD by main thread / Previous write
+                # of size N at 0xDEAD by thread T1).
+                cat "$WORK_DIR/run.err" >&2 || true
                 exit 1
             fi
         done


### PR DESCRIPTION
Diagnostic-channel widening for issue #96 (cpp-tsan flake at `RowFrame::to_result`).

The script prints the full TSan stderr on failure instead of `tail -n 60`.
ThreadSanitizer reports for the high-fanout fixtures span 80+ lines —
truncation drops the leading "Read of size N / Previous write of size N"
heads, which are the only lines that name the racing field. On the
`cb58e08` failure those heads are gone from the run log forever.

This PR does **not** fix the race itself. The race window is
GHA-runner-timing specific (~0.25 %/trial, 0 hits across 8000+ local
trials including a 5ms window-amplification probe). Once this lands and
CI naturally surfaces the race again, issue #96 gets the full TSan output
posted as a comment, then a targeted fix follows in a separate PR.

Cost: a few hundred extra lines of CI log when the smoke fails. On
success `cat` is never invoked (gated by `wait $pid` returning non-zero),
so green runs are unchanged.

Refs #96
