### PR TITLE
fix(ci): trigger release.yml on tag push instead of workflow_run (#123)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [master]
-    tags: ["v*"]
     paths-ignore:
       - ".claude/**"
       - ".githooks/**"
@@ -29,6 +28,10 @@ on:
       - "CLAUDE.md"
       - "LICENSE"
       - "README.md"
+  # release.yml invokes this workflow on tag pushes as its CI gate. Direct
+  # tag push triggers were removed so the same SHA does not run CI twice
+  # (once on push:tags and once via workflow_call from release.yml).
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,21 @@
 name: Release
 
+# Trigger directly on tag pushes, not via workflow_run after CI.
+# GitHub's workflow_run trigger does not reliably deliver tag-ref CI
+# completions to listening workflows (see issue #123 — head_branch comes
+# back as the default branch, so the `if` guard skips every run). Tag
+# pushes already run CI in parallel via the CI workflow's own
+# `on: push: tags: ["v*"]` config, so this workflow stays independent.
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  push:
+    tags:
+      - "v*"
 
 jobs:
   pypi-apple:
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -41,17 +42,12 @@ jobs:
           skip-existing: true
 
   java:
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: pine-java
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions/setup-java@v5
         with:
           distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,26 @@ name: Release
 # Trigger directly on tag pushes, not via workflow_run after CI.
 # GitHub's workflow_run trigger does not reliably deliver tag-ref CI
 # completions to listening workflows (see issue #123 — head_branch comes
-# back as the default branch, so the `if` guard skips every run). Tag
-# pushes already run CI in parallel via the CI workflow's own
-# `on: push: tags: ["v*"]` config, so this workflow stays independent.
+# back as the default branch, so the `if` guard skips every run). Instead,
+# release.yml owns the CI gate by invoking ci.yml as a reusable workflow
+# (workflow_call). pypi-apple / java jobs run only if CI passes via
+# `needs: ci`. CI's direct tag push trigger was removed in tandem so the
+# same SHA does not run CI twice.
 on:
   push:
     tags:
       - "v*"
 
 jobs:
+  # Gate publish on full CI passing for the tag SHA. Calls ci.yml as a
+  # reusable workflow; secrets: inherit lets CI jobs access the same
+  # secret scope they would on a master push.
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
   pypi-apple:
+    needs: ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -42,6 +52,7 @@ jobs:
           skip-existing: true
 
   java:
+    needs: ci
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Closes #123.

## Problem

`release.yml` triggered on `workflow_run` after CI. GitHub does not reliably deliver the upstream `workflow_run` event with the tag ref as `head_branch` — for tag-ref CI completions, `head_branch` comes back as the default branch instead. The per-job `if startsWith(github.event.workflow_run.head_branch, 'v')` guard then skipped every run.

v0.10.7 hit this exact path:

| created_at (UTC)     | head_branch | head_sha | conclusion |
|---|---|---|---|
| 2026-06-17T15:47:43Z | master      | 5618f49… | CI success |
| 2026-06-17T16:01:57Z | **v0.10.7** | 5618f49… | CI success |
| 2026-06-17T15:59:10Z | master      |          | release skipped |

The 16:01 CI completion on `head_branch=v0.10.7` produced **no corresponding `release.yml` workflow_run event** — that's the missing trigger. Net effect: PyPI / Maven Central never received artifacts; GitHub Releases page has no entry.

## Fix (final design — 2 commits)

Restore the "publish only on green CI" safety property using the **reusable-workflow pattern**, which sidesteps the `workflow_run` head_branch quirk that caused #123.

**Commit 1 — `29f7de6`**: switched `release.yml` from `workflow_run` to `push: tags: ["v*"]`, but left publish ungated. Bot-reviewer flagged this as dangerous (PyPI / Maven publishes are effectively irreversible — see [bot comment on #126](https://github.com/Liam0205/pineapple/pull/126#issuecomment-4747106066)).

**Commit 2 — `c554fc9`**: restore the gate via `workflow_call`:

- `ci.yml` gains `workflow_call` so `release.yml` can invoke CI as a reusable workflow on the tag SHA
- `ci.yml`'s direct `push.tags: ["v*"]` trigger is removed so the same SHA does not run CI twice
- `release.yml` adds a first job `ci` that `uses: ./.github/workflows/ci.yml` with `secrets: inherit`
- `pypi-apple` and `java` now `needs: ci` — publish runs only after every CI job (17+ jobs: lint / test / cross-validate / fuzz / benchmark / cpp-{build,lint,test,sanitizer,tsan}) reports success on the tag SHA

`needs` defaults to `success()` semantics, so the gate is implicit and explicit.

## Behaviour change summary

| Trigger          | Before #123 fix | After commit 1 (no gate) | After commit 2 (final)            |
|------------------|-----------------|--------------------------|-----------------------------------|
| `push: master`   | CI runs         | CI runs                  | CI runs                           |
| `push: tags v*`  | CI runs + skipped release | CI runs + release runs (no gate) | release runs → invokes CI → publish gated on green |
| `pull_request`   | CI runs         | CI runs                  | CI runs                           |

## v0.10.7 backfill

Out of scope for this fix. v0.10.7 artifacts and GitHub Release entry will be hand-published.

## Test plan

- [x] YAML syntax valid on both files (`python3 -c 'import yaml; yaml.safe_load(open(...))'`)
- [x] CI 21/21 green on commit 2 (release.yml is YAML-validated, not invoked; `workflow_call` is a YAML feature with no per-PR CI proof, full validation requires a real tag push post-merge)
- [ ] Post-merge: validated on the next tag push by observing release.yml fires → invokes ci.yml via workflow_call → all CI jobs pass on tag SHA → pypi-apple / java publish in sequence