### PR TITLE
docs: 自动更新 llmdoc 文档 (2026-06-13)

### DIFF
--- a/llmdoc/guides/ci-quality-baseline.md
+++ b/llmdoc/guides/ci-quality-baseline.md
@@ -41,6 +41,19 @@
 
 Benchmark job 将 `go test -bench` 输出写入 `benchmark.txt`，同时追加到 `$GITHUB_STEP_SUMMARY` 供 PR/CI 页面直接查看；artifact 作为可下载原始结果保留。
 
+## 统一任务入口（Makefile）
+
+仓库提供顶层 `Makefile` 与 `pine-go/Makefile` 作为本地与 CI 共用的统一任务入口，封装跨四语言的格式化 / lint / test / bench / codegen / 版本管理等命令。目标列表以 `make help`（或两个 Makefile 自身）为准，禁止在本指南中硬编码完整清单。常用入口示例：
+
+- `make all` — 本地提交前全检（`fmt-check lint test codegen-check`，不含 cross-validate / differential-fuzz / fuzz 等慢 job）
+- `make fmt` / `make fmt-check` — 各语言格式化写回 / dry-run（CI 用，任何 diff 即 fail）
+- `make lint` / `make test` / `make bench` / `make codegen` — 全语言 lint / 测试 / benchmark / codegen
+- `make bench-lua-backends` — wangshu vs gopher-lua 后端对比（见 `llmdoc/reference/lua-backend.md`）
+- `make hooks` — 安装 git hooks（等价 `git config core.hooksPath .githooks`）
+- `make bump VERSION=X.Y.Z` / `make tag-release` — 跨 5 处同步版本号 + 全验 / 创建并推送双 tag
+
+CI 的多个 job 直接调用这些 make target（如 `make go-cover` / `make cpp-test` / `make cross-validate` / `make codegen-check` / `make bench`），使本地与流水线执行同一份命令序列、避免 CI 内联命令与本地操作漂移。`make bench` 默认走 `pine-go/benchmarks/` 独立子 module 并带 `-tags=pine_bench`，`TAGS` 追加在其上（如 `make bench TAGS=lua_gopher` 切换对照后端）。复杂跨语言序列（如 pine-cpp 的 cmake/ctest）抽取到 `scripts/` 下脚本（如 `scripts/cpp-test.sh`），由 make target 调用。
+
 ## Go lint
 
 工具：`golangci-lint`，配置位于 `.golangci.yml`。

--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -19,7 +19,7 @@
 ## guides/
 
 - `llmdoc/guides/standard-workflow.md` — 标准工作流程：llmdoc 加载、plan mode 对齐、任务跟踪、逐步验证、文档同步。
-- `llmdoc/guides/ci-quality-baseline.md` — CI 工程质量基线：lint（含 Java checkstyle `failOnViolation=true` + `OneStatementPerLine`、C++ clang-format）/ test / coverage / fuzz / differential-fuzz / cross-validate / nightly cross-runtime benchmark / release-gate 架构与接入约定（含 pine-cpp 的 4 个 CI job 与 cross-validate cpp 二进制注入路径），以及本地 `.githooks/` 体系（`pre-commit` staged-only 格式 gate + `pre-push` 工程级 lint + 自包装 CI watch）。
+- `llmdoc/guides/ci-quality-baseline.md` — CI 工程质量基线：lint（含 Java checkstyle `failOnViolation=true` + `OneStatementPerLine`、C++ clang-format）/ test / coverage / fuzz / differential-fuzz / cross-validate / nightly cross-runtime benchmark / release-gate 架构与接入约定（含 pine-cpp 的 4 个 CI job 与 cross-validate cpp 二进制注入路径），统一任务入口 Makefile 体系（顶层 + `pine-go/` Makefile 封装跨四语言 fmt/lint/test/bench/codegen/版本管理，CI 与本地共用同一命令序列、`make bench` 默认 `pine_bench` tag），以及本地 `.githooks/` 体系（`pre-commit` staged-only 格式 gate + `pre-push` 工程级 lint + 自包装 CI watch）。
 - `llmdoc/guides/investigation-to-fix-testing.md` — 从调查到修复的测试策略：按缺陷类型选择测试层、最小修复面原则。
 - `llmdoc/guides/cross-layer-validation.md` — 跨层语义校验：JSON 边界类型枚举、codegen 语义验证、边界值 E2E、隐含 metadata 契约检测、扩展点对等验证（能力等价）。
 - `llmdoc/guides/benchmark-hygiene.md` — Benchmark 噪声卫生：跑前/跑后 load 与残留进程检查、同日同机对照纪律、±5-7% 二进制布局噪声与 perf stat 交叉验证、fixture 代表性（calibrated 为性能决策唯一裁判）、microbench 访问模式戒律、逐 op 删除归因法、测量路径对称性（PureVM vs CallOnly vs Boundary 不可互推）。


### PR DESCRIPTION
## llmdoc 文档自动更新

由 GitHub Actions 定时任务自动生成，基于过去 24 小时合并到 `master` 分支的代码变更。

### 本次更新内容

过去 24 小时（33 commits）的核心代码变更——wangshu 后端引入、Backend/Pool/Engine 三层抽象、CallInto 零分配边界、默认后端翻转为 wangshu、pin-table 泄漏修复——**已由同窗口内的 `docs(llmdoc)` 提交（`b3f104a`/`9d77799`/`e7d31ec`）覆盖**（见 `reference/lua-backend.md` 与两篇 wangshu reflection）。

本 PR 仅补充一处尚未文档化的开发者工作流变更：

- **统一 Makefile 任务入口体系**（`816e94f`/`d9a1526`/`dcd2f87`/`2b71fad`）：新增顶层 `Makefile` + `pine-go/Makefile`，封装跨四语言的 fmt/lint/test/bench/codegen/版本管理；CI 多个 job 改走 make target（`make go-cover`/`make cpp-test`/`make cross-validate`/`make codegen-check`/`make bench`），本地与流水线共用同一命令序列。
  - `guides/ci-quality-baseline.md`：新增「统一任务入口（Makefile）」一节
  - `index.md`：更新该 guide 描述

纯 bug 修复 / 重构 / 版本 bump / CI 配置微调按 skill 约定跳过。

**请检查文档内容是否准确后合并。**