### PR TITLE
perf(pine-go/lua): typed-array fast path for Go int + releaseSlots style polish (#116)

### DIFF
--- a/pine-go/operators/lua/pool_wangshu.go
+++ b/pine-go/operators/lua/pool_wangshu.go
@@ -340,11 +340,16 @@ func (e *wangshuEngine) releaseFnCache() {
 // 量不同 name 的 slot 时应配套". A long-lived pool state would otherwise
 // accumulate one pin slot per (borrow, ItemInput field name) pair across QPS.
 // Repeated Release is safe (idempotent), so unconditional clear is OK.
+//
+// Dropping the map reference (rather than ranging+delete) lets the next
+// SetGlobal lazy-rebuild via the existing `if e.slots == nil` guard, so the
+// "clear the cache" intent stays explicit instead of relying on a structural
+// Release+delete pair.
 func (e *wangshuEngine) releaseSlots() {
-	for k, s := range e.slots {
-		(&s).Release()
-		delete(e.slots, k)
+	for _, s := range e.slots {
+		s.Release()
 	}
+	e.slots = nil
 }
 
 // SetContext forwards ctx to wangshu's internal cancellation hook so deadline
@@ -572,13 +577,15 @@ func (e *wangshuEngine) makeArrayTable(arr []any) (wangshu.Value, error) {
 	return tv, nil
 }
 
-// tryTypedArray probes arr for type homogeneity against the four primitive
-// Go types wangshu's typed-array constructors accept. Returns (Value, true)
-// when every element matches; falls back to (Nil, false) on the first
-// heterogeneous element, nil, or composite. NewInt64ArrayTable can return an
-// error when a value exceeds float64 precision (|v| > 2^53); we treat that as
-// a silent fallback so the heterogeneous path's lossy int64→float64 conversion
+// tryTypedArray probes arr for type homogeneity against the primitive Go
+// types wangshu's typed-array constructors accept. Returns (Value, true) when
+// every element matches; falls back to (Nil, false) on the first heterogeneous
+// element, nil, or composite. NewInt64ArrayTable can return an error when a
+// value exceeds float64 precision (|v| > 2^53); we treat that as a silent
+// fallback so the heterogeneous path's lossy int64→float64 conversion
 // (toValue's `wangshu.Number(float64(x))`) keeps the historical behaviour.
+// Both `int` and `int64` route through NewInt64ArrayTable since toValue
+// promotes both via float64; this preserves cross-engine numeric parity.
 func (e *wangshuEngine) tryTypedArray(arr []any) (wangshu.Value, bool) {
 	switch arr[0].(type) {
 	case float64:
@@ -599,6 +606,20 @@ func (e *wangshuEngine) tryTypedArray(arr []any) (wangshu.Value, bool) {
 				return wangshu.Nil(), false
 			}
 			out[i] = n
+		}
+		tv, err := e.st.NewInt64ArrayTable(out)
+		if err != nil {
+			return wangshu.Nil(), false
+		}
+		return tv, true
+	case int:
+		out := make([]int64, len(arr))
+		for i, v := range arr {
+			n, ok := v.(int)
+			if !ok {
+				return wangshu.Nil(), false
+			}
+			out[i] = int64(n)
 		}
 		tv, err := e.st.NewInt64ArrayTable(out)
 		if err != nil {

--- a/pine-go/operators/lua/pool_wangshu_test.go
+++ b/pine-go/operators/lua/pool_wangshu_test.go
@@ -534,3 +534,71 @@ func TestWangshuDropFatStateConcurrent(t *testing.T) {
 		t.Fatal("no drops recorded; concurrent test did not exercise the workaround")
 	}
 }
+
+// TestTryTypedArrayHomogeneousInt guards the #116 finding 1 follow-up: the
+// typed-array fast path must hit on []any built from Go-native `int` values
+// (common when callers don't go through the int64 promotion), not just
+// `int64`/`float64`/`bool`/`string`. Without the `case int:` arm, the slow
+// path silently took over and we lost the typed-array win documented in #115.
+//
+// We hit two angles: (a) tryTypedArray directly returns ok=true for an int
+// slice, proving the fast path is reachable; (b) end-to-end SetGlobal+Call
+// produces numeric output equal to the int64 path, proving the conversion
+// preserves cross-engine numeric parity (both arms feed
+// NewInt64ArrayTable, which internally promotes via float64).
+func TestTryTypedArrayHomogeneousInt(t *testing.T) {
+	wp, err := newWangshuPool(`function sumxs() local s=0; for i=1,#xs do s=s+xs[i] end; return s end`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wp.Close()
+
+	eng := wp.Borrow()
+	if eng == nil {
+		t.Fatal("unexpected nil borrow")
+	}
+	defer wp.Return(eng)
+	we := eng.(*wangshuEngine)
+
+	// (a) fast path reachable for []any{int}
+	intArr := []any{1, 2, 3, 4, 5}
+	v, ok := we.tryTypedArray(intArr)
+	if !ok {
+		t.Fatal("tryTypedArray missed the homogeneous int fast path")
+	}
+	v.Release()
+
+	// (b) numeric parity: int and int64 slices with the same values produce
+	// identical script-visible sums.
+	if err := we.SetGlobal("xs", []any{1, 2, 3, 4, 5}); err != nil {
+		t.Fatalf("SetGlobal int: %v", err)
+	}
+	gotInt, err := we.Call("sumxs", 1)
+	if err != nil {
+		t.Fatalf("Call int: %v", err)
+	}
+	if err := we.SetGlobal("xs", []any{int64(1), int64(2), int64(3), int64(4), int64(5)}); err != nil {
+		t.Fatalf("SetGlobal int64: %v", err)
+	}
+	gotInt64, err := we.Call("sumxs", 1)
+	if err != nil {
+		t.Fatalf("Call int64: %v", err)
+	}
+	if len(gotInt) != 1 || len(gotInt64) != 1 {
+		t.Fatalf("expected one return each, got %d and %d", len(gotInt), len(gotInt64))
+	}
+	if gotInt[0] != gotInt64[0] {
+		t.Fatalf("int arm sum=%v != int64 arm sum=%v", gotInt[0], gotInt64[0])
+	}
+	if want := float64(15); gotInt[0] != want {
+		t.Fatalf("sum=%v, want %v", gotInt[0], want)
+	}
+
+	// Heterogeneous mix (int+string) must NOT match the fast path: probe
+	// returns false so makeArrayTable falls back to the generic NewArrayTable
+	// route. This pins the "first element decides" classifier behaviour.
+	_, ok = we.tryTypedArray([]any{1, "two"})
+	if ok {
+		t.Fatal("tryTypedArray accepted heterogeneous int+string as a fast path")
+	}
+}


### PR DESCRIPTION
Closes #116.

Two non-blocking follow-ups on #113 / #115 typed-array path. Single commit / single file domain — the issue explicitly asked to batch into one cleanup.

## Finding 1 — `tryTypedArray` missed `[]any` of Go-native `int`

The fast path's switch matched four concrete types (`float64`/`int64`/`bool`/`string`). When the caller built `[]any{1, 2, 3}` from Go-native `int` literals (DataFrame-side `SetItem(idx, field, 2)` is one path; `pool_wangshu.go:504` already case-handles `int` in `toValue`), the switch fell through and the slow path picked them up via reflect — correct behaviour, missed optimisation.

Added a `case int:` arm symmetric to the `int64` arm: convert to `[]int64`, run `NewInt64ArrayTable`, fall back silently on its `|v|>2^53` error. Cross-engine numeric parity is preserved because both arms promote through `float64` in the slow / heterogeneous paths anyway (`toValue` does `wangshu.Number(float64(int))` and `wangshu.Number(float64(int64))` identically).

## Finding 2 — `releaseSlots` style: `(&s).Release() + delete` → `s.Release() + e.slots = nil`

Old form was correct — Go map iteration permits in-loop `delete`, and `(&s).Release()` worked around the addressability gap on map values. But the intent (`clear the cache`) reads as structural workaround; if a future refactor drops the `delete` (`keep map allocated`), `(&s).Release()` silently no-ops the cleanup.

Switched to Option B from the issue: `s.Release()` + `e.slots = nil`. Aligns with the existing `if e.slots == nil` lazy-init in `SetGlobal`, makes the intent explicit, no behaviour change.

## Test plan

- [x] New `TestTryTypedArrayHomogeneousInt` — directly probes `tryTypedArray` for the int fast path (ok=true), runs `SetGlobal+Call` end-to-end to assert int vs int64 numeric parity, and pins heterogeneous-mix fallback (ok=false)
- [x] `go test ./operators/lua/ -race -count=1` — both default (wangshu) and `-tags=lua_gopher` green
- [x] `go test ./operators/transform/ -race -count=1` — LuaOp consumers green
- [x] `go vet` + `golangci-lint run` — both tags 0 issues
- [x] No `lua_script` byte-equality contract change — the typed-array path was already wired in #115, this only widens the type-tag classifier

## Notes

- Non-blocking by design. The merged #113 / #115 bench delta still holds; this PR strictly widens fast-path coverage (Finding 1) and clarifies the cache-clear idiom (Finding 2).
- No wangshu dep change needed — both `s.Release()` (auto-address since `Release` is pointer receiver) and `NewInt64ArrayTable` are already in v0.2.0-rc4.
- Not pursuing the maximal Finding-1 expansion (`uint*`/`float32` arms) — Issue notes those are profile-driven; no real fixture has surfaced them, and adding them blind would balloon classifier LOC without measured ROI.