### PR TITLE
feat(githook): pre-push auto --set-upstream relay — absorb wangshu#24

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -86,6 +86,11 @@ zero="0000000000000000000000000000000000000000"
 refspecs=()
 have_update=0          # at least one non-delete ref → CI watch is meaningful
 force_lease_args=()    # one --force-with-lease=ref:sha per non-fast-forward ref
+head_branch_pushed=0   # refspecs include the branch HEAD currently points at
+head_remote_ref=""     # candidate -u target (`refs/heads/<branch>`) on the remote
+
+# Which branch HEAD points at (empty when detached — no -u candidate then).
+head_ref="$(git symbolic-ref HEAD 2>/dev/null || true)"
 
 while read -r local_ref local_sha remote_ref remote_sha; do
   [ -z "${remote_ref:-}" ] && continue
@@ -109,6 +114,11 @@ while read -r local_ref local_sha remote_ref remote_sha; do
        && ! git merge-base --is-ancestor "$remote_sha" "$local_sha" 2>/dev/null; then
       force_lease_args+=("--force-with-lease=${remote_ref}:${remote_sha}")
     fi
+    # HEAD's branch is being pushed ⇒ candidate for auto -u relay below.
+    if [ -n "$head_ref" ] && [ "$local_ref" = "$head_ref" ]; then
+      head_branch_pushed=1
+      head_remote_ref="$remote_ref"
+    fi
   fi
 done
 
@@ -125,12 +135,28 @@ fi
 
 remote_name="${1:-origin}"
 
+# `-u` auto-relay (absorbed from ctex-kit#888 / wangshu#24): git does NOT pass
+# the outer command-line args to the hook, so the inner push doesn't know
+# whether the user typed `-u`. Detect: HEAD's branch is being pushed AND it has
+# no upstream right now ⇒ inject `--set-upstream` on the inner push. Already
+# tracking → untouched; detached HEAD → untouched; pushing only tags / other
+# branches → untouched. No side effects.
+set_upstream_args=()
+if [ "$head_branch_pushed" -eq 1 ] \
+   && ! git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1; then
+  set_upstream_args=(--set-upstream)
+  echo "post-push: auto --set-upstream ($(git rev-parse --abbrev-ref HEAD) → ${remote_name}/${head_remote_ref#refs/heads/})" >&2
+fi
+
 echo "post-push: performing real push to '${remote_name}' (${refspecs[*]})..." >&2
 # `${arr[@]+"${arr[@]}"}` is the parameter-expansion guard form: empty under
 # `set -u` on bash 3.2 (the default /bin/bash on macOS), equivalent to
 # `"${arr[@]}"` on bash >=4.4. A bare expansion of an empty array trips
 # "unbound variable" on bash 3.2 and aborts the hook on every non-force push.
-GIT_POSTPUSH=1 git push ${force_lease_args[@]+"${force_lease_args[@]}"} "${remote_name}" "${refspecs[@]}"
+GIT_POSTPUSH=1 git push \
+  ${set_upstream_args[@]+"${set_upstream_args[@]}"} \
+  ${force_lease_args[@]+"${force_lease_args[@]}"} \
+  "${remote_name}" "${refspecs[@]}"
 push_rc=$?
 if [ "$push_rc" -ne 0 ]; then
   echo "post-push: inner push failed (rc=${push_rc}) — not watching CI." >&2


### PR DESCRIPTION
## Summary

吸收 [wangshu#24](https://github.com/Liam0205/wangshu/pull/24)（其自身吸收 [ctex-kit#888](https://github.com/CTeX-org/ctex-kit/pull/888)）在 `.githooks/pre-push` 上的 `-u` 自动接力改进。

**问题**：git 不把 outer 命令行参数透传给 hook，所以 self-wrapped INNER push 不知道用户原本是否带了 `-u`。结果：非 master 分支首次 push 永远不会设 upstream，后续 push 都得手动加 `-u`。

**修法**：hook 在已有的 refspec 扫描循环里多记两条 `head_branch_pushed` / `head_remote_ref`（只对当前 HEAD 所在的非删除 refspec 置位），inner push 之前自检"HEAD 的分支被推送 AND 当前没 upstream"，命中则在 inner push 注入 `--set-upstream`。

行为保证：
- 已有 upstream → 不动
- detached HEAD → 不动
- 只推 tag / 别的分支 → 不动
- 多 ref push 中包含当前 HEAD → 命中（结构与 force-with-lease 同周扫描共享）
- 无副作用

实现要点：
1. while-read 循环里多记 `head_branch_pushed` 和 `head_remote_ref`（仅对当前 HEAD 所在的非删除 refspec 置位）
2. inner push 前自检 `git rev-parse @{upstream}` 是否失败；失败 → `--set-upstream` 加入 inner push
3. stderr 一行 `post-push: auto --set-upstream (...)` 告知接力发生
4. 注释明确出处指向 `ctex-kit#888 / wangshu#24`，便于跨仓库追溯

与 wangshu#24 结构对应：变量命名、检测点、注入位置完全一致；仅注释翻译为英文以匹配 pineapple hook 的现有风格。

## Test plan

- [x] **本 PR 本身就是测试**：`feat/pre-push-set-upstream-autohook` 分支创建后没设 upstream，`git push origin feat/...`（**没带 `-u`**）触发 hook，stderr 显示 `post-push: auto --set-upstream (feat/... → origin/feat/...)`；push 后 `git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}'` 返回 `origin/feat/pre-push-set-upstream-autohook` ✓
- [x] `bash -n .githooks/pre-push` 语法 check 通过
- [x] 仅 1 文件 27+/1- 改动，不动 force-with-lease / refspec mirror / CI watch / exit 75 等其他既有逻辑