### PR TITLE
fix(ci): cut daily-sanitized-fuzz rounds 40 % to fit measured throughput (#132 #133)

### DIFF
--- a/.github/workflows/daily-sanitized-fuzz.yml
+++ b/.github/workflows/daily-sanitized-fuzz.yml
@@ -17,8 +17,9 @@ name: Daily Sanitized Differential Fuzz
 # (#132 / #133) tripped exit=124 on both passes — actual throughput in
 # long runs is closer to ~1.5 s/round (ASan) / ~1.6 s/round (TSan), and
 # sanitizer shadow memory pressure compounds over thousands of rounds.
-# Cut rounds 40 % to ~3000 ASan + ~2000 TSan, which budgets to ~75m + ~55m
-# and leaves ~20 % buffer inside the inner per-pass timeouts. Nightly
+# Cut rounds (ASan 5000→3000 / 40 %, TSan 3500→2000 / ~43 %) to
+# ~3000 ASan + ~2000 TSan, which budgets to ~75m + ~55m and leaves
+# ~15-20 % buffer inside the inner per-pass timeouts. Nightly
 # diff-fuzz keeps driving 10k Release rounds for raw throughput /
 # different seed coverage; this workflow is the deep-diagnostic
 # complement, NOT a replacement.
@@ -154,7 +155,7 @@ jobs:
       - name: Run TSan differential fuzz
         # Race-only pass. TSan production runs (#132 / #133) measured
         # ~1.6 s/round; 2000 rounds projects to ~55 minutes; budget 70m
-        # step, 65m fuzz inner — leaves ~20 % headroom. Distinct save
+        # step, 65m fuzz inner — leaves ~15 % headroom. Distinct save
         # dir so the two passes don't share case numbering (and so
         # packaging can pick them apart).
         timeout-minutes: 70

--- a/.github/workflows/daily-sanitized-fuzz.yml
+++ b/.github/workflows/daily-sanitized-fuzz.yml
@@ -11,15 +11,17 @@ name: Daily Sanitized Differential Fuzz
 # opened; running the main fuzz with -fsanitize=thread / address makes the
 # first hit produce a full stack instead of `cpp_rc=1` with no diagnostic.
 #
-# Cost: ASan ~3x slower, TSan ~5-10x slower than Release. Smoke-run
-# measurements (#128 follow-up, 100 ASan + 50 TSan rounds in 9 minutes
-# end-to-end) show ~1.4 s/round across both sanitizers — the per-round
-# cost is dominated by go/java fuzz orchestration rather than cpp
-# instrumentation overhead. That makes a daily 4h budget feasible:
-# build (~5m) + ASan ~5000r (~120m) + TSan ~3500r (~80m) + buffers fits
-# inside ~205 minutes wall time. Nightly diff-fuzz keeps driving 10k
-# Release rounds for raw throughput / different seed coverage; this
-# workflow is the deep-diagnostic complement, NOT a replacement.
+# Cost: ASan ~3x slower, TSan ~5-10x slower than Release. Initial
+# smoke-run measurements (#128, 100/50 rounds) projected ~1.4 s/round and
+# 5000+3500 fitting in ~205m. The 2026-06-20 / 06-21 production runs
+# (#132 / #133) tripped exit=124 on both passes — actual throughput in
+# long runs is closer to ~1.5 s/round (ASan) / ~1.6 s/round (TSan), and
+# sanitizer shadow memory pressure compounds over thousands of rounds.
+# Cut rounds 40 % to ~3000 ASan + ~2000 TSan, which budgets to ~75m + ~55m
+# and leaves ~20 % buffer inside the inner per-pass timeouts. Nightly
+# diff-fuzz keeps driving 10k Release rounds for raw throughput /
+# different seed coverage; this workflow is the deep-diagnostic
+# complement, NOT a replacement.
 
 on:
   schedule:
@@ -28,10 +30,10 @@ on:
     inputs:
       asan-rounds:
         description: "ASan fuzz rounds (cpp ASan main run)"
-        default: "5000"
+        default: "3000"
       tsan-rounds:
         description: "TSan fuzz rounds (smaller — TSan is 5-10x slower)"
-        default: "3500"
+        default: "2000"
       stability-runs:
         description: "Stability check reruns per case"
         default: "3"
@@ -49,12 +51,12 @@ permissions:
 jobs:
   sanitized-fuzz:
     runs-on: ubuntu-latest
-    # 4h hard budget. Smoke-run measured ~1.4 s/round across both
-    # sanitizers; 5000+3500 rounds + builds + buffers projects to
-    # ~205 minutes. 240m leaves ~35 minutes of headroom for runner-side
-    # noise without leaving so much slack that incomplete passes (#109
-    # diagnostic) get masked by the global timeout.
-    timeout-minutes: 240
+    # 3h hard budget. Production runs (#132, #133) ran ~1.5-1.6 s/round
+    # under sanitizer pressure; 3000 ASan + 2000 TSan + builds + buffers
+    # projects to ~140 minutes. 180m leaves ~40 minutes of headroom for
+    # runner-side noise without leaving so much slack that incomplete
+    # passes (#109 diagnostic) get masked by the global timeout.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6
 
@@ -124,19 +126,19 @@ jobs:
 
       - name: Run ASan differential fuzz
         # Main fuzz pass: cpp uses ASan binary so heap UAF / overflow /
-        # UB surfaces directly. ASan replicates ~3x slower than Release,
-        # but smoke-run measured ~1.4 s/round end-to-end (orchestration
-        # cost dominates). 5000 rounds projects to ~120 minutes; budget
-        # 130m step, 125m fuzz inner.
-        timeout-minutes: 130
+        # UB surfaces directly. ASan replicates ~3x slower than Release;
+        # production runs (#132 / #133) measured ~1.5 s/round under
+        # sanitizer pressure. 3000 rounds projects to ~75 minutes;
+        # budget 95m step, 90m fuzz inner — leaves ~20 % headroom.
+        timeout-minutes: 95
         env:
           ASAN_OPTIONS: "halt_on_error=0 detect_leaks=0 abort_on_error=0 print_stacktrace=1"
           UBSAN_OPTIONS: "halt_on_error=0 print_stacktrace=1"
         run: |
           set -o pipefail
-          ROUNDS="${{ inputs.asan-rounds || '5000' }}"
+          ROUNDS="${{ inputs.asan-rounds || '3000' }}"
           rc=0
-          timeout 125m python3 scripts/differential-fuzz.py \
+          timeout 90m python3 scripts/differential-fuzz.py \
             --rounds "$ROUNDS" \
             --stability-runs ${{ inputs.stability-runs || '3' }} \
             --go-bin pine-go/pineapple-run \
@@ -150,21 +152,21 @@ jobs:
           exit 0
 
       - name: Run TSan differential fuzz
-        # Race-only pass. Smaller round count because TSan is 5-10x slower
-        # than Release in raw cpp time; smoke-run still measured ~1.4 s/round
-        # end-to-end, so 3500 rounds projects to ~80 minutes; budget 100m
-        # step, 95m fuzz inner. Distinct save dir so the two passes don't
-        # share case numbering (and so packaging can pick them apart).
-        timeout-minutes: 100
+        # Race-only pass. TSan production runs (#132 / #133) measured
+        # ~1.6 s/round; 2000 rounds projects to ~55 minutes; budget 70m
+        # step, 65m fuzz inner — leaves ~20 % headroom. Distinct save
+        # dir so the two passes don't share case numbering (and so
+        # packaging can pick them apart).
+        timeout-minutes: 70
         env:
           # halt_on_error=0: keep going so one race doesn't kill the sweep.
           # second_deadlock_stack=1: surface both sides of a lock-order race.
           TSAN_OPTIONS: "halt_on_error=0 second_deadlock_stack=1"
         run: |
           set -o pipefail
-          ROUNDS="${{ inputs.tsan-rounds || '3500' }}"
+          ROUNDS="${{ inputs.tsan-rounds || '2000' }}"
           rc=0
-          timeout 95m python3 scripts/differential-fuzz.py \
+          timeout 65m python3 scripts/differential-fuzz.py \
             --rounds "$ROUNDS" \
             --stability-runs ${{ inputs.stability-runs || '3' }} \
             --go-bin pine-go/pineapple-run \
@@ -216,8 +218,8 @@ jobs:
             echo ""
             echo "| Pass | rounds | status | FAIL | UNSTABLE | exit |"
             echo "|---|---|---|---|---|---|"
-            echo "| ASan | ${{ inputs.asan-rounds || '5000' }} | $asan_status | $ASAN_FAIL | $ASAN_UNSTABLE | $ASAN_EXIT |"
-            echo "| TSan | ${{ inputs.tsan-rounds || '3500' }} | $tsan_status | $TSAN_FAIL | $TSAN_UNSTABLE | $TSAN_EXIT |"
+            echo "| ASan | ${{ inputs.asan-rounds || '3000' }} | $asan_status | $ASAN_FAIL | $ASAN_UNSTABLE | $ASAN_EXIT |"
+            echo "| TSan | ${{ inputs.tsan-rounds || '2000' }} | $tsan_status | $TSAN_FAIL | $TSAN_UNSTABLE | $TSAN_EXIT |"
             echo ""
             if [[ "$asan_status" == "incomplete" ]]; then
               echo "⚠️ **ASan pass did not produce a Results: summary** (exit=$ASAN_EXIT) — likely a timeout or script crash. ASan findings, if any, are lost."
@@ -410,12 +412,13 @@ jobs:
 
           ### Suggested triage
 
-          - If exit=124: the per-pass \`timeout\` (ASan 125m, TSan 95m)
-            tripped. Either bump the limit or cut rounds. TSan 3500 rounds
-            at the smoke-run-measured ~1.4 s/round budgets to ~80m, with
-            ~15m head; ASan 5000 rounds budgets to ~120m with ~5m head.
-            If runs trip exit=124 routinely, that's a runner-noise signal
-            — bump the inner timeout first, only cut rounds if recurrent.
+          - If exit=124: the per-pass \`timeout\` (ASan 90m, TSan 65m)
+            tripped. Either bump the limit or cut rounds. TSan 2000 rounds
+            at the production-measured ~1.6 s/round budgets to ~55m, with
+            ~10m head; ASan 3000 rounds at ~1.5 s/round budgets to ~75m
+            with ~15m head. If runs trip exit=124 routinely, that's a
+            runner-noise signal — bump the inner timeout first, only cut
+            rounds if recurrent.
           - If exit≠124: script crash; check the workflow logs for the
             actual failure step.
 


### PR DESCRIPTION
Closes #132. Closes #133.

## Problem

Two consecutive days (06-20, 06-21) of daily-sanitized-fuzz ran with **both ASan and TSan exit=124**. The workflow's diagnostic capability went to zero for those days — when #109's race finally surfaces, neither pass would catch it.

Both auto-filed incomplete-pass issues agree: the #129 budget (5000 ASan + 3500 TSan rounds inside 125m + 95m inner timeouts) was too aggressive.

## Why the smoke run mis-projected

The #128 smoke run (100 ASan + 50 TSan rounds, 9 minutes total) gave ~1.4 s/round. Production runs measure ~1.5 s/round ASan and ~1.6 s/round TSan. Likely contributors to the ~10 % cost increase as runs grow:

- Sanitizer shadow-memory pressure accumulates over thousands of rounds (not visible at 100 rounds)
- Runner noise compounds non-linearly with run length (swap, page faults, GC pauses)
- TSan's shadow-of-shadow tracking grows the seen-event set; ASan's red-zone bookkeeping fills the heap

The smoke-run rate was right to within 7-15 %, but the original budget gave only 5-15 % headroom — not enough.

## Fix: cut rounds 40 %, re-budget from measured rates with 20 % headroom

| | rounds (was → now) | measured rate | inner timeout (was → now) | headroom |
|---|---|---|---|---|
| **ASan** | 5000 → **3000** | 1.5 s/r | 125m → **90m** | ~15m of 90m (20 %) |
| **TSan** | 3500 → **2000** | 1.6 s/r | 95m → **65m** | ~10m of 65m (~18 %) |

Step `timeout-minutes`: 130/100 → 95/70. Job `timeout-minutes`: 240 → 180. Total wall-time projection ~140m, leaving ~40m headroom against the 180m job ceiling.

## Coverage net

| | rounds/run | runs/week | rounds/week ASan + TSan |
|---|---|---|---|
| Original weekly (#128) | 1500 + 500 | 1 | 2000 |
| Aggressive daily (#129) | 5000 + 3500 (target) | 7 | 0 (timing out) |
| **This PR** | 3000 + 2000 | 7 | **35 000** |

Daily cadence × even-cut rounds is **strictly more coverage** than the original weekly design, while restoring the workflow's actual ability to finish.

## What was refreshed

- Header rationale comment (now references the #132/#133 production measurements, not the smoke-run estimate)
- Step-summary table defaults
- Incomplete-pass issue triage paragraph (timeouts and rate sources reflect production)
- All `timeout-minutes` and inner `timeout XXm` values consistent with the new rounds and 20 % headroom

## Test plan

- [x] YAML valid
- [x] No stale `5000` / `3500` / `125m` / `95m` numerics outside the header rationale comment (which intentionally records the regression)
- [ ] Post-merge: trigger via workflow_dispatch with the new defaults to validate the 90m + 65m envelope under production runner conditions before the next cron fires
- [ ] If the very next daily run also trips exit=124: drop another 20 % from rounds (and re-derive timeouts), or temporarily disable the cron to stop the issue spam

## Out of scope

- #109 root-cause fix. #131 finally captured the race via TSan; analysis posted on #109. Daily fuzz must run cleanly first or the next race window will slip past silently — which this PR restores.