### PR TITLE
fix(ci): bump apt-get timeout 300→600 in nightly workflows (#125)

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Install system deps
         run: |
-          timeout 300 sudo apt-get update
-          timeout 300 sudo apt-get install -y --no-install-recommends \
+          timeout 600 sudo apt-get update
+          timeout 600 sudo apt-get install -y --no-install-recommends \
             cmake build-essential libluajit-5.1-dev libcurl4-openssl-dev
 
       - name: Install hey

--- a/.github/workflows/nightly-diff-fuzz.yml
+++ b/.github/workflows/nightly-diff-fuzz.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Install C++ build deps
         run: |
-          timeout 300 sudo apt-get update
-          timeout 300 sudo apt-get install -y --no-install-recommends \
+          timeout 600 sudo apt-get update
+          timeout 600 sudo apt-get install -y --no-install-recommends \
             cmake ninja-build g++-13 libluajit-5.1-dev libcurl4-openssl-dev
 
       - name: Build Go binary


### PR DESCRIPTION
Closes #125.

## Problem

2026-06-18 nightly diff-fuzz failed at the C++ build deps step with exit code 124 — 5 minutes into the job, matching `timeout 300` exactly.

```
16:49:29 Run timeout 300 sudo apt-get update + timeout 300 sudo apt-get install ...
16:54:09 Get:4 cmake-data (2155 kB)
16:54:26 Get:5 cmake amd64 (11.2 MB)
16:54:36 exit code 124
```

The previous 10 nightly runs all completed in 4:30~4:50 hours, well under the global `timeout-minutes: 355` + `timeout 340m` budgets. The 06-18 failure is purely the apt step's per-command guard tripping on a slow Azure mirror cycle.

## Fix

Both `nightly-diff-fuzz.yml` and `nightly-benchmark.yml` carry the identical idiom `timeout 300 sudo apt-get update` + `timeout 300 sudo apt-get install …`. Bump both to `600` (10 minutes) — generous enough to absorb mirror congestion, still bounded to keep a runaway apt from eating the whole nightly window.

## Scope

This **only** fixes the infrastructure timeout. The independent go-vs-cpp column/row-store divergence pattern in #109 (2026-06-15) and #124 (2026-06-17) is unrelated — those need separate root-cause investigation.

## Test plan

- [x] YAML syntax validated (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] Post-merge: confirmed on the next nightly run by observing the apt step completes within budget (or, if congestion persists, has more headroom before tripping the guard)