### PR TITLE
fix(pine-cpp): close DAG completion-latch use-after-scope race in run_dag

### DIFF
--- a/pine-cpp/src/runtime/engine.cpp
+++ b/pine-cpp/src/runtime/engine.cpp
@@ -794,9 +794,20 @@ std::vector<OpTrace> run_dag(const Config& config, const Graph& graph,
 
   // Completion latch: counts down from n. When it reaches 0, all nodes
   // have finished (either executed or skipped due to cancellation).
+  //
+  // `done` (guarded by done_mu) — not the bare `remaining` atomic — is the
+  // wait predicate. The last worker to finish must set `done` while holding
+  // done_mu and notify under the lock, so the main thread cannot leave the
+  // wait until that worker has released done_mu. Without this, a worker could
+  // decrement `remaining` to 0 (waking the main thread) but still be inside
+  // its notify path touching done_mu/done_cv when run_dag returns and those
+  // stack locals are destroyed — a use-after-scope race (TSan: a worker read
+  // of a run_dag stack slot racing a downstream to_result write that reused
+  // the same stack address).
   std::atomic<std::size_t> remaining{n};
   std::mutex done_mu;
   std::condition_variable done_cv;
+  bool done = false;
 
   std::function<void(std::size_t)> node_body;
 
@@ -820,7 +831,14 @@ std::vector<OpTrace> run_dag(const Config& config, const Graph& graph,
       }
     }
     if (remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      // Last node done. Set the predicate and notify under done_mu so the
+      // main thread's wait cannot return until we release the lock — this is
+      // what keeps our access to done_mu/done_cv ordered before run_dag's
+      // stack teardown. Notifying outside the lock (or relying on the bare
+      // `remaining` atomic as the predicate) leaves a window where the woken
+      // main thread destroys these locals while we're still touching them.
       std::lock_guard<std::mutex> lk(done_mu);
+      done = true;
       done_cv.notify_all();
     }
   };
@@ -974,10 +992,13 @@ std::vector<OpTrace> run_dag(const Config& config, const Graph& graph,
     }
   }
 
-  // Wait for all nodes to complete.
+  // Wait for all nodes to complete. The predicate reads `done` (guarded by
+  // done_mu), so this returns only after the last worker released done_mu in
+  // propagate_and_signal — ensuring no worker is still touching these stack
+  // locals when run_dag returns and destroys them.
   {
     std::unique_lock<std::mutex> lk(done_mu);
-    done_cv.wait(lk, [&] { return remaining.load(std::memory_order_acquire) == 0; });
+    done_cv.wait(lk, [&] { return done; });
   }
 
   auto dag_end = std::chrono::steady_clock::now();


### PR DESCRIPTION
## Summary

Fixes the intermittent `cpp-tsan` failure that has recurred on master (#96, and again on the 0.10.2 bump commit). This time the TSan report came through **untruncated** (thanks to a0333b7), pinning the root cause.

**The race**: `RowFrame::to_result` (`row_frame.cpp:258`, the `Result r` stack local) written by the main thread races a dag_pool worker's read of a `run_dag` stack slot at the same reused address. Trigger: `barrier_transform_reorder.json` (4-root DAG, **no data_parallel**), iter 18/50.

**Root cause** — classic "condvar destroyed while notifying" + stack reuse:
- `propagate_and_signal` decremented the completion latch `remaining` with an acq_rel atomic **outside** `done_mu`, and the main thread's `done_cv.wait` predicate read that bare atomic.
- The last worker drops `remaining` to 0 (waking the main thread) while still **between** the decrement and its `lock_guard(done_mu) + notify_all`.
- The woken main thread returns from `run_dag`, tearing down `done_mu`/`done_cv`/`remaining`; the worker then touches `done_mu` on freed stack, and that address gets reused by the downstream `to_result` `Result r`.
- dag_pool workers are long-lived (per-request, never joined), so the latch — not a join — is the only ordering point, and it had a hole.

**Fix**: gate the wait on a `bool done` set under `done_mu`; the last worker sets `done` + `notify_all` while holding `done_mu`. The main thread must re-acquire `done_mu` to leave the wait, forcing the worker's lock release to happen-before `run_dag`'s stack teardown. `remaining` stays as the atomic "am I last?" detector; `done` is the lock-guarded predicate. 3 real lines + comments.

This also overturns the earlier window-view-aliasing hypothesis on #96: the real cause is this latch race (independent of data_parallel / window views), which is why it reproduces with a no-data_parallel fixture and never reproduces locally when dag_pool runs everything inline.

## Test plan

- [x] 211 doctests pass
- [x] trigger fixture run 1600x (200 iter × 8 = 4× the CI strength that reproduced it) under TSan: **zero races**
- [x] full `cpp-tsan-smoke.sh` at 4× stress across all high-fanout fixtures + 200-concurrent server burst: clean
- [ ] CI green

Closes #96.

## Follow-up (not in this PR)

The `make_window_view` double-lock aliasing (view instance guards parent's `items_` with its own `mu_`) is a separate structural concern surfaced during this investigation — not the cause of this crash, but worth tracking. Filing a backlog issue.